### PR TITLE
feat(development): add developing-workers skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,13 +47,14 @@
     {
       "name": "development",
       "source": "./",
-      "description": "Development toolkit: auditing-accessibility, configuring-environment, debugging, designing-api, enforcing-type-safety, gathering-knowledge, handling-error, implementing, modeling-database, optimizing-performance, planning, refactoring, testing",
+      "description": "Development toolkit: auditing-accessibility, configuring-environment, debugging, designing-api, developing-workers, enforcing-type-safety, gathering-knowledge, handling-error, implementing, modeling-database, optimizing-performance, planning, refactoring, testing",
       "category": "devtools",
       "skills": [
         "./skills/development/auditing-accessibility",
         "./skills/development/configuring-environment",
         "./skills/development/debugging",
         "./skills/development/designing-api",
+        "./skills/development/developing-workers",
         "./skills/development/enforcing-type-safety",
         "./skills/development/gathering-knowledge",
         "./skills/development/handling-error",

--- a/skills/development/developing-workers/PURPOSE.md
+++ b/skills/development/developing-workers/PURPOSE.md
@@ -1,0 +1,15 @@
+# developing-workers
+
+Local development workflow for Cloudflare Workers projects — generating secrets, running migrations, and orchestrating services.
+
+## Responsibilities
+
+- Generate `.dev.vars` files for Wrangler Workers from Doppler or env sources
+- Run D1 local migrations across single and multi-database projects
+- Orchestrate multiple Workers and services using process-compose
+- Diagnose and fix Worker startup failures in local dev
+- Seed, reset, and inspect local D1 databases
+
+## Tools
+
+- `tools/devvars-check.ts` — scan for wrangler configs and report which workers are missing `.dev.vars`

--- a/skills/development/developing-workers/SKILL.md
+++ b/skills/development/developing-workers/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: developing-workers
+description: Guides local Cloudflare Workers development — generating .dev.vars from Doppler or env files, running D1 local migrations, orchestrating multiple workers with process-compose, and diagnosing startup failures. Use when setting up a Workers project locally for the first time, generating .dev.vars for Wrangler, configuring Doppler for local secrets, running migrations against local D1, starting multiple workers with process-compose, debugging why a worker won't start locally, seeding or resetting local D1 databases, or checking whether .dev.vars are complete.
+allowed-tools: Read Grep Glob Bash Write Edit
+---
+
+# Local Workers Development
+
+## Decision Tree
+
+- What are you doing?
+  - **First time setup** → see "Bootstrap" below
+  - **Generating `.dev.vars` for workers** → see ".dev.vars setup" below
+  - **Running local D1 migrations** → see "D1 migrations" below
+  - **Starting dev services** → see "Service orchestration" below
+  - **A worker isn't starting** → see "Diagnosing failures" below
+  - **Seeding or resetting databases** → see "Database operations" below
+  - **Checking which workers have missing secrets** → run `tools/devvars-check.ts`
+
+## Bootstrap
+
+First-time setup sequence:
+
+1. Check `mise.toml` or `package.json` for a setup script (usually `bun run dev:setup` or `bun scripts/setup.ts`)
+2. If it exists, run it — it typically generates `.dev.vars` and can auto-migrate on first run
+3. Run migrations manually if not auto-applied: `bun scripts/migrate.ts` or `bun run dev:migrate`
+4. Seed: `bun scripts/seed.ts` or `bun run dev:seed`
+5. Start services: `bun scripts/dev.ts` or `mise run dev`
+
+If there's no setup script, follow ".dev.vars setup" and "D1 migrations" manually.
+
+## .dev.vars setup
+
+Wrangler reads secrets from `.dev.vars` (not `.env`) when running Workers locally. This file is gitignored and must be created for each Worker.
+
+**Source priority:**
+1. **Doppler** — if `doppler.yaml` exists at the project root, Doppler injects secrets into `process.env` automatically when using `mise` (via `_.source` in `mise.toml`) or `doppler run --`
+2. **`.env.secrets`** — fallback for devs who haven't configured Doppler
+3. **`.env`** — non-secret config (URLs, ports, feature flags); always present
+
+**Manual `.dev.vars` creation:**
+```bash
+# Minimal .dev.vars for a single Worker
+cat apis/auth/.dev.vars.example  # see what vars are expected
+cp apis/auth/.dev.vars.example apis/auth/.dev.vars
+# Fill in real values
+```
+
+**If the project has `scripts/setup.ts`**, run it instead — it handles Doppler loading, env interpolation (e.g. `${CLOUDFLARE_D1_TOKEN}`), and writes `.dev.vars` for all workers in one pass.
+
+**Checking coverage:** run `tools/devvars-check.ts` to see which workers are missing their `.dev.vars`.
+
+## D1 migrations
+
+```bash
+# Apply migrations locally (single database)
+bunx wrangler d1 migrations apply <database-name> --local
+
+# With a specific config file
+bunx wrangler d1 migrations apply <db-name> --local --config wrangler.jsonc
+
+# For multi-database projects, check wrangler.toml for [[d1_databases]] to find all names
+# Run for each database
+```
+
+If the project has `scripts/migrate.ts`, prefer it — it handles ordering across multiple databases and tracks state so it's safe to re-run.
+
+Never hand-edit migration files. If a migration needs a fix, generate a new one.
+
+## Service orchestration
+
+Projects use **process-compose** to run multiple Workers and services simultaneously:
+
+```bash
+# Start everything (TUI mode)
+process-compose up
+# or via project scripts:
+bun scripts/dev.ts
+mise run dev
+
+# Start specific services
+bun scripts/dev.ts --only=auth,user
+bun scripts/dev.ts --only=apis    # all API workers
+bun scripts/dev.ts --only=app     # Expo only
+
+# Point Expo at deployed APIs (skip local workers)
+bun scripts/dev.ts --remote
+```
+
+Read `process-compose.yml` to find service names, ports, and readiness probes. Each Worker runs on its own port (e.g., auth=4804, user=4801, content=4802).
+
+## Diagnosing failures
+
+When a worker fails to start:
+
+1. Verify `.dev.vars` exists: `ls apis/<name>/.dev.vars`
+2. Compare with `.dev.vars.example` to find missing vars
+3. Run the worker directly to see the raw error:
+   ```bash
+   cd apis/<name> && bunx wrangler dev
+   ```
+4. Check for port conflicts: `lsof -i :<port>` — kill conflicting process or change port in config
+5. Verify D1 migrations have been applied locally
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Missing required env var` | `.dev.vars` incomplete | Run `bun scripts/setup.ts` or add missing var |
+| `D1_ERROR: no such table` | Migrations not applied | Run `bun scripts/migrate.ts` or `wrangler d1 migrations apply --local` |
+| `EADDRINUSE` | Port already in use | `lsof -i :<port>` and kill the process |
+| `Cannot find module` | Missing deps | Run `bun install` |
+
+## Database operations
+
+```bash
+# Seed local databases
+bun scripts/seed.ts  # or: bun run dev:seed
+
+# Wipe and re-seed (reset)
+bun scripts/reset.ts  # or: bun run dev:reset
+
+# Run a SQL query against local D1
+bunx wrangler d1 execute <database-name> --local --command "SELECT * FROM users LIMIT 10"
+
+# Open Drizzle Studio for local D1
+bunx drizzle-kit studio
+```
+
+## Key references
+
+| File | What it covers |
+|---|---|
+| `tools/devvars-check.ts` | Scan for wrangler configs and report which workers are missing `.dev.vars` |

--- a/skills/development/developing-workers/tools/devvars-check.ts
+++ b/skills/development/developing-workers/tools/devvars-check.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+/**
+ * devvars-check — scan for wrangler configs and report which workers are missing .dev.vars.
+ *
+ * For each wrangler config found, checks:
+ *   - Whether .dev.vars exists
+ *   - If .dev.vars.example exists, which variables from the example are absent in the actual file
+ *
+ * Usage: bun tools/devvars-check.ts [root-dir]
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join, relative } from "node:path"
+import { glob } from "bun"
+
+const rootDir = process.argv[2] ?? process.cwd()
+
+function parseVarNames(content: string): string[] {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"))
+    .map((line) => line.split("=")[0].trim())
+    .filter(Boolean)
+}
+
+const wranglerPatterns = ["**/wrangler.toml", "**/wrangler.json", "**/wrangler.jsonc"]
+
+const configs: string[] = []
+for (const pattern of wranglerPatterns) {
+  for await (const match of glob(pattern, { cwd: rootDir, dot: true })) {
+    // Skip node_modules
+    if (match.includes("node_modules")) continue
+    configs.push(join(rootDir, match))
+  }
+}
+
+if (configs.length === 0) {
+  console.log("No wrangler config files found.")
+  process.exit(0)
+}
+
+type WorkerStatus = {
+  config: string
+  dir: string
+  devvarsExists: boolean
+  missingVars: string[]
+}
+
+const results: WorkerStatus[] = []
+
+for (const configPath of configs) {
+  const dir = dirname(configPath)
+  const devvarsPath = join(dir, ".dev.vars")
+  const examplePath = join(dir, ".dev.vars.example")
+
+  const devvarsExists = existsSync(devvarsPath)
+  let missingVars: string[] = []
+
+  if (devvarsExists && existsSync(examplePath)) {
+    const exampleContent = readFileSync(examplePath, "utf-8")
+    const devvarsContent = readFileSync(devvarsPath, "utf-8")
+
+    const expectedVars = parseVarNames(exampleContent)
+    const actualVars = new Set(parseVarNames(devvarsContent))
+
+    missingVars = expectedVars.filter((v) => !actualVars.has(v))
+  } else if (!devvarsExists && existsSync(examplePath)) {
+    // .dev.vars missing entirely — report all vars from example as missing
+    const exampleContent = readFileSync(examplePath, "utf-8")
+    missingVars = parseVarNames(exampleContent)
+  }
+
+  results.push({
+    config: relative(rootDir, configPath),
+    dir: relative(rootDir, dir) || ".",
+    devvarsExists,
+    missingVars,
+  })
+}
+
+const ok = results.filter((r) => r.devvarsExists && r.missingVars.length === 0)
+const missing = results.filter((r) => !r.devvarsExists)
+const incomplete = results.filter((r) => r.devvarsExists && r.missingVars.length > 0)
+
+console.log(`\nScanned ${results.length} worker(s) in ${rootDir}\n`)
+
+if (ok.length > 0) {
+  console.log(`✓ Complete (${ok.length}):`)
+  for (const r of ok) {
+    console.log(`  ${r.dir}`)
+  }
+  console.log()
+}
+
+if (incomplete.length > 0) {
+  console.log(`⚠ Incomplete .dev.vars (${incomplete.length}):`)
+  for (const r of incomplete) {
+    console.log(`  ${r.dir}`)
+    for (const v of r.missingVars) {
+      console.log(`    missing: ${v}`)
+    }
+  }
+  console.log()
+}
+
+if (missing.length > 0) {
+  console.log(`✗ Missing .dev.vars (${missing.length}):`)
+  for (const r of missing) {
+    console.log(`  ${r.dir}  (config: ${r.config})`)
+  }
+  console.log()
+}
+
+if (missing.length > 0 || incomplete.length > 0) {
+  console.log("Run `bun scripts/setup.ts` to generate missing .dev.vars files.")
+  console.log(
+    "Or copy the .dev.vars.example for each worker and fill in the missing values.\n"
+  )
+  process.exit(1)
+} else {
+  console.log("All workers have complete .dev.vars. ✓\n")
+  process.exit(0)
+}

--- a/skills/documentation/writing/PURPOSE.md
+++ b/skills/documentation/writing/PURPOSE.md
@@ -23,5 +23,5 @@ Write and maintain project documentation — READMEs, contributing guides, archi
 
 ## Cross-references
 
-- ADR scaffolding: `development/knowledge` (tools/adr-create.ts)
-- Environment variable documentation: `project/parts/config` (tools/env-docs.ts)
+- ADR scaffolding: `development/gathering-knowledge` (tools/adr-create.ts)
+- Project structure and environment config: `project/scaffolding`

--- a/skills/documentation/writing/SKILL.md
+++ b/skills/documentation/writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing
-description: Writes and maintains project documentation — READMEs, CONTRIBUTING.md, architecture overviews, ADRs, GitHub templates, and Mermaid diagrams. Use when creating docs for a new project, updating existing documentation, or scaffolding contributor workflows.
+description: Writes and maintains project documentation — READMEs, CONTRIBUTING.md, architecture overviews, GitHub templates, and Mermaid diagrams — with built-in support for Library/CLI, Service, Monorepo, Expo, Rust, and Swift project types. Use when creating docs for a new project, updating existing documentation, scaffolding contributor workflows, or generating architecture diagrams from code.
 allowed-tools: Read Grep Glob Bash Write Edit
 ---
 
@@ -146,7 +146,7 @@ For a well-configured project, also set:
 
 ## ADR
 
-> **Cross-reference:** ADR scaffolding is handled by `development/knowledge` (tools/adr-create.ts). Use that skill to create new ADRs.
+> **Cross-reference:** ADR scaffolding is handled by `development/gathering-knowledge` (tools/adr-create.ts). Use that skill to create new ADRs.
 
 1. Fill in the four sections:
    - **Context** — what situation forced a decision?
@@ -209,5 +209,5 @@ Badges provide at-a-glance project status. Use shields.io for consistency. Full 
 | `tools/badge-sync.ts` | Generate and update CI, coverage, npm version badges |
 | `tools/setup-validator.ts` | Verify documented setup steps run cleanly |
 | `tools/mermaid-gen.ts` | Generate Mermaid diagrams from modules and DB schema |
-| `development/knowledge` | ADR scaffolding (tools/adr-create.ts) |
-| `project/parts/config` | Environment variable documentation (tools/env-docs.ts) |
+| `development/gathering-knowledge` | ADR scaffolding (tools/adr-create.ts) |
+| `project/scaffolding` | Project structure and environment config reference |


### PR DESCRIPTION
## What repos/patterns inspired this skill

Scanned **ellie** and **strijthagencup**. Both follow the same local Workers dev setup:

- `doppler.yaml` → secrets injected via `mise` → `scripts/setup.ts` generates `.dev.vars` per worker
- `scripts/migrate.ts` applies D1 migrations across multiple databases
- `process-compose.yml` orchestrates multiple Wrangler workers + mailpit + Expo
- `scripts/dev.ts` with `--only=apis`, `--only=app`, `--remote` flags

The ellie git log has 15+ `fix(ci):` commits related to this exact setup — D1 migrations, `.dev.vars` generation, secret syncing — showing it's a recurring pain point.

## What workflow it covers

Local Cloudflare Workers development:
- Generating `.dev.vars` from Doppler or env fallback
- Running D1 local migrations (single and multi-database)
- Orchestrating multiple workers with process-compose
- Diagnosing worker startup failures
- Seeding and resetting local D1 databases

## Why it's useful

This pattern sits between two existing skills that don't cover it:
- `deploying-cloudflare` — focuses on production/staging deployment, not local dev
- `configuring-environment` — covers tool versions and devcontainers, not service orchestration

Includes `devvars-check.ts` that scans all wrangler configs and reports which workers are missing or have incomplete `.dev.vars` — real validation logic, not a thin wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)