### PR TITLE
Add security scanning skill with SAST and DAST tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -156,10 +156,11 @@
     {
       "name": "security",
       "source": "./",
-      "description": "Security toolkit: auditing-security",
+      "description": "Security toolkit: auditing-security, scanning-security",
       "category": "devtools",
       "skills": [
-        "./skills/security/auditing-security"
+        "./skills/security/auditing-security",
+        "./skills/security/scanning-security"
       ],
       "strict": false
     },

--- a/skills/security/scanning-security/PURPOSE.md
+++ b/skills/security/scanning-security/PURPOSE.md
@@ -1,0 +1,20 @@
+# Security Scanning
+
+Automated security scanning using SAST and DAST tools — runs scanners, normalizes results, triages findings, and generates tool configurations.
+
+## Responsibilities
+
+- Detect available SAST tools and run them against a codebase
+- Run DAST scans against target URLs using nuclei or ZAP
+- Normalize scan output across tools into a unified finding format
+- Triage and deduplicate findings by severity, confidence, and CWE
+- Generate and validate scanner configuration files (semgrep rules, nuclei templates, eslint-plugin-security configs)
+- Guide CI pipeline integration for automated scanning
+- Manage false positive suppressions with audit trails
+
+## Tools
+
+- `tools/sast-scan.ts` — detect available SAST tools and run them, normalize output into a unified format
+- `tools/dast-scan.ts` — run DAST tools (nuclei, ZAP) against a target URL, normalize output
+- `tools/triage-findings.ts` — parse scan results, deduplicate, prioritize by severity and confidence
+- `tools/scan-config.ts` — generate or validate tool-specific configuration files

--- a/skills/security/scanning-security/SKILL.md
+++ b/skills/security/scanning-security/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: scanning-security
+description: Runs automated SAST and DAST security scans using tools like semgrep, bandit, eslint-plugin-security, nuclei, and ZAP — detects available scanners, executes them, normalizes and triages findings, generates scanner configs, and guides CI integration. Use when the user wants to run a security scan, configure semgrep or nuclei, triage scan results, set up security scanning in CI, or suppress false positives from automated scanners.
+allowed-tools: Read Grep Glob Bash Write Edit
+---
+
+# Security Scanning
+
+## Decision Tree
+
+- What kind of scanning?
+  - **Run a SAST scan on the codebase** → run `tools/sast-scan.ts`
+  - **Run a DAST scan against a live target** → run `tools/dast-scan.ts`
+  - **Triage or review existing scan results** → run `tools/triage-findings.ts`
+  - **Generate or validate scanner config** → run `tools/scan-config.ts`
+  - **Set up scanning in CI** → see `references/ci-integration.md`
+  - **Suppress a false positive** → follow "Suppressing false positives" below
+  - **Full automated security scan** → follow "Full scan" below
+
+## Full scan
+
+Run SAST and DAST together, then triage:
+
+1. `tools/sast-scan.ts [directory] --json > sast-results.json` — runs all available SAST tools
+2. If there is a live target URL: `tools/dast-scan.ts <url> --json > dast-results.json`
+3. `tools/triage-findings.ts sast-results.json [dast-results.json]` — deduplicate and prioritize
+4. Review triaged output with the user — walk through critical and high findings first
+5. For findings that need config changes, run `tools/scan-config.ts` to generate suppression rules or custom policies
+
+## SAST scanning
+
+1. Run `tools/sast-scan.ts [directory] [--tools semgrep,bandit,eslint]`
+2. The tool auto-detects which scanners are installed and which languages are present
+3. If no scanner is available, it prints installation instructions for the best match
+4. Results are normalized into a common format: file, line, rule ID, severity, message, CWE
+5. Review findings starting from critical severity — for each finding:
+   - **True positive** → fix the code or file an issue
+   - **False positive** → suppress with `tools/scan-config.ts suppress <rule-id> <file:line> --reason "justification"`
+   - **Needs investigation** → flag for manual review (suggest `auditing-security` for deeper analysis)
+
+## DAST scanning
+
+1. Confirm the target URL is authorized for scanning — never scan without explicit permission
+2. Run `tools/dast-scan.ts <url> [--tools nuclei,zap] [--severity critical,high]`
+3. Results include: URL, method, vulnerability type, severity, evidence
+4. For each finding, verify exploitability before reporting as confirmed
+
+## Suppressing false positives
+
+Every suppression needs a reason. The pattern depends on the tool:
+
+- **semgrep**: add `# nosemgrep: <rule-id>` inline, or add to `.semgrep-exclude.yml`
+- **bandit**: add `# nosec B<number>` inline, or add to `.bandit` config
+- **eslint-plugin-security**: `// eslint-disable-next-line security/<rule>`
+- **nuclei**: exclude template IDs in the nuclei config
+
+Use `tools/scan-config.ts suppress` to generate the correct suppression with an audit comment.
+
+## Boundary with auditing-security
+
+This skill runs automated scanners and interprets their output. For manual code review, auth logic analysis, permission matrices, secret scanning, or dependency CVE audits, use `auditing-security` instead. If a SAST finding needs deeper manual analysis (e.g., a complex injection path), hand off to `auditing-security`.
+
+## Key references
+
+| File | What it covers |
+|---|---|
+| `tools/sast-scan.ts` | Detect and run SAST tools, normalize output |
+| `tools/dast-scan.ts` | Run DAST tools against target URLs |
+| `tools/triage-findings.ts` | Deduplicate, prioritize, format findings |
+| `tools/scan-config.ts` | Generate/validate scanner configs, manage suppressions |
+| `references/ci-integration.md` | Patterns for GitHub Actions, GitLab CI |

