### PR TITLE
feat(project): add task spec skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 build/
 .cache/
 tools/
+local/
 
 # mise
 .mise.local.toml

--- a/plugins/project/.claude-plugin/plugin.json
+++ b/plugins/project/.claude-plugin/plugin.json
@@ -3,7 +3,8 @@
 	"description": "Project setup and context management",
 	"skills": [
 		"./skills/project-context",
-		"./skills/requirements"
+		"./skills/requirements",
+		"./skills/task-spec"
 	],
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/project/skills/task-spec/SKILL.md
+++ b/plugins/project/skills/task-spec/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: task-spec
+description: Interviews the user to turn rough intent into a written task spec before filing an issue, starting code, or doing substantial work. Use when the user asks to create an issue, start implementation, scope a task, capture specs, clarify intent, write acceptance criteria, says "grill me", or has a fuzzy request that needs a concrete brief before action.
+allowed-tools: Read Grep Glob Bash Write Edit AskUserQuestion
+---
+
+# Task Spec
+Turn a loose task idea into a concrete brief that can drive an issue, implementation, review, or delegated work. This skill is intentionally a little demanding: it should surface assumptions, force tradeoffs into the open, and write down what "done" means before work begins.
+
+## Decision tree
+- What is the user trying to start?
+  - **Whole-system requirements or architecture intake** -> hand off to `requirements`; this skill is for bounded tasks, issues, and implementation briefs.
+  - **Linear or GitHub issue creation** -> run "Spec intake", then write ticket-ready issue text. Use the relevant issue-creation workflow only after the brief is coherent.
+  - **Code implementation** -> inspect the repo, run "Spec intake" for missing intent, then use the brief as the implementation plan. If open questions are non-blocking, record assumptions and continue.
+  - **General task, process, research, or delegation** -> run "Spec intake", then produce a task brief with owner-ready next actions.
+  - **Tiny low-risk change** (typo, obvious config tweak, simple command) -> do the task directly; do not slow the user down with ceremony.
+  - **User says to "just do it" but the scope is unclear or risky** -> run the lightweight intake first and explain which unknowns block useful work.
+
+## Spec intake
+
+### 1. Read available context
+Before asking questions, inspect what is already available:
+
+- Existing issue, PR, Linear ticket, chat history, README, `.context/`, product docs, or nearby code.
+- Repo signals: current branch, dirty state, relevant modules, tests, conventions, and recent commits when they matter.
+- Prior decisions or user preferences already captured in skills, AGENTS.md, CLAUDE.md, or project context.
+
+Do not ask the user to repeat facts that can be read from the workspace or linked context. Start by stating the knowns and the assumptions you are carrying forward.
+
+### 2. Classify the task
+Choose the smallest useful spec shape:
+
+|Task shape|Use when|Output|
+|---|---|---|
+|Issue brief|The next action is filing or refining a ticket|Ticket-ready title, body, acceptance criteria, labels/metadata if known|
+|Implementation brief|The next action is coding|Goal, constraints, implementation notes, acceptance criteria, verification plan|
+|Decision brief|The next action is choosing between options|Decision to make, options, criteria, risks, recommendation request|
+|Research brief|The next action is investigation|Question, sources/context, expected evidence, output format|
+|Delegation brief|Another agent or person will do the work|Task, boundaries, handoff context, done state|
+
+If the shape is uncertain, ask one routing question first instead of launching the full interview.
+
+### 3. Interview hard, but keep it useful
+Ask in batches of 3-5 questions. Use `AskUserQuestion` when available; otherwise ask directly in chat. Start with the unknowns most likely to change scope or invalidate the work.
+
+Cover these areas, skipping anything already known:
+
+1. **Outcome** -> What should be true when this is done? Who benefits? Why now?
+2. **Scope** -> What is in, what is out, and what should stay untouched?
+3. **Current context** -> What exists today? What prompted the task? What examples, screenshots, logs, links, or prior attempts matter?
+4. **Constraints** -> Stack, product rules, compatibility, budget, timing, legal/compliance, team/process, or dependency limits.
+5. **Acceptance criteria** -> Observable checks, user-visible behavior, edge cases, and failure cases.
+6. **Verification** -> Tests, manual checks, review steps, telemetry, rollout, or "good enough" evidence.
+7. **Traceability** -> Where should the spec live: chat, `.context/tasks/`, Linear, GitHub, PR body, or a handoff note?
+
+Use `references/question-bank.md` when the task spans several areas or the first interview pass feels thin.
+
+### 4. Push on vague language
+When the user uses words like "simple", "fast", "clean", "better", "proper", "flexible", or "production-ready", ask what that means in this case. Convert adjectives into examples, thresholds, or explicit tradeoffs.
+
+Good pressure:
+- "What is the first unacceptable outcome?"
+- "Which part is allowed to be ugly for v1?"
+- "What would make you reject the PR even if it technically works?"
+- "What should this definitely not turn into?"
+
+Do not argue for its own sake. If the user does not know, record an assumption and label it as such.
+
+### 5. Write the brief
+Use `references/task-brief-template.md` as the default structure. Trim sections that do not apply.
+
+The brief should be specific enough that another competent agent could pick it up without re-interviewing the user. Keep it plain:
+
+- Concrete verbs instead of abstract goals.
+- Numbered acceptance criteria.
+- Explicit non-goals.
+- Assumptions and open questions separated from settled decisions.
+- Verification steps that match the project, not generic "run tests".
+
+### 6. Continue or hand off
+After the brief:
+
+- **If the user asked for an issue** -> create or update the issue using the relevant Linear/GitHub workflow, preserving the brief structure.
+- **If the user asked for code** -> implement from the brief unless a blocking question remains.
+- **If the user asked for planning only** -> stop at the brief and call out the next concrete action.
+- **If the task belongs to another skill** -> pass the brief forward so the next skill has the user's intent without another intake loop.
+
+## Output rules
+- Prefer a useful brief over a long questionnaire. Ask only questions whose answers would change the result.
+- Separate "blocked" from "can assume". A missing nice-to-have detail should not stall the task.
+- Keep the user's voice where it clarifies intent, but write the final brief in operational language.
+- For issues, do not include private/internal context unless the destination is private or the user approved it.
+- For code work, include the validation plan before editing so the implementation has a finish line.
+
+## Key references
+|File|When to read|
+|---|---|
+|`references/question-bank.md`|Need sharper interview prompts for a specific task type|
+|`references/task-brief-template.md`|Need the default output structure for briefs, issues, or implementation plans|

