### PR TITLE
docs(writing): fix stale cross-references and improve description

### DIFF
--- a/skills/documentation/writing/PURPOSE.md
+++ b/skills/documentation/writing/PURPOSE.md
@@ -23,5 +23,5 @@ Write and maintain project documentation — READMEs, contributing guides, archi
 
 ## Cross-references
 
-- ADR scaffolding: `development/knowledge` (tools/adr-create.ts)
-- Environment variable documentation: `project/parts/config` (tools/env-docs.ts)
+- ADR scaffolding: `development/gathering-knowledge` (tools/adr-create.ts)
+- Project structure and environment config: `project/scaffolding`

--- a/skills/documentation/writing/SKILL.md
+++ b/skills/documentation/writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing
-description: Writes and maintains project documentation — READMEs, CONTRIBUTING.md, architecture overviews, ADRs, GitHub templates, and Mermaid diagrams. Use when creating docs for a new project, updating existing documentation, or scaffolding contributor workflows.
+description: Writes and maintains project documentation — READMEs, CONTRIBUTING.md, architecture overviews, GitHub templates, and Mermaid diagrams — with built-in support for Library/CLI, Service, Monorepo, Expo, Rust, and Swift project types. Use when creating docs for a new project, updating existing documentation, scaffolding contributor workflows, or generating architecture diagrams from code.
 allowed-tools: Read Grep Glob Bash Write Edit
 ---
 
@@ -146,7 +146,7 @@ For a well-configured project, also set:
 
 ## ADR
 
-> **Cross-reference:** ADR scaffolding is handled by `development/knowledge` (tools/adr-create.ts). Use that skill to create new ADRs.
+> **Cross-reference:** ADR scaffolding is handled by `development/gathering-knowledge` (tools/adr-create.ts). Use that skill to create new ADRs.
 
 1. Fill in the four sections:
    - **Context** — what situation forced a decision?
@@ -209,5 +209,5 @@ Badges provide at-a-glance project status. Use shields.io for consistency. Full 
 | `tools/badge-sync.ts` | Generate and update CI, coverage, npm version badges |
 | `tools/setup-validator.ts` | Verify documented setup steps run cleanly |
 | `tools/mermaid-gen.ts` | Generate Mermaid diagrams from modules and DB schema |
-| `development/knowledge` | ADR scaffolding (tools/adr-create.ts) |
-| `project/parts/config` | Environment variable documentation (tools/env-docs.ts) |
+| `development/gathering-knowledge` | ADR scaffolding (tools/adr-create.ts) |
+| `project/scaffolding` | Project structure and environment config reference |


### PR DESCRIPTION
## Summary

- Fix two dead cross-references left over from skill renames/consolidation: `development/knowledge` → `development/gathering-knowledge` and `project/parts/config` → `project/scaffolding` (both in SKILL.md and PURPOSE.md)
- Update the description to differentiate `writing` from `developer-docs`, which had an identical description — now explicitly calls out multi-project-type template support (Library/CLI, Service, Monorepo, Expo, Rust, Swift)

## Test plan

- [x] `bun run generate` passes with no errors
- [x] Pre-commit hook confirms marketplace.json is up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)