--- a/skills/security/scanning-security/references/ci-integration.md
+++ b/skills/security/scanning-security/references/ci-integration.md
@@ -1,0 +1,127 @@
+# CI Integration for Security Scanning
+
+## GitHub Actions — SAST on pull requests
+
+```yaml
+name: Security Scan
+on:
+  pull_request:
+
+jobs:
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: p/owasp-top-ten p/typescript
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+```
+
+## GitHub Actions — DAST on staging deploy
+
+```yaml
+name: DAST Scan
+on:
+  deployment_status:
+    types: [success]
+
+jobs:
+  dast:
+    if: github.event.deployment_status.environment == 'staging'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nuclei
+        run: |
+          go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Run Nuclei
+        run: |
+          nuclei -u ${{ github.event.deployment_status.target_url }} \
+            -severity critical,high \
+            -jsonl -o nuclei-results.jsonl
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dast-results
+          path: nuclei-results.jsonl
+```
+
+## GitLab CI
+
+```yaml
+stages:
+  - test
+  - deploy
+  - dast
+
+sast:
+  stage: test
+  image: returntocorp/semgrep
+  script:
+    - semgrep scan --config auto --json -o semgrep-results.json .
+  artifacts:
+    paths:
+      - semgrep-results.json
+    when: always
+
+dast:
+  stage: dast
+  image: projectdiscovery/nuclei
+  needs: [deploy-staging]
+  script:
+    - nuclei -u $STAGING_URL -severity critical,high -jsonl -o nuclei-results.jsonl
+  artifacts:
+    paths:
+      - nuclei-results.jsonl
+    when: always
+```
+
+## General patterns
+
+- **SAST on every PR** — fast, catches issues before merge
+- **DAST on staging deploys** — tests the running application after deploy
+- **Fail on critical only** — use `--severity critical` to gate merges; report high/medium as warnings
+- **SARIF upload** — GitHub Security tab aggregates findings across runs
+- **Baseline scanning** — use `--baseline` flags to only report new findings, not pre-existing ones
+- **Cache scanner databases** — semgrep rules and nuclei templates can be cached between runs
+
+## Severity gating
+
+To fail CI only on critical/high findings:
+
+```bash
+# Run scan, capture exit code
+semgrep scan --config auto --json -o results.json . || true
+
+# Check for critical/high findings
+bun run tools/triage-findings.ts results.json --min-severity high --json | \
+  jq -e '.afterDedup == 0' || exit 1
+```
+
+## Configuration in repo
+
+Keep scanner configs versioned alongside code:
+
+```
+.semgrep.yml          # Semgrep rules and exclusions
+.bandit               # Bandit configuration
+nuclei-templates/     # Custom nuclei templates
+scan-suppressions.log # Audit trail for false-positive suppressions
+```
+
+Use `tools/scan-config.ts validate` in CI to ensure configs are well-formed before running scans.