--- a/plugins/project/skills/task-spec/references/question-bank.md
+++ b/plugins/project/skills/task-spec/references/question-bank.md
@@ -1,0 +1,87 @@
+# Question Bank
+Use these as source material, not as a script. Pick the few questions whose answers would most change the brief.
+
+## Universal
+- What should be true after this task that is not true now?
+- What is the smallest version that would still be useful?
+- What is out of scope even if it is nearby?
+- What is the user-visible behavior, if any?
+- What would make you reject the result?
+- What previous attempt, decision, bug, or discussion should shape this?
+- What part is highest risk: correctness, UX, data, security, performance, reliability, migration, or coordination?
+- Is there a hard deadline, external dependency, or sequencing constraint?
+- Where should the final spec or issue live?
+
+## Issue Creation
+- Is this a bug, feature, chore, refactor, research task, or follow-up?
+- Who is the issue for: you, another engineer, design, product, support, or a future agent?
+- What project, initiative, milestone, or parent issue should it connect to?
+- What evidence should be included: logs, screenshots, repro steps, customer examples, links, metrics?
+- What labels, priority, team, or component are already known?
+- What would count as resolved enough to close the issue?
+- Should the issue include implementation guidance, or only describe the problem and acceptance criteria?
+- Is any context sensitive enough to keep out of a public GitHub issue?
+
+## Code Implementation
+- Which files, modules, routes, screens, packages, or APIs are likely in scope?
+- Are there existing patterns the implementation must follow?
+- What should stay backward compatible?
+- What data migrations, feature flags, config changes, or rollout steps might be needed?
+- What tests should prove this works: unit, integration, e2e, snapshot, contract, manual?
+- Are there performance, accessibility, security, privacy, or observability requirements?
+- How should errors, loading states, empty states, or partial failures behave?
+- What is the acceptable blast radius if something goes wrong?
+
+## Bug Fix
+- What is the expected behavior and the actual behavior?
+- Can the issue be reproduced? If yes, what are the exact steps?
+- When did it start? Was there a recent deploy, dependency change, migration, or data import?
+- Is it affecting all users, one segment, one environment, or one account?
+- What logs, stack traces, screenshots, recordings, or IDs identify the failure?
+- What workaround exists today?
+- What regression test should fail before the fix and pass after?
+
+## Product or UX
+- What user job is this supporting?
+- What is the primary action on the screen or flow?
+- What information must be visible before the user can act?
+- What states need design: loading, empty, error, disabled, partial success, permissions, offline?
+- What existing UI should this match?
+- What is the mobile/desktop expectation?
+- What copy or terminology is settled, and what can be rewritten?
+- What should analytics or qualitative feedback tell us after launch?
+
+## Data, API, or Integration
+- What are the source of truth and ownership boundaries?
+- What are the core entities and identifiers?
+- What reads and writes happen most often?
+- What consistency is required? Are stale reads acceptable anywhere?
+- What happens when the dependency is slow, unavailable, or returns partial data?
+- What auth, rate limits, retries, idempotency, or webhook behavior matters?
+- What data must not be logged or exposed?
+- What migration, backfill, or rollback path is needed?
+
+## Refactor or Cleanup
+- What pain is the current shape causing?
+- What behavior must remain identical?
+- What can change publicly: APIs, file paths, exported names, command names, UI, data shape?
+- What code should not be touched because it is risky or owned elsewhere?
+- How will we know the refactor did not change behavior?
+- Is this preparing for a known follow-up? If yes, what does that follow-up need?
+- What is the acceptable amount of churn?
+
+## Research or Investigation
+- What question needs an answer?
+- What decision will the answer unlock?
+- What sources are acceptable: code, logs, docs, web, production data, interviews?
+- What counts as enough evidence?
+- Should the output be a recommendation, options table, risk list, repro, or issue?
+- What assumptions should not be made without proof?
+
+## Delegation
+- Who or what will receive this brief?
+- What context can they assume, and what must be included?
+- What files or ownership areas are off limits?
+- What authority do they have: propose, edit, test, create an issue, open a PR?
+- What should they report back: diff summary, test output, risks, questions, or links?
+- What is the handoff format?