--- a/skills/security/scanning-security/tools/dast-scan.ts
+++ b/skills/security/scanning-security/tools/dast-scan.ts
@@ -1,0 +1,338 @@
+const args = Bun.argv.slice(2);
+
+const HELP = `
+dast-scan — Run DAST tools against a target URL, normalize output
+
+Usage:
+  bun run tools/dast-scan.ts <url> [options]
+
+Options:
+  --tools <list>       Comma-separated tools to run (nuclei,zap) — default: auto-detect
+  --severity <list>    Filter by severity (critical,high,medium,low,info)
+  --templates <path>   Custom nuclei templates directory
+  --json               Output as JSON instead of plain text
+  --help               Show this help message
+
+IMPORTANT: Only scan targets you are authorized to test.
+`.trim();
+
+if (args.includes("--help")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const jsonOutput = args.includes("--json");
+const toolsFlag = args.find((_, i) => args[i - 1] === "--tools") ?? "";
+const severityFlag = args.find((_, i) => args[i - 1] === "--severity") ?? "";
+const templatesFlag = args.find((_, i) => args[i - 1] === "--templates") ?? "";
+const positionalArgs = args.filter(
+  (a, i) =>
+    !a.startsWith("--") &&
+    args[i - 1] !== "--tools" &&
+    args[i - 1] !== "--severity" &&
+    args[i - 1] !== "--templates",
+);
+
+interface DastFinding {
+  tool: string;
+  templateId: string;
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  url: string;
+  method: string;
+  vulnerabilityType: string;
+  description: string;
+  evidence?: string;
+  cwe?: string;
+  reference?: string[];
+}
+
+interface DastResult {
+  target: string;
+  toolsRun: string[];
+  toolsMissing: string[];
+  totalFindings: number;
+  summary: Record<string, number>;
+  findings: DastFinding[];
+  installHints: string[];
+}
+
+async function commandExists(cmd: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["which", cmd], { stdout: "pipe", stderr: "pipe" });
+    await proc.exited;
+    return proc.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeSeverity(sev: string): DastFinding["severity"] {
+  const s = sev.toLowerCase();
+  if (s === "critical") return "critical";
+  if (s === "high") return "high";
+  if (s === "medium" || s === "warning") return "medium";
+  if (s === "low") return "low";
+  return "info";
+}
+
+function isProductionUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    return (
+      !host.includes("localhost") &&
+      !host.includes("127.0.0.1") &&
+      !host.includes("0.0.0.0") &&
+      !host.includes("staging") &&
+      !host.includes("dev") &&
+      !host.includes("test") &&
+      !host.includes("local") &&
+      !host.endsWith(".local") &&
+      !host.endsWith(".test") &&
+      !host.endsWith(".internal")
+    );
+  } catch {
+    return false;
+  }
+}
+
+// --- Nuclei ---
+
+async function runNuclei(url: string): Promise<DastFinding[]> {
+  const nucleiArgs = ["nuclei", "-u", url, "-jsonl", "-silent"];
+
+  if (severityFlag) {
+    nucleiArgs.push("-severity", severityFlag);
+  }
+  if (templatesFlag) {
+    nucleiArgs.push("-t", templatesFlag);
+  }
+
+  const proc = Bun.spawn(nucleiArgs, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  if (!stdout.trim()) return [];
+
+  const findings: DastFinding[] = [];
+  for (const line of stdout.trim().split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const r = JSON.parse(line);
+      findings.push({
+        tool: "nuclei",
+        templateId: r["template-id"] ?? r.templateID ?? "unknown",
+        severity: normalizeSeverity(r.info?.severity ?? r.severity ?? "info"),
+        url: r.matched ?? r["matched-at"] ?? url,
+        method: r.type ?? "http",
+        vulnerabilityType: r.info?.name ?? r.name ?? "unknown",
+        description: r.info?.description ?? r.description ?? "",
+        evidence: r.matcher_name ?? r["matcher-name"] ?? r.extracted_results?.join(", "),
+        cwe: r.info?.classification?.["cwe-id"]?.[0]
+          ? `CWE-${r.info.classification["cwe-id"][0]}`
+          : undefined,
+        reference: r.info?.reference ?? [],
+      });
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  return findings;
+}
+
+// --- ZAP ---
+
+async function runZap(url: string): Promise<DastFinding[]> {
+  // Try zap-cli first, then docker-based ZAP
+  const zapAvailable = await commandExists("zap-cli");
+  if (!zapAvailable) return [];
+
+  const proc = Bun.spawn(
+    ["zap-cli", "quick-scan", url, "--spider", "-f", "json"],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  if (!stdout.trim()) return [];
+
+  try {
+    const data = JSON.parse(stdout);
+    const alerts = data.alerts ?? data.site?.[0]?.alerts ?? [];
+    return alerts.map((a: any) => ({
+      tool: "zap",
+      templateId: `zap-${a.pluginid ?? a.alertRef ?? "unknown"}`,
+      severity: normalizeSeverity(riskToSeverity(a.riskcode ?? a.risk ?? 0)),
+      url: a.url ?? url,
+      method: a.method ?? "GET",
+      vulnerabilityType: a.alert ?? a.name ?? "unknown",
+      description: a.description ?? "",
+      evidence: a.evidence ?? undefined,
+      cwe: a.cweid ? `CWE-${a.cweid}` : undefined,
+      reference: a.reference ? [a.reference] : [],
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function riskToSeverity(risk: number | string): string {
+  const r = typeof risk === "string" ? parseInt(risk, 10) : risk;
+  if (r >= 3) return "high";
+  if (r === 2) return "medium";
+  if (r === 1) return "low";
+  return "info";
+}
+
+// --- Main ---
+
+async function main() {
+  const targetUrl = positionalArgs[0];
+
+  if (!targetUrl) {
+    console.error("Error: target URL is required.");
+    console.error("Usage: bun run tools/dast-scan.ts <url> [options]");
+    process.exit(1);
+  }
+
+  // Validate URL
+  try {
+    new URL(targetUrl);
+  } catch {
+    console.error(`Error: invalid URL: ${targetUrl}`);
+    process.exit(1);
+  }
+
+  // Production URL warning
+  if (isProductionUrl(targetUrl)) {
+    console.error(`WARNING: ${targetUrl} looks like a production URL.`);
+    console.error("Ensure you have explicit authorization to scan this target.");
+    console.error("Use --tools and --severity flags to limit scan scope.\n");
+  }
+
+  const requestedTools = toolsFlag ? toolsFlag.split(",").map((t) => t.trim()) : [];
+  const severityFilter = severityFlag
+    ? new Set(severityFlag.split(",").map((s) => s.trim().toLowerCase()))
+    : null;
+
+  const toolRegistry = [
+    {
+      name: "nuclei",
+      detect: () => commandExists("nuclei"),
+      run: runNuclei,
+      installHint: "go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest  # or: brew install nuclei",
+    },
+    {
+      name: "zap",
+      detect: () => commandExists("zap-cli"),
+      run: runZap,
+      installHint: "pip install zaproxy  # or: docker pull zaproxy/zap-stable",
+    },
+  ];
+
+  const candidates = requestedTools.length
+    ? toolRegistry.filter((t) => requestedTools.includes(t.name))
+    : toolRegistry;
+
+  const toolsRun: string[] = [];
+  const toolsMissing: string[] = [];
+  const installHints: string[] = [];
+  let allFindings: DastFinding[] = [];
+
+  for (const tool of candidates) {
+    const available = await tool.detect();
+    if (!available) {
+      toolsMissing.push(tool.name);
+      installHints.push(`${tool.name}: ${tool.installHint}`);
+      continue;
+    }
+
+    try {
+      const findings = await tool.run(targetUrl);
+      allFindings.push(...findings);
+      toolsRun.push(tool.name);
+    } catch (err: any) {
+      console.error(`Warning: ${tool.name} failed: ${err.message}`);
+      toolsMissing.push(tool.name);
+    }
+  }
+
+  // Apply severity filter
+  if (severityFilter) {
+    allFindings = allFindings.filter((f) => severityFilter.has(f.severity));
+  }
+
+  // Sort by severity
+  const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  allFindings.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+  const summary: Record<string, number> = {};
+  for (const f of allFindings) {
+    summary[f.severity] = (summary[f.severity] ?? 0) + 1;
+  }
+
+  const result: DastResult = {
+    target: targetUrl,
+    toolsRun,
+    toolsMissing,
+    totalFindings: allFindings.length,
+    summary,
+    findings: allFindings,
+    installHints,
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Human-readable
+  console.log("# DAST Scan Report\n");
+  console.log(`Target: ${targetUrl}`);
+  console.log(`Tools run: ${toolsRun.join(", ") || "none"}`);
+  if (toolsMissing.length) {
+    console.log(`Tools missing: ${toolsMissing.join(", ")}`);
+  }
+  console.log(`Total findings: ${allFindings.length}\n`);
+
+  if (installHints.length) {
+    console.log("## Install missing tools\n");
+    for (const hint of installHints) {
+      console.log(`  ${hint}`);
+    }
+    console.log();
+  }
+
+  if (allFindings.length === 0) {
+    console.log("No findings detected.");
+    return;
+  }
+
+  console.log("## Summary\n");
+  for (const sev of ["critical", "high", "medium", "low", "info"]) {
+    if (summary[sev]) console.log(`  ${sev}: ${summary[sev]}`);
+  }
+  console.log();
+
+  console.log("## Findings\n");
+  let currentSeverity = "";
+  for (const f of allFindings) {
+    if (f.severity !== currentSeverity) {
+      currentSeverity = f.severity;
+      console.log(`### ${f.severity.toUpperCase()}\n`);
+    }
+    console.log(`  ${f.url} — [${f.tool}] ${f.templateId}`);
+    console.log(`    Type: ${f.vulnerabilityType}`);
+    console.log(`    ${f.description.slice(0, 200)}`);
+    if (f.evidence) console.log(`    Evidence: ${f.evidence}`);
+    if (f.cwe) console.log(`    CWE: ${f.cwe}`);
+    console.log();
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/skills/security/scanning-security/tools/sast-scan.ts
+++ b/skills/security/scanning-security/tools/sast-scan.ts
@@ -1,0 +1,419 @@
+const args = Bun.argv.slice(2);
+
+const HELP = `
+sast-scan — Detect available SAST tools and run them, normalize output
+
+Usage:
+  bun run tools/sast-scan.ts [directory] [options]
+
+Options:
+  --tools <list>      Comma-separated tools to run (semgrep,bandit,eslint)
+  --severity <list>   Filter by severity (critical,high,medium,low,info)
+  --json              Output as JSON instead of plain text
+  --help              Show this help message
+
+Auto-detects project languages and available scanners.
+Runs each scanner, parses output into a normalized finding format.
+`.trim();
+
+if (args.includes("--help")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+const jsonOutput = args.includes("--json");
+const toolsFlag = args.find((_, i) => args[i - 1] === "--tools") ?? "";
+const severityFlag = args.find((_, i) => args[i - 1] === "--severity") ?? "";
+const filteredArgs = args.filter(
+  (a, i) => !a.startsWith("--") && args[i - 1] !== "--tools" && args[i - 1] !== "--severity",
+);
+
+import { readdir } from "node:fs/promises";
+import { join, resolve, extname } from "node:path";
+
+interface SastFinding {
+  tool: string;
+  ruleId: string;
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  confidence: "high" | "medium" | "low";
+  file: string;
+  line: number;
+  column?: number;
+  endLine?: number;
+  message: string;
+  cwe?: string;
+  category: string;
+  snippet?: string;
+}
+
+interface SastResult {
+  root: string;
+  toolsRun: string[];
+  toolsMissing: string[];
+  totalFindings: number;
+  summary: Record<string, number>;
+  findings: SastFinding[];
+  installHints: string[];
+}
+
+interface ToolInfo {
+  name: string;
+  command: string;
+  languages: string[];
+  installHint: string;
+  detect: () => Promise<boolean>;
+  run: (dir: string) => Promise<SastFinding[]>;
+}
+
+async function commandExists(cmd: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["which", cmd], { stdout: "pipe", stderr: "pipe" });
+    await proc.exited;
+    return proc.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function detectLanguages(dir: string): Promise<Set<string>> {
+  const langs = new Set<string>();
+  const extMap: Record<string, string> = {
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mts": "typescript",
+    ".mjs": "javascript",
+    ".py": "python",
+    ".rb": "ruby",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".php": "php",
+  };
+
+  async function walk(d: string, depth: number): Promise<void> {
+    if (depth > 4) return;
+    try {
+      const entries = await readdir(d, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          if (["node_modules", ".git", "dist", ".next", "vendor", "__pycache__", "venv", ".venv"].includes(entry.name)) continue;
+          await walk(join(d, entry.name), depth + 1);
+        } else {
+          const ext = extname(entry.name);
+          if (extMap[ext]) langs.add(extMap[ext]);
+        }
+        if (langs.size >= 5) return;
+      }
+    } catch {
+      // skip unreadable dirs
+    }
+  }
+
+  await walk(dir, 0);
+  return langs;
+}
+
+function normalizeSeverity(sev: string): SastFinding["severity"] {
+  const s = sev.toLowerCase();
+  if (s === "error" || s === "critical" || s === "high_severity") return "critical";
+  if (s === "warning" || s === "high" || s === "medium_severity") return "high";
+  if (s === "medium") return "medium";
+  if (s === "low" || s === "low_severity" || s === "note") return "low";
+  return "info";
+}
+
+function normalizeConfidence(conf: string): SastFinding["confidence"] {
+  const c = conf.toLowerCase();
+  if (c === "high" || c === "definite") return "high";
+  if (c === "medium" || c === "possible") return "medium";
+  return "low";
+}
+
+// --- Semgrep parser ---
+
+async function runSemgrep(dir: string): Promise<SastFinding[]> {
+  const proc = Bun.spawn(["semgrep", "scan", "--json", "--config", "auto", dir], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  if (!stdout.trim()) return [];
+
+  try {
+    const data = JSON.parse(stdout);
+    const results = data.results ?? [];
+    return results.map((r: any) => ({
+      tool: "semgrep",
+      ruleId: r.check_id ?? "unknown",
+      severity: normalizeSeverity(r.extra?.severity ?? "info"),
+      confidence: normalizeConfidence(r.extra?.metadata?.confidence ?? "medium"),
+      file: r.path ?? "",
+      line: r.start?.line ?? 0,
+      column: r.start?.col,
+      endLine: r.end?.line,
+      message: r.extra?.message ?? "",
+      cwe: extractCwe(r.extra?.metadata?.cwe),
+      category: r.extra?.metadata?.category ?? categorizeRule(r.check_id ?? ""),
+      snippet: r.extra?.lines ?? "",
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// --- Bandit parser ---
+
+async function runBandit(dir: string): Promise<SastFinding[]> {
+  const proc = Bun.spawn(["bandit", "-r", dir, "-f", "json", "-q"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  if (!stdout.trim()) return [];
+
+  try {
+    const data = JSON.parse(stdout);
+    const results = data.results ?? [];
+    return results.map((r: any) => ({
+      tool: "bandit",
+      ruleId: r.test_id ?? "unknown",
+      severity: normalizeSeverity(r.issue_severity ?? "info"),
+      confidence: normalizeConfidence(r.issue_confidence ?? "medium"),
+      file: r.filename ?? "",
+      line: r.line_number ?? 0,
+      column: undefined,
+      endLine: r.end_col_offset ? r.line_number : undefined,
+      message: r.issue_text ?? "",
+      cwe: r.issue_cwe?.id ? `CWE-${r.issue_cwe.id}` : undefined,
+      category: categorizeRule(r.test_id ?? ""),
+      snippet: r.code ?? "",
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// --- ESLint security plugin parser ---
+
+async function runEslintSecurity(dir: string): Promise<SastFinding[]> {
+  // Try npx eslint with JSON output
+  const proc = Bun.spawn(
+    ["npx", "eslint", "--format", "json", "--no-error-on-unmatched-pattern", dir],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+
+  const stdout = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  if (!stdout.trim()) return [];
+
+  try {
+    const data = JSON.parse(stdout);
+    const findings: SastFinding[] = [];
+
+    for (const file of data) {
+      for (const msg of file.messages ?? []) {
+        // Only include security plugin rules
+        if (!msg.ruleId?.startsWith("security/")) continue;
+        findings.push({
+          tool: "eslint-plugin-security",
+          ruleId: msg.ruleId,
+          severity: msg.severity === 2 ? "high" : "medium",
+          confidence: "medium",
+          file: file.filePath ?? "",
+          line: msg.line ?? 0,
+          column: msg.column,
+          endLine: msg.endLine,
+          message: msg.message ?? "",
+          cwe: undefined,
+          category: categorizeRule(msg.ruleId ?? ""),
+          snippet: undefined,
+        });
+      }
+    }
+    return findings;
+  } catch {
+    return [];
+  }
+}
+
+// --- Helpers ---
+
+function extractCwe(cwe: any): string | undefined {
+  if (!cwe) return undefined;
+  if (typeof cwe === "string") return cwe;
+  if (Array.isArray(cwe) && cwe.length > 0) return String(cwe[0]);
+  return undefined;
+}
+
+function categorizeRule(ruleId: string): string {
+  const id = ruleId.toLowerCase();
+  if (id.includes("inject") || id.includes("sqli") || id.includes("xss") || id.includes("command")) return "injection";
+  if (id.includes("crypto") || id.includes("hash") || id.includes("random") || id.includes("cipher")) return "crypto";
+  if (id.includes("auth") || id.includes("session") || id.includes("password") || id.includes("credential")) return "auth";
+  if (id.includes("path") || id.includes("traversal") || id.includes("file")) return "file-access";
+  if (id.includes("deserial") || id.includes("pickle") || id.includes("yaml.load")) return "deserialization";
+  if (id.includes("eval") || id.includes("exec") || id.includes("spawn") || id.includes("child_process")) return "code-execution";
+  if (id.includes("cors") || id.includes("csrf") || id.includes("origin")) return "web-security";
+  return "general";
+}
+
+// --- Tool registry ---
+
+function buildTools(languages: Set<string>): ToolInfo[] {
+  const tools: ToolInfo[] = [
+    {
+      name: "semgrep",
+      command: "semgrep",
+      languages: ["typescript", "javascript", "python", "go", "java", "ruby", "rust", "php"],
+      installHint: "pip install semgrep  # or: brew install semgrep",
+      detect: () => commandExists("semgrep"),
+      run: runSemgrep,
+    },
+    {
+      name: "bandit",
+      command: "bandit",
+      languages: ["python"],
+      installHint: "pip install bandit",
+      detect: () => commandExists("bandit"),
+      run: runBandit,
+    },
+    {
+      name: "eslint",
+      command: "npx",
+      languages: ["typescript", "javascript"],
+      installHint: "npm install --save-dev eslint-plugin-security",
+      detect: async () => {
+        if (!languages.has("typescript") && !languages.has("javascript")) return false;
+        return commandExists("npx");
+      },
+      run: runEslintSecurity,
+    },
+  ];
+
+  return tools;
+}
+
+async function main() {
+  const dir = resolve(filteredArgs[0] ?? ".");
+  const languages = await detectLanguages(dir);
+  const requestedTools = toolsFlag ? toolsFlag.split(",").map((t) => t.trim()) : [];
+  const severityFilter = severityFlag
+    ? new Set(severityFlag.split(",").map((s) => s.trim().toLowerCase()))
+    : null;
+
+  const allTools = buildTools(languages);
+
+  // Filter to requested tools or all relevant ones
+  const candidates = requestedTools.length
+    ? allTools.filter((t) => requestedTools.includes(t.name))
+    : allTools.filter((t) => t.languages.some((l) => languages.has(l)));
+
+  const toolsRun: string[] = [];
+  const toolsMissing: string[] = [];
+  const installHints: string[] = [];
+  let allFindings: SastFinding[] = [];
+
+  for (const tool of candidates) {
+    const available = await tool.detect();
+    if (!available) {
+      toolsMissing.push(tool.name);
+      installHints.push(`${tool.name}: ${tool.installHint}`);
+      continue;
+    }
+
+    try {
+      const findings = await tool.run(dir);
+      allFindings.push(...findings);
+      toolsRun.push(tool.name);
+    } catch (err: any) {
+      console.error(`Warning: ${tool.name} failed: ${err.message}`);
+      toolsMissing.push(tool.name);
+    }
+  }
+
+  // Apply severity filter
+  if (severityFilter) {
+    allFindings = allFindings.filter((f) => severityFilter.has(f.severity));
+  }
+
+  // Sort by severity
+  const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  allFindings.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+  const summary: Record<string, number> = {};
+  for (const f of allFindings) {
+    summary[f.severity] = (summary[f.severity] ?? 0) + 1;
+  }
+
+  const result: SastResult = {
+    root: dir,
+    toolsRun,
+    toolsMissing,
+    totalFindings: allFindings.length,
+    summary,
+    findings: allFindings,
+    installHints,
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Human-readable output
+  console.log("# SAST Scan Report\n");
+  console.log(`Directory: ${dir}`);
+  console.log(`Languages: ${[...languages].join(", ") || "none detected"}`);
+  console.log(`Tools run: ${toolsRun.join(", ") || "none"}`);
+  if (toolsMissing.length) {
+    console.log(`Tools missing: ${toolsMissing.join(", ")}`);
+  }
+  console.log(`Total findings: ${allFindings.length}\n`);
+
+  if (installHints.length) {
+    console.log("## Install missing tools\n");
+    for (const hint of installHints) {
+      console.log(`  ${hint}`);
+    }
+    console.log();
+  }
+
+  if (allFindings.length === 0) {
+    console.log("No findings detected.");
+    return;
+  }
+
+  console.log("## Summary\n");
+  for (const sev of ["critical", "high", "medium", "low", "info"]) {
+    if (summary[sev]) console.log(`  ${sev}: ${summary[sev]}`);
+  }
+  console.log();
+
+  console.log("## Findings\n");
+  let currentSeverity = "";
+  for (const f of allFindings) {
+    if (f.severity !== currentSeverity) {
+      currentSeverity = f.severity;
+      console.log(`### ${f.severity.toUpperCase()}\n`);
+    }
+    console.log(`  ${f.file}:${f.line} — [${f.tool}] ${f.ruleId}`);
+    console.log(`    ${f.message}`);
+    if (f.cwe) console.log(`    CWE: ${f.cwe}`);
+    if (f.snippet) console.log(`    Code: ${String(f.snippet).trim().slice(0, 120)}`);
+    console.log();
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/skills/security/scanning-security/tools/scan-config.ts
+++ b/skills/security/scanning-security/tools/scan-config.ts
@@ -1,0 +1,311 @@
+const args = Bun.argv.slice(2);
+
+const HELP = `
+scan-config — Generate or validate scanner configuration files
+
+Usage:
+  bun run tools/scan-config.ts <command> [options]
+
+Commands:
+  generate <tool> [directory]                    Generate a starter config for a tool
+  validate <config-file>                         Validate a scanner config file
+  suppress <rule-id> <file:line> --reason <text> Add a false-positive suppression
+
+Supported tools: semgrep, bandit, eslint-security, nuclei
+
+Options:
+  --json    Output as JSON
+  --help    Show this help message
+`.trim();
+
+if (args.includes("--help") || args.length === 0) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+import { readFile, writeFile, appendFile, access } from "node:fs/promises";
+import { resolve, extname } from "node:path";
+
+const jsonOutput = args.includes("--json");
+const command = args[0];
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --- Generate ---
+
+const SEMGREP_CONFIG = `rules:
+  - id: custom-rules
+    patterns: []
+    message: "Custom rule placeholder"
+    severity: WARNING
+    languages: [typescript, javascript, python]
+
+# Use rulesets from the Semgrep registry:
+# semgrep scan --config p/owasp-top-ten
+# semgrep scan --config p/typescript
+# semgrep scan --config p/python
+# semgrep scan --config p/secrets
+`;
+
+const BANDIT_CONFIG = `[bandit]
+# Exclude directories from scanning
+exclude_dirs = tests,venv,.venv,node_modules
+
+# Skip specific test IDs (e.g., B101 = assert_used)
+# skips = B101
+
+# Set severity threshold
+# severity = medium
+
+# Profile (optional)
+# profile = gate
+`;
+
+const ESLINT_SECURITY_CONFIG = `// Add to your existing .eslintrc or eslint.config
+// npm install --save-dev eslint-plugin-security
+
+// For flat config (eslint.config.js):
+// import security from "eslint-plugin-security";
+// export default [security.configs.recommended];
+
+// For legacy config (.eslintrc):
+{
+  "plugins": ["security"],
+  "extends": ["plugin:security/recommended"]
+}
+`;
+
+const NUCLEI_CONFIG = `# nuclei config — place in ~/.config/nuclei/config.yaml or pass with -config
+severity: critical,high,medium
+rate-limit: 50
+bulk-size: 25
+concurrency: 10
+retries: 1
+timeout: 10
+# templates-directory: ./nuclei-templates
+# exclude-templates: dos/
+`;
+
+async function generate(tool: string, dir: string): Promise<void> {
+  const configs: Record<string, { file: string; content: string }> = {
+    semgrep: { file: ".semgrep.yml", content: SEMGREP_CONFIG },
+    bandit: { file: ".bandit", content: BANDIT_CONFIG },
+    "eslint-security": { file: ".eslint-security-example.js", content: ESLINT_SECURITY_CONFIG },
+    nuclei: { file: ".nuclei-config.yml", content: NUCLEI_CONFIG },
+  };
+
+  const config = configs[tool];
+  if (!config) {
+    console.error(`Unknown tool: ${tool}. Supported: ${Object.keys(configs).join(", ")}`);
+    process.exit(1);
+  }
+
+  const outPath = resolve(dir, config.file);
+  if (await fileExists(outPath)) {
+    console.error(`File already exists: ${outPath}`);
+    console.error("Remove it first or use 'validate' to check the existing config.");
+    process.exit(1);
+  }
+
+  await writeFile(outPath, config.content, "utf-8");
+
+  if (jsonOutput) {
+    console.log(JSON.stringify({ action: "generate", tool, file: outPath }));
+  } else {
+    console.log(`Generated ${config.file} at ${outPath}`);
+    console.log(`Edit the file to customize rules for your project.`);
+  }
+}
+
+// --- Validate ---
+
+async function validate(configPath: string): Promise<void> {
+  const fullPath = resolve(configPath);
+  if (!(await fileExists(fullPath))) {
+    console.error(`File not found: ${fullPath}`);
+    process.exit(1);
+  }
+
+  const content = await readFile(fullPath, "utf-8");
+  const ext = extname(fullPath);
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Basic validation by file type
+  if (ext === ".yml" || ext === ".yaml") {
+    // Check for valid YAML structure
+    if (!content.trim()) {
+      errors.push("File is empty");
+    }
+    if (content.includes("\t")) {
+      warnings.push("YAML files should use spaces, not tabs");
+    }
+    // Check semgrep-specific structure
+    if (fullPath.includes("semgrep")) {
+      if (!content.includes("rules:") && !content.includes("config:")) {
+        warnings.push("Semgrep config should contain 'rules:' or reference a registry config");
+      }
+    }
+  } else if (ext === ".json") {
+    try {
+      JSON.parse(content);
+    } catch (err: any) {
+      errors.push(`Invalid JSON: ${err.message}`);
+    }
+  }
+
+  // Check for overly broad suppressions
+  if (content.includes("nosemgrep") && !content.includes(":")) {
+    warnings.push("Semgrep suppression without specific rule ID — suppress specific rules instead");
+  }
+
+  const result = {
+    file: fullPath,
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`# Config Validation: ${configPath}\n`);
+    if (errors.length === 0 && warnings.length === 0) {
+      console.log("No issues found.");
+    }
+    if (errors.length) {
+      console.log("## Errors\n");
+      for (const e of errors) console.log(`  - ${e}`);
+      console.log();
+    }
+    if (warnings.length) {
+      console.log("## Warnings\n");
+      for (const w of warnings) console.log(`  - ${w}`);
+      console.log();
+    }
+  }
+
+  if (errors.length) process.exit(1);
+}
+
+// --- Suppress ---
+
+async function suppress(): Promise<void> {
+  const ruleId = args[1];
+  const fileLineArg = args[2];
+  const reasonIdx = args.indexOf("--reason");
+  const reason = reasonIdx !== -1 ? args.slice(reasonIdx + 1).filter((a) => !a.startsWith("--")).join(" ") : "";
+
+  if (!ruleId || !fileLineArg) {
+    console.error("Usage: scan-config.ts suppress <rule-id> <file:line> --reason <text>");
+    process.exit(1);
+  }
+
+  if (!reason) {
+    console.error("A --reason is required for all suppressions.");
+    process.exit(1);
+  }
+
+  const [filePath, lineStr] = fileLineArg.split(":");
+  const line = parseInt(lineStr, 10);
+
+  if (!filePath || isNaN(line)) {
+    console.error("Invalid file:line format. Example: src/auth.ts:42");
+    process.exit(1);
+  }
+
+  const fullPath = resolve(filePath);
+  if (!(await fileExists(fullPath))) {
+    console.error(`File not found: ${fullPath}`);
+    process.exit(1);
+  }
+
+  const content = await readFile(fullPath, "utf-8");
+  const lines = content.split("\n");
+
+  if (line < 1 || line > lines.length) {
+    console.error(`Line ${line} is out of range (file has ${lines.length} lines)`);
+    process.exit(1);
+  }
+
+  // Determine suppression comment based on rule ID pattern
+  let comment: string;
+  const ext = extname(fullPath);
+  const commentPrefix = [".py", ".rb", ".sh", ".bash", ".yml", ".yaml"].includes(ext) ? "#" : "//";
+
+  if (ruleId.startsWith("B") && /^B\d+$/.test(ruleId)) {
+    // Bandit rule
+    comment = `${commentPrefix} nosec ${ruleId} — ${reason}`;
+  } else if (ruleId.startsWith("security/")) {
+    // ESLint security plugin
+    comment = `${commentPrefix} eslint-disable-next-line ${ruleId} — ${reason}`;
+  } else {
+    // Default to semgrep style
+    comment = `${commentPrefix} nosemgrep: ${ruleId} — ${reason}`;
+  }
+
+  // Insert suppression comment above the target line
+  const indent = lines[line - 1].match(/^(\s*)/)?.[1] ?? "";
+  lines.splice(line - 1, 0, `${indent}${comment}`);
+
+  await writeFile(fullPath, lines.join("\n"), "utf-8");
+
+  // Append to audit log
+  const logEntry = `${new Date().toISOString()} | SUPPRESS | ${ruleId} | ${filePath}:${line} | ${reason}\n`;
+  await appendFile(resolve("scan-suppressions.log"), logEntry, "utf-8");
+
+  if (jsonOutput) {
+    console.log(JSON.stringify({ action: "suppress", ruleId, file: filePath, line, reason, comment }));
+  } else {
+    console.log(`Added suppression for ${ruleId} at ${filePath}:${line}`);
+    console.log(`Comment: ${comment}`);
+    console.log(`Logged to scan-suppressions.log`);
+  }
+}
+
+// --- Main ---
+
+async function main() {
+  switch (command) {
+    case "generate": {
+      const tool = args[1];
+      const dir = args[2] ?? ".";
+      if (!tool) {
+        console.error("Usage: scan-config.ts generate <tool> [directory]");
+        console.error("Tools: semgrep, bandit, eslint-security, nuclei");
+        process.exit(1);
+      }
+      await generate(tool, dir);
+      break;
+    }
+    case "validate": {
+      const configFile = args[1];
+      if (!configFile) {
+        console.error("Usage: scan-config.ts validate <config-file>");
+        process.exit(1);
+      }
+      await validate(configFile);
+      break;
+    }
+    case "suppress": {
+      await suppress();
+      break;
+    }
+    default:
+      console.error(`Unknown command: ${command}`);
+      console.error("Commands: generate, validate, suppress");
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/skills/security/scanning-security/tools/triage-findings.ts
+++ b/skills/security/scanning-security/tools/triage-findings.ts
@@ -1,0 +1,244 @@
+const args = Bun.argv.slice(2);
+
+const HELP = `
+triage-findings — Parse scan results, deduplicate, prioritize by severity
+
+Usage:
+  bun run tools/triage-findings.ts [findings-files...] [options]
+
+Options:
+  --min-severity <level>   Filter below threshold (critical,high,medium,low,info)
+  --group-by <field>       Group by: severity, file, rule, category, tool (default: severity)
+  --no-dedupe              Disable deduplication
+  --json                   Output as JSON instead of plain text
+  --help                   Show this help message
+
+Reads JSON findings from files (output of sast-scan.ts or dast-scan.ts with --json).
+If no files given, reads from stdin.
+`.trim();
+
+if (args.includes("--help")) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+import { readFile } from "node:fs/promises";
+
+const jsonOutput = args.includes("--json");
+const noDedupe = args.includes("--no-dedupe");
+const minSeverityFlag = args.find((_, i) => args[i - 1] === "--min-severity") ?? "";
+const groupByFlag = args.find((_, i) => args[i - 1] === "--group-by") ?? "severity";
+const fileArgs = args.filter(
+  (a, i) =>
+    !a.startsWith("--") &&
+    args[i - 1] !== "--min-severity" &&
+    args[i - 1] !== "--group-by",
+);
+
+interface Finding {
+  tool: string;
+  ruleId: string;
+  severity: string;
+  confidence?: string;
+  file?: string;
+  line?: number;
+  url?: string;
+  method?: string;
+  message: string;
+  cwe?: string;
+  category?: string;
+  snippet?: string;
+  vulnerabilityType?: string;
+}
+
+interface TriagedResult {
+  inputFindings: number;
+  afterDedup: number;
+  groups: Record<string, Finding[]>;
+  actionItems: Record<string, number>;
+}
+
+const SEVERITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+function deduplicateFindings(findings: Finding[]): Finding[] {
+  const seen = new Map<string, Finding>();
+
+  for (const f of findings) {
+    // Key by location + rule for SAST, or URL + type for DAST
+    const key = f.file
+      ? `${f.file}:${f.line ?? 0}:${f.ruleId}`
+      : `${f.url}:${f.method}:${f.vulnerabilityType ?? f.ruleId}`;
+
+    const existing = seen.get(key);
+    if (!existing) {
+      seen.set(key, f);
+    } else {
+      // Keep the higher-severity finding, note the other tool
+      const existingSev = SEVERITY_ORDER[existing.severity] ?? 4;
+      const newSev = SEVERITY_ORDER[f.severity] ?? 4;
+      if (newSev < existingSev) {
+        seen.set(key, { ...f, message: `${f.message} (also reported by ${existing.tool})` });
+      } else {
+        seen.set(key, { ...existing, message: `${existing.message} (also reported by ${f.tool})` });
+      }
+    }
+  }
+
+  return [...seen.values()];
+}
+
+function groupFindings(findings: Finding[], field: string): Record<string, Finding[]> {
+  const groups: Record<string, Finding[]> = {};
+
+  for (const f of findings) {
+    let key: string;
+    switch (field) {
+      case "file":
+        key = f.file ?? f.url ?? "unknown";
+        break;
+      case "rule":
+        key = f.ruleId;
+        break;
+      case "category":
+        key = f.category ?? "uncategorized";
+        break;
+      case "tool":
+        key = f.tool;
+        break;
+      case "severity":
+      default:
+        key = f.severity;
+        break;
+    }
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(f);
+  }
+
+  return groups;
+}
+
+async function readFindings(): Promise<Finding[]> {
+  let allFindings: Finding[] = [];
+
+  if (fileArgs.length > 0) {
+    for (const filePath of fileArgs) {
+      try {
+        const content = await readFile(filePath, "utf-8");
+        const data = JSON.parse(content);
+        // Support both raw findings array and wrapped result objects
+        const findings = data.findings ?? (Array.isArray(data) ? data : []);
+        allFindings.push(...findings);
+      } catch (err: any) {
+        console.error(`Warning: could not read ${filePath}: ${err.message}`);
+      }
+    }
+  } else {
+    // Read from stdin
+    const chunks: string[] = [];
+    const reader = Bun.stdin.stream().getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(new TextDecoder().decode(value));
+      }
+    } catch {
+      // stdin closed
+    }
+    const content = chunks.join("");
+    if (content.trim()) {
+      try {
+        const data = JSON.parse(content);
+        const findings = data.findings ?? (Array.isArray(data) ? data : []);
+        allFindings.push(...findings);
+      } catch (err: any) {
+        console.error(`Warning: could not parse stdin: ${err.message}`);
+      }
+    }
+  }
+
+  return allFindings;
+}
+
+async function main() {
+  let findings = await readFindings();
+  const inputCount = findings.length;
+
+  if (inputCount === 0) {
+    console.log(jsonOutput ? JSON.stringify({ inputFindings: 0, afterDedup: 0, groups: {}, actionItems: {} }) : "No findings to triage.");
+    return;
+  }
+
+  // Apply severity filter
+  if (minSeverityFlag) {
+    const minLevel = SEVERITY_ORDER[minSeverityFlag.toLowerCase()] ?? 4;
+    findings = findings.filter((f) => (SEVERITY_ORDER[f.severity] ?? 4) <= minLevel);
+  }
+
+  // Deduplicate
+  if (!noDedupe) {
+    findings = deduplicateFindings(findings);
+  }
+
+  // Sort by severity
+  findings.sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 4) - (SEVERITY_ORDER[b.severity] ?? 4));
+
+  // Group
+  const groups = groupFindings(findings, groupByFlag);
+
+  // Action items summary
+  const actionItems: Record<string, number> = {};
+  for (const f of findings) {
+    actionItems[f.severity] = (actionItems[f.severity] ?? 0) + 1;
+  }
+
+  const result: TriagedResult = {
+    inputFindings: inputCount,
+    afterDedup: findings.length,
+    groups,
+    actionItems,
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Human-readable
+  console.log("# Triage Report\n");
+  console.log(`Input findings: ${inputCount}`);
+  console.log(`After dedup: ${findings.length}`);
+  if (inputCount !== findings.length) {
+    console.log(`Duplicates removed: ${inputCount - findings.length}`);
+  }
+  console.log();
+
+  console.log("## Action Items\n");
+  for (const sev of ["critical", "high", "medium", "low", "info"]) {
+    if (actionItems[sev]) console.log(`  ${sev}: ${actionItems[sev]}`);
+  }
+  console.log();
+
+  console.log(`## Findings (grouped by ${groupByFlag})\n`);
+  for (const [group, groupFindings] of Object.entries(groups)) {
+    console.log(`### ${group} (${groupFindings.length})\n`);
+    for (const f of groupFindings) {
+      const location = f.file ? `${f.file}:${f.line ?? "?"}` : f.url ?? "unknown";
+      console.log(`  ${location} — [${f.tool}] ${f.ruleId}`);
+      console.log(`    ${f.message}`);
+      if (f.cwe) console.log(`    CWE: ${f.cwe}`);
+      console.log();
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a comprehensive security scanning skill that automates SAST (Static Application Security Testing) and DAST (Dynamic Application Security Testing) scanning, with tools for normalizing results, triaging findings, and managing scanner configurations.

## Key Changes

- **SAST Scanner (`sast-scan.ts`)**: Detects and runs available SAST tools (semgrep, bandit, eslint-plugin-security) against codebases, auto-detects project languages, normalizes output into a unified finding format with severity, confidence, CWE, and code snippets
  
- **DAST Scanner (`dast-scan.ts`)**: Runs DAST tools (nuclei, ZAP) against target URLs with production URL warnings, normalizes findings across tools, supports custom nuclei templates and severity filtering

- **Configuration Management (`scan-config.ts`)**: Generates starter configs for semgrep, bandit, eslint-plugin-security, and nuclei; validates config files; manages false-positive suppressions with audit logging

- **Finding Triage (`triage-findings.ts`)**: Parses scan results from multiple tools, deduplicates findings by location/rule, prioritizes by severity, groups by configurable fields (severity, file, rule, category, tool)

- **CI Integration Guide (`ci-integration.md`)**: Documents GitHub Actions and GitLab CI patterns for SAST on PRs and DAST on staging deploys, including severity gating and SARIF upload

- **Skill Documentation**: Added SKILL.md with decision tree and workflows, PURPOSE.md with responsibilities, and updated marketplace.json to register the new skill

## Implementation Details

- All tools use Bun's `spawn()` for command execution and stream-based output parsing
- Unified `SastFinding` and `DastFinding` interfaces normalize output across different scanner formats
- Severity normalization handles tool-specific severity levels (e.g., "error" → "critical", "warning" → "high")
- Deduplication uses location+rule as key for SAST, URL+method+type for DAST
- Suppression comments are language-aware (Python/Ruby use `#`, JS/TS use `//`)
- All tools support both human-readable and JSON output formats

https://claude.ai/code/session_01G8B7ut6smdYfcSwEzx4s2f