--- a/plugins/project/skills/task-spec/references/task-brief-template.md
+++ b/plugins/project/skills/task-spec/references/task-brief-template.md
@@ -1,0 +1,121 @@
+# Task Brief Template
+Trim sections that do not apply. Keep unresolved details out of the settled requirements.
+
+## Default brief
+```markdown
+# <short task title>
+
+## Context
+- Current state:
+- Trigger:
+- Relevant links/files/issues:
+
+## Goal
+- <what should be true when this is done>
+
+## Non-goals
+- <explicitly out of scope>
+
+## Requirements
+1. <testable requirement>
+2. <testable requirement>
+
+## Acceptance criteria
+1. Given <context>, when <action>, then <observable result>.
+2. <observable check>
+
+## Constraints
+- Technical:
+- Product/design:
+- Process/timing:
+- Security/privacy/compliance:
+
+## Assumptions
+- <assumption that is safe enough to proceed with>
+
+## Open questions
+- [blocking] <question that must be answered before work starts>
+- [non-blocking] <question that can be answered during implementation>
+
+## Verification
+- Automated:
+- Manual:
+- Review/rollout:
+```
+
+## Issue body
+```markdown
+## Problem
+<what is wrong or missing, and why it matters>
+
+## Scope
+<what this issue covers>
+
+## Non-goals
+- <what should not be included>
+
+## Acceptance criteria
+- [ ] <observable outcome>
+- [ ] <observable outcome>
+
+## Context
+<links, examples, screenshots, logs, related issues, prior decisions>
+
+## Implementation notes
+<optional; include only if useful and not overly prescriptive>
+
+## Verification
+<how the assignee should prove this is done>
+```
+
+## Implementation brief
+```markdown
+# Implementation Brief: <task>
+
+## Intent
+<one paragraph: desired outcome and why>
+
+## Scope
+In:
+- <included area>
+
+Out:
+- <excluded area>
+
+## Expected behavior
+1. <behavior>
+2. <behavior>
+
+## Implementation notes
+- <repo-specific guidance, files, patterns, dependencies>
+
+## Risks
+- <risk and mitigation>
+
+## Validation plan
+- <lint/format/typecheck/test/manual check that fits the project>
+
+## Done when
+- <final observable condition>
+```
+
+## Decision brief
+```markdown
+# Decision Brief: <decision>
+
+## Decision needed
+<the choice to make>
+
+## Options
+1. <option>
+2. <option>
+
+## Criteria
+- <criterion and why it matters>
+
+## Known constraints
+- <constraint>
+
+## Evidence needed
+- <what would change the decision>
+```

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -345,8 +345,8 @@ function flag(filePath: string, content: string): Flag[] {
 const glob = new Glob("**/*.md");
 const files: string[] = [];
 for await (const path of glob.scan({ cwd: ROOT, absolute: true })) {
-	// Skip node_modules, .git, build artifacts, and caches
-	if (/node_modules|\.git\/|\/build\/|\/\.cache\//.test(path)) continue;
+	// Skip generated/vendor areas and local-only private agent setup.
+	if (/node_modules|\.git\/|\/build\/|\/\.cache\/|\/local\//.test(path)) continue;
 	files.push(path);
 }
 files.sort();


### PR DESCRIPTION
## Summary

- Add `task-spec`, a project skill for turning rough intent into a written task brief before issues, code work, research, or delegation.
- Add a reusable question bank for issue creation, implementation, bug fixes, UX, integrations, refactors, research, and handoffs.
- Add task brief templates for default briefs, issue bodies, implementation briefs, and decision briefs.

## Validation

- `bun run check`
  - Passed for this change.
  - Existing warnings remain in unrelated skills.

## Notes

- Added the shared Codex skill symlink at `~/.agents/skills/task-spec`.
