### PR TITLE
feat: add project docs plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,6 +42,11 @@
 			"category": "devtools"
 		},
 		{
+			"name": "project-docs",
+			"source": "./plugins/project-docs",
+			"category": "devtools"
+		},
+		{
 			"name": "skill-creation",
 			"source": "./plugins/skill-creation",
 			"category": "devtools"

--- a/plugins/project-docs/.claude-plugin/plugin.json
+++ b/plugins/project-docs/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+	"name": "project-docs",
+	"description": "Project document templates and document-template authoring guidance",
+	"skills": [
+		"./skills/create-doc-template"
+	],
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	}
+}

--- a/plugins/project-docs/README.md
+++ b/plugins/project-docs/README.md
@@ -1,0 +1,81 @@
+# Project docs
+Starter templates for the documents we keep around a product.
+
+## What's in here
+|Template|When to write it|How many|
+|---|---|---|
+|[Documentation placement rules](documents/documentation-placement-rules.md)|When contributors need one rulebook for where planning, repo, and code-level docs belong.|One per app, product area, or repo|
+|[Testing strategy](documents/testing-strategy.md)|When a project needs one shared testing contract across features, packages, services, and releases.|One per app, product area, repo, or long-running project|
+|[Project brief](documents/project-brief.md)|At the start of a project, before commitment. The one-pager that justifies it.|One per project|
+|[Customer profile](documents/customer-profile.md)|Once we have a rough sense of who this is for. A living document that grows as we learn.|One per project|
+|[Research brief](documents/research-brief.md)|When evidence needs its own source trail before a product, dependency, or implementation decision.|One per focused research question|
+|[Platform dependency](documents/platform-dependency.md)|When the product builds on something external — API, OS framework, hardware, vendor.|One per load-bearing dependency|
+|[Feature spec](documents/feature-spec.md)|Before building a feature with real scope.|One per feature|
+|[Technical design](documents/technical-design.md)|After product scope is clear enough to choose implementation shape.|One per feature, system, or infrastructure change that needs engineering review|
+|[Decision record](documents/decision-record.md)|After choosing a product, technical, operational, or process direction that future work may need to understand.|One per important decision|
+|[Release readiness](documents/release-readiness.md)|Before shipping a release, feature, service change, library version, CLI update, or infrastructure change.|One per release or launch decision|
+|[Post-release review](documents/post-release-review.md)|After something ships, stalls, or gets abandoned and the team needs to preserve what happened.|One per release or abandoned effort|
+
+## Project types they cover
+The templates are designed to flex across project shapes — iOS apps, cross-platform Expo apps, backend APIs, open-source libraries, CLIs, almost any coding project. Each section's prompt either applies generically or names how to adapt it for non-UI projects (libraries, APIs). Sections that genuinely don't apply to a given project (UI design on a pure library, telemetry on an offline CLI) should be deleted, not left empty — but only after being honest that nothing fits.
+
+## How they relate
+- **Documentation placement rules** define which surface owns each kind of document: Linear initiative, Linear project, Linear issue, repo `documents/`, or code-level docs.
+- **Testing strategy** defines the project-wide confidence model: test layers, coverage expectations, tools, fixtures, CI, flaky-test handling, and manual checks.
+- **Project brief** frames the project. Summarizes the audience and points at the full customer profile. Names the platform dependencies it commits to.
+- **Customer profile** owns audience truth. The brief and feature specs reference it instead of re-describing personas.
+- **Research brief** owns evidence and source trail. Decisions, dependency docs, briefs, and specs link to it instead of carrying all the research inline.
+- **Platform dependency** owns the truth about an external system. Feature specs that touch the dependency link to it.
+- **Feature spec** builds on the brief's scope and references the customer profile and platform dependency docs it touches. It owns user stories, acceptance criteria, product behavior, and user-visible rollout.
+- **Technical design** builds on the feature spec and testing strategy. It owns implementation structure, state ownership, contracts, failure handling, migration, and the feature-specific testing plan.
+- **Decision record** preserves why a direction was chosen. Link it from the doc or issue whose scope, behavior, dependency, cost, or future options changed.
+- **Release readiness** collects the evidence for a ship/hold decision. It references the project brief, feature specs, dependency risks, testing strategy, and decision records that affect release.
+- **Post-release review** compares what happened against the plan. It should turn useful lessons into follow-up issues or decision records instead of burying them in prose.
+
+The relationship appears in two places:
+
+- `related:` in YAML frontmatter, where automation can validate the referenced files still exist.
+- Template comments near the top of each document, where planners and AI agents can see how to use the chain without adding visible boilerplate to finished docs.
+
+We are not adding a rendered `## Related documents` section by default. Real docs should link to related docs where the reference helps the reader: the brief's audience section can link to the customer profile, feature specs can link to the parent brief and relevant platform dependencies, and release docs can link to the feature specs they cover. The validator checks that these references resolve; it does not enforce relationship types or a minimum set of required related docs.
+
+## Planner guide
+Use the templates as a chain, not as independent forms:
+
+1. Start with **documentation placement rules** when a repo or app has more than one possible documentation surface. It prevents early drafts from becoming accidental sources of truth.
+2. Add a **testing strategy** when the project needs a shared testing contract before individual features start inventing their own layers or tools.
+3. Write the **project brief**. It defines why the project exists, the scope boundary, success criteria, and the assumptions that matter.
+4. Use the **customer profile** for audience detail. Briefs and feature specs should point to it instead of re-creating personas, market notes, or acquisition assumptions.
+5. Create **platform dependency** docs for external systems that shape what can be built. Link them from the brief when the project commits to them and from feature specs when a feature relies on them.
+6. Write **feature specs** against the brief, customer profile, and dependencies. A feature spec should explain feature behavior, not restate the project thesis or audience model.
+7. Use research briefs and decision records when evidence or choices need their own trail, then link them from the doc whose claims depend on them.
+8. Use release readiness before shipping and post-release review afterward. These compare shipped reality against the brief, feature specs, testing strategy, dependency risks, and decisions.
+
+The frontmatter `related:` list is for automation and planning context. Inline markdown links are for readers.
+
+## Conventions
+- **Sentence case** for all headings. "Why it should exist", not "Why It Should Exist".
+- **YAML frontmatter** at the top of each doc: `title`, `status`, `owner`, `last_updated`, `related`.
+- **Avoid generic Scope openers.** If the document needs a short orientation, put it directly under the H1. Keep a numbered Summary only when summary is the first real section.
+- **HTML comments** carry section prompts and planning guidance. Delete prompt comments as you fill the section in, or leave them while drafting.
+- **`---` between every H2.** Not before the first, not after the last.
+- **Mermaid diagrams** are encouraged when they make a flow, state machine, sequence, component boundary, or rollout easier to review. Prefer a small useful diagram over a paragraph that names every box in prose.
+- **Markdown tables** are encouraged for acceptance criteria, state lists, schema fields, endpoint contracts, rollout phases, dependency limits, risks, and alternatives. Tables make docs easier to scan and reference in review comments.
+- **Markdown** is formatted with Prettier (`proseWrap: never`) and linted with markdownlint-cli2. Run `bun run check` before committing; `bun run fix` to auto-fix.
+
+## Creating a new template
+Agents should use the plugin skill at [skills/create-doc-template/SKILL.md](skills/create-doc-template/SKILL.md). It captures the workflow for researching the document type, trimming the outline, matching the templates already in `documents/`, and writing section prompts that are useful to both humans and LLMs.
+
+## Status values
+- **Active** — maintained template or current rulebook.
+- **Draft** — actively being written, expect changes.
+- **In review** — content has settled, gathering feedback.
+- **Approved** — current source of truth.
+- **Archived** — superseded; kept for history.
+
+## Using a template
+1. Copy the file out of `documents/` into the destination repo or doc store.
+2. Fill in the frontmatter.
+3. Walk the sections top to bottom. Delete a section if it's genuinely not relevant; don't leave it empty.
+4. Replace each `<!-- Prompt: ... -->` comment with the content it asks for. The prompts are guidance, not section descriptions — they shouldn't survive into the final doc.
+5. When a section describes a flow, decision, matrix, or contract, consider whether a Mermaid diagram or Markdown table would be clearer than prose.

--- a/plugins/project-docs/documents/customer-profile.md
+++ b/plugins/project-docs/documents/customer-profile.md
@@ -1,0 +1,89 @@
+---
+title: Customer profile & market
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - project-brief.md
+  - feature-spec.md
+---
+
+# Customer profile & market
+<!-- Prompt: This is a living document. Update it as the audience picture sharpens. We are a "the customer doesn't know what they want" company — we trust observed pain over stated solution-asks. The doc captures who we believe this is for, the signals that back that belief, and the assumptions that could turn out to be wrong. -->
+
+<!-- Relationship guide for planners/AI: This document owns audience truth. The project brief may summarize the audience and feature specs may name the user, but personas, market shape, alternatives, willingness to pay, acquisition, and audience assumptions should live here. -->
+
+## 1. Who is this for?
+
+### 1.1. The audience
+<!-- Prompt: Plain-language description of the group as a whole. The shared situation, mindset, or stage that makes someone a candidate at all. One short paragraph. If a person doesn't fit this description, they're not in any of the personas below and the product probably isn't for them. -->
+
+#### Shared markers
+<!-- Prompt: Verifiable traits every member of the audience shares. Things you could point at and confirm, not adjectives. Three to six items as a bulleted list. Examples vary by audience: for consumers — platform owned, hardware in daily use, profession, life stage, spoken language, paid tier of an adjacent service. For developers — programming language they ship in, framework or runtime they target, stage of their company, the kind of repo they maintain. Pick markers you could verify, not ones you'd have to ask about. -->
+
+- Marker 1
+- Marker 2
+- Marker 3
+
+### 1.2. User personas
+<!-- Prompt: One to three user personas. Each persona gets a clear name and a one-line identity, followed by a Markdown table with two columns: Characteristic and Description. Include rows for Situation, Goal, Constraints, Product fit, Tells, and Acquisition.
+
+Use the characteristics this way:
+- Situation: The setting they live or work in. What a typical day or session looks like, only the parts that matter to this product.
+- Goal: What they're trying to accomplish in the moments where this product would show up. Not abstract life goals, the concrete thing.
+- Constraints: What limits them. Time, money, attention, hardware, skill, permissions, other people.
+- Product fit: What about the product fits them better than what they do today. Honest, not a sales pitch.
+- Tells: Observable signals that someone is this persona. A job title, a behavior, a tool they already use, a phrase they'd use to describe their problem.
+- Acquisition: Where this specific persona would first encounter the product. A channel, a community, a search query, a referrer, an adjacent product. Different personas often need different paths in. -->
+
+#### 1.2.1. {Persona name}
+<!-- Prompt: First persona. One-line identity, then the characteristics table. -->
+
+#### 1.2.2. {Persona name}
+<!-- Prompt: Second persona (optional). -->
+
+#### 1.2.3. {Persona name}
+<!-- Prompt: Third persona (optional). -->
+
+### 1.3. Anti-audience
+<!-- Prompt: People the product is explicitly not for. Not a list of everyone outside the personas, only the audiences the product could plausibly attract and shouldn't. For each, a short reason. The job is to make scope decisions easier when someone shows up wanting a feature that belongs to a different product. -->
+
+### 1.4. Pain signals
+<!-- Prompt: Evidence the underlying pain exists, not validation that anyone has asked for this specific solution. The audience often can't articulate the solution — that's our job. What to capture: complaints in forums, workarounds people build, abandoned workflows, paid alternatives that almost fit, search queries with rising volume, recurring support tickets in adjacent products, quotes from interviews. Cite where seen. Distinguish what we observed from what we inferred. -->
+
+---
+
+## 2. Addressable market
+
+### 2.1. Reachable population
+<!-- Prompt: How large the audience plausibly is and what bounds it. Hardware ownership, platform, geography, language, profession, life stage, paid tier of an adjacent service. Cite numbers where they exist; mark estimates as estimates. A precise "small but real" beats a vague "huge market." Layer the filters: total candidates, those with the right context, those with the right intent. -->
+
+### 2.2. Where they already are
+<!-- Prompt: The communities, platforms, content, search queries, stores, app categories, and physical spaces this audience lives in. Not a marketing plan, a map. Where they discover tools today, who they trust, what they already pay attention to. -->
+
+### 2.3. How the audience grows or shrinks
+<!-- Prompt: The conditions that change the size of the addressable population over time. Hardware refresh cycles, platform shifts, regulation, generational change, the success of an adjacent product. Two or three real forces, not a SWOT. -->
+
+---
+
+## 3. Alternatives and value
+
+### 3.1. What they currently use
+<!-- Prompt: The alternatives the audience reaches for today, including doing nothing. For each: what it does well, what it does badly, what it costs in money, time, or friction, and whether switching has a cost beyond price. Frame competitors as the audience sees them, not as the industry classifies them. -->
+
+### 3.2. Willingness to pay
+<!-- Prompt: What this audience already pays for adjacent things, in what shape (one-time, subscription, included with a platform, free with ads), and what that implies for this product. Observe what's already happening in their wallet rather than guess at a price. -->
+
+---
+
+## 4. Assumption risks
+<!-- Prompt: The audience-level bets that could turn out wrong, and how we'd find out. List them explicitly so revisions to this doc have something to push against. For each:
+- **Assumption** — the belief in one line.
+- **What it would mean if wrong** — which personas, market sizing, or scope decisions collapse.
+- **How we'd notice** — the signal that would prompt us to revisit. An interview pattern, a metric, a failed channel.
+Common shapes: "we believe persona X exists at scale," "we believe they'd switch from Y," "we believe they'd pay for this shape of thing," "we believe channel Z reaches them." -->
+
+---
+
+## 5. Open questions
+<!-- Prompt: Audience-level and market-level questions that are still unresolved and affect product or scope decisions. Excludes anything covered by the project brief or feature specs. -->

--- a/plugins/project-docs/documents/decision-record.md
+++ b/plugins/project-docs/documents/decision-record.md
@@ -1,0 +1,48 @@
+---
+title: Decision record
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - research-brief.md
+  - project-brief.md
+  - feature-spec.md
+---
+
+# Decision record
+<!-- Prompt: Use this for important product, technical, operational, or process decisions after a direction is chosen. Keep it short enough to write while the reasoning is still fresh. The point is to preserve why the decision was made, not to restage the debate. -->
+
+<!-- Relationship guide for planners/AI: Use this when a choice changes scope, behavior, constraints, cost, or future options. Link research briefs for evidence and link this record from the project brief or feature spec whose direction it changes. -->
+
+## 1. Decision
+<!-- Prompt: State the decision in one or two sentences. Use plain language. A reader should understand what is now true without reading the rest of the document first. -->
+
+---
+
+## 2. Context
+<!-- Prompt: The situation that forced the decision. Include the product, technical, customer, operational, cost, timing, or dependency facts that mattered. Link to the issue, research brief, feature spec, technical design, platform dependency, prototype, or discussion that provides detail. -->
+
+---
+
+## 3. Options considered
+<!-- Prompt: The real options, including doing nothing when that was plausible. For each option, describe the shape of the choice and the strongest reason someone might pick it. Do not include straw options just to make the chosen path look obvious. -->
+
+---
+
+## 4. Chosen option
+<!-- Prompt: Why this option won. Name the constraints or evidence that mattered most, the trade-off we accept, and any condition that made this decision right now rather than universally right forever. -->
+
+---
+
+## 5. Trade-offs
+<!-- Prompt: What this choice makes easier and what it makes harder. Include costs, maintenance burden, user impact, lock-in, migration work, scope we are leaving behind, and risks we are accepting. If the decision creates a constraint for future projects, say so explicitly. -->
+
+---
+
+## 6. Follow-up work
+<!-- Prompt: Concrete work created by the decision. Link issues where they exist. If a follow-up is intentionally not filed, state why. Keep this to work needed to make the decision real, not every idea that came up during discussion. -->
+
+---
+
+## 7. Review trigger
+<!-- Prompt: The signal that should cause us to revisit the decision: a date, usage threshold, cost threshold, platform change, incident, customer pattern, better alternative, or missing assumption becoming clear. If there is no expected review, say what would still invalidate the decision. -->

--- a/plugins/project-docs/documents/documentation-placement-rules.md
+++ b/plugins/project-docs/documents/documentation-placement-rules.md
@@ -1,0 +1,121 @@
+---
+title: Documentation placement rules
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-15
+related:
+  - project-brief.md
+  - customer-profile.md
+  - testing-strategy.md
+  - research-brief.md
+  - platform-dependency.md
+  - feature-spec.md
+  - technical-design.md
+  - decision-record.md
+  - release-readiness.md
+  - post-release-review.md
+---
+
+# Documentation placement rules
+<!-- Prompt: Use this once per app, product area, or repo when contributors need a stable rulebook for where planning and reference docs live. The goal is to remove guessing. Keep the rules concrete enough that a new contributor can place a document without asking where it belongs. -->
+
+<!-- Relationship guide for planners/AI: This is a meta-template. It does not replace the project brief, customer profile, testing strategy, feature spec, technical design, research brief, decision record, release readiness, or post-release review. It tells people where those docs should live and why. Link the filled version from the app initiative, the repo README, and any project kickoff issue. -->
+
+## 1. Summary
+<!-- Prompt: In one short paragraph, define the app, product area, repo, or team this placement rulebook covers. Name the default planning surface and the default versioned-doc surface. If the rulebook only applies during a certain phase, say that here. -->
+
+Use these rules to decide where a document belongs before writing it. The rule is not "put docs wherever the first draft started." The rule is: pick the surface that matches the document's lifespan, audience, review path, and need to change with code.
+
+---
+
+## 2. Surfaces in use
+<!-- Prompt: Delete surfaces this app or repo does not use. Add any extra surfaces that are real sources of truth, such as support knowledge bases, design files, dashboards, or package registries. Keep only surfaces someone is expected to maintain. -->
+
+|Surface|Level|Use it for|Why this surface exists|
+|---|---|---|---|
+|Linear initiatives|Initiative|App-level or product-line direction that spans more than one project.|Initiative docs keep long-running direction next to the work it funds and sequences.|
+|Linear projects|Project|Project briefs, milestone plans, launch state, and project-level decisions.|Project docs stay visible to planning, status, and ownership discussions.|
+|Linear issues|Issue|Task-specific investigation notes, clarifications, and acceptance details for one piece of work.|Issue context should travel with the work item and close with it.|
+|Linear documents|Initiative, project, or issue|Narrative planning docs that need comments, lightweight edits, or broad planning visibility.|Linear is the collaboration layer for planning and review before code changes exist.|
+|Repo `documents/` folder|Repo|Versioned templates, technical designs, decision records, dependency docs, and product docs that should change with code.|Repo docs get branch history, PR review, and code-adjacent ownership.|
+|Code-level docs|Module, package, API, or command|READMEs, doc comments, inline notes, generated reference, and examples tied to implementation.|Code-level docs should change in the same diff as the behavior they explain.|
+
+---
+
+## 3. Document placement rules
+<!-- Prompt: This table is the contract. Add or remove rows until it covers the document types contributors actually create. Each row must answer "if this kind of doc, then that surface" and include the reason, so the rule survives turnover. -->
+
+|If the document is...|Primary home|Level|Link it from|Reason|
+|---|---|---|---|---|
+|Initiative charter, app strategy, or product-line thesis|Linear initiative document|Initiative|Project briefs and project kickoff issues|The audience is broader than one project, and the document should move with initiative planning.|
+|Project brief or project-level scope|Linear project document by default; repo `documents/project-brief.md` when the repo needs a versioned copy|Project or repo|Initiative, feature specs, and kickoff issues|Planning needs visibility in Linear, but code-coupled scope needs review history with the repo.|
+|Customer profile, market notes, or audience assumptions|Linear project or initiative document; repo `documents/customer-profile.md` only when the repo owns the product truth|Project, initiative, or repo|Project brief and feature specs|Audience truth changes as planning learns; only version it with code when the product repo is the canonical owner.|
+|Testing strategy|Repo `documents/testing-strategy.md` when testing choices should change with code; Linear project or initiative document when the strategy is a planning commitment across repos|Repo, project, or initiative|Technical designs, release readiness, and PR descriptions when testing expectations affect review|The project needs one confidence model so feature-level plans can point to it instead of re-arguing layers, tools, fixtures, and CI gates.|
+|Research brief or evidence trail|Linear project or initiative document; repo `documents/research-brief.md` when the evidence supports a code or product contract|Project, initiative, or repo|Decision records, feature specs, and dependency docs|Research should be near the decision it informs, with enough source trail for review.|
+|Platform dependency analysis|Repo `documents/platform-dependency.md` when the dependency shapes implementation; Linear initiative or project document when it is a strategic vendor choice|Repo, initiative, or project|Project brief, feature specs, release readiness|Dependency risk often affects both planning and code; place it where the lasting owner will notice changes.|
+|Feature spec or acceptance criteria|Linear project document for broad product review; Linear issue for small scoped work; repo `documents/feature-spec.md` when behavior should be versioned with code|Project, issue, or repo|Implementation issues, technical design, and release readiness|Product behavior needs stakeholder review first; durable behavior should also live where code reviewers can maintain it.|
+|Technical design or architecture plan|Repo `documents/technical-design.md` once it affects implementation; Linear project document while options are still being shaped|Repo or project|Feature spec, PR description, decision records|Engineering choices need PR review and code history when they become build commitments.|
+|Decision record|Repo `documents/decision-record.md` for product, technical, dependency, or process decisions that create precedent; Linear issue or project comment for local task decisions|Repo, project, or issue|The affected docs, PR, and follow-up issues|Decisions are only useful later if they sit where future reviewers will look for the reason.|
+|Release readiness|Linear project document by default; repo `documents/release-readiness.md` when release evidence is tied to a versioned artifact|Project or repo|Release issue, PR, changelog, and post-release review|Launch state belongs with project coordination; shipped contracts may need repo history.|
+|Post-release review|Linear project document by default; repo `documents/post-release-review.md` when lessons should travel with the codebase|Project or repo|Initiative, project, decision records, and follow-up issues|Retrospectives should feed planning, but codebase-specific lessons should be easy to find from the repo.|
+|Runbook, support handoff, or operator procedure|Repo docs or code-level docs when tied to implementation; Linear project document for temporary launch handoff|Repo, module, or project|Release readiness and owner handoff issue|Operational docs age badly when separated from the thing they operate.|
+|README, API reference, examples, or doc comments|Code-level docs|Repo, package, module, API, or command|Technical design when extra context is needed|Reader-facing implementation docs should be reviewed in the same change as the interface.|
+|Temporary investigation notes|Linear issue comment, then promote the durable facts to the right doc|Issue|Final doc or decision record|Scratch work should not become a second source of truth.|
+
+---
+
+## 4. Ownership and review expectations
+<!-- Prompt: Fill this table with names, roles, or teams. "Everyone" is not an owner. If the owner changes by surface, keep the rule explicit. -->
+
+|Surface|Owner|Review before changing|Keep current by|
+|---|---|---|---|
+|Linear initiative documents|Initiative owner|Initiative stakeholders and project owners|Reviewing at initiative kickoff, major scope changes, and initiative closeout.|
+|Linear project documents|Project owner|People accountable for scope, delivery, and launch|Updating when project scope, dates, risks, or release state change.|
+|Linear issue comments and issue-linked docs|Issue assignee|Reviewer for the issue or PR when the note affects acceptance|Summarizing durable findings into the parent doc before closing the issue.|
+|Repo `documents/` folder|Repo owner or area owner|Code owners or the people accountable for the product contract|Requiring PR review and updating related frontmatter when links change.|
+|Code-level docs|Module, package, or API owner|Same reviewers as the code path|Changing docs in the same PR as the behavior or interface.|
+
+---
+
+## 5. Cross-linking conventions
+<!-- Prompt: Keep these conventions specific to the surfaces you use. The test is whether someone can move from a Linear issue to the canonical doc, then from the doc to the relevant code or PR, without guessing. -->
+
+- Link the canonical document, not a copied summary. If a short summary is needed in another place, include one or two lines and point back to the source.
+- Linear initiatives link to the project documents and repo docs that carry durable scope, dependency, or decision context.
+- Linear projects link to the initiative, the repo, release docs, and open issues that need document updates.
+- Linear issues link to the smallest document that sets the boundary for the work. Avoid linking the whole document chain unless each link changes the task.
+- Repo docs use `related:` frontmatter for repo-local Markdown files that automation can validate.
+- Repo docs use inline Markdown links when the reader needs to open a related doc at that point in the text.
+- PR descriptions link the Linear issue and any repo docs changed or used as acceptance context.
+- Decision records link the research, project, feature, dependency, issue, or PR that forced the decision.
+
+---
+
+## 6. What does not belong anywhere
+<!-- Prompt: Add local exclusions. For each one, say what to do instead so people do not create unofficial hiding places. -->
+
+|Content|Do this instead|Reason|
+|---|---|---|
+|Secrets, credentials, tokens, private keys, or recovery codes|Store them in the approved secret manager and link only to the access process.|Docs are copied, indexed, exported, and reviewed by more people than secrets should reach.|
+|Raw personal data, unredacted customer material, or interview transcripts|Put the raw material in the approved research or support system; document only the sanitized finding and source location.|Planning docs need evidence, not unnecessary exposure of private data.|
+|Duplicated copies of a canonical doc|Replace the copy with a link and a short local note if context is needed.|Duplicate docs drift and make reviewers check the wrong source.|
+|Unverified claims, guesses, or uncited market numbers|Mark them as assumptions or move them into a research brief with sources.|Readers need to know which statements are evidence and which are bets.|
+|"Maybe later" feature ideas with no owner or trigger|File a Linear suggestion issue or delete the note.|Backlog-shaped notes need triage, ownership, and a reason to revisit.|
+|Old decisions with no current owner and no review trigger|Archive them or replace them with a decision record that names the current rule.|A stale decision without a trigger is worse than no decision because it looks authoritative.|
+
+---
+
+## 7. Review trigger for these rules
+<!-- Prompt: Name the signals that force this rulebook to change. Include both scheduled review and event-based review. -->
+
+Review these placement rules when any of the following happens:
+
+- A new documentation surface becomes a real source of truth.
+- Contributors ask more than once where a recurring document type belongs.
+- A project review finds that work was delayed because docs were split, duplicated, or hidden.
+- A document type appears that does not fit the table in section 3.
+- A repo starts or stops owning product truth for an app, package, API, or operational process.
+- An initiative or project closes and the team has to decide what stays durable.
+- Ownership changes for the initiative, project, repo, or module.
+
+At minimum, review this rulebook during initiative kickoff and after the first release that used it.

--- a/plugins/project-docs/documents/feature-spec.md
+++ b/plugins/project-docs/documents/feature-spec.md
@@ -1,0 +1,110 @@
+---
+title: Feature spec
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - project-brief.md
+  - customer-profile.md
+  - platform-dependency.md
+  - release-readiness.md
+---
+
+# Feature spec
+<!-- Prompt: Open with one short paragraph describing the feature this doc defines, what it deliberately leaves to other docs, and links to the relevant project brief, customer profile, or platform dependency. This template is designed to flex across project types — iOS or Expo apps, backend APIs, open-source libraries, CLIs. Skip sections that genuinely don't apply (UI design on a library, telemetry on an offline CLI) but only after being honest that nothing fits. The remaining structure should hold for anything we ship. -->
+
+<!-- Relationship guide for planners/AI: This document should be written against the parent project brief, customer profile, and any platform dependency it touches. Define feature behavior here; do not restate the project thesis, personas, or dependency contracts except where a short link-backed summary helps the reader. -->
+
+## 1. User stories & acceptance criteria
+<!-- Prompt: One or more user stories framing the feature from the perspective of who uses it. The "user" depends on the project: end user for an app, developer integrating for a library, client for an API, operator for a tool. Format: "As a {who}, I want to {what} so that {why}."
+
+For each story, list acceptance criteria as observable conditions that mean "done." Use a Markdown table when there are several criteria, variants, roles, or states to compare. Criteria should be testable: "the response includes a `version` field" beats "the response is well-formed."
+
+Keep stories small enough that the criteria fit on one screen. If a story sprawls, split it. -->
+
+---
+
+## 2. Design
+<!-- Prompt: For features with UI: link to or embed the design source of truth (Figma frame, screenshot, design doc). Include enough that a reader can picture the feature without opening anything else, but the linked source stays canonical. Add screenshots, wireframes, state tables, or Mermaid flow diagrams when they make the intended experience easier to review. Note any states the design covers (empty, loading, error, success) and which are still missing.
+
+For features without UI (libraries, APIs, CLIs): delete this section. The Model and Behavior sections already carry the shape. If you find yourself wanting code samples or request/response examples here, put them in section 3 (Model) instead. -->
+
+---
+
+## 3. Model
+<!-- Prompt: The product-level concepts the feature exposes: domain objects, user-facing states, key signals, categories, and externally visible request or response shapes. Keep storage layout, ownership, migrations, and internal runtime state in the technical design.
+
+If the feature transforms raw inputs into a normalized form, describe the transform and what comes out. Use a Markdown table for fields, states, buckets, or categories when readers will need to reference individual rows.
+
+If there are discrete states, buckets, or categories layered on top of a continuous value, list them with what each means. Note which boundaries are tunable and which are fixed. Defaults should come from somewhere real (testing, remote config), not magic numbers.
+
+For APIs and libraries, this is where public request/response shapes, type signatures, and example payloads live. Internal DTOs, database rows, queues, and function boundaries belong in the technical design. -->
+
+---
+
+## 4. Lifecycle
+<!-- Prompt: The product lifecycle: states the user, integrator, client, or operator can observe, and what triggers each transition. Explicit user actions vs automatic transitions. What starts it, what ends it, what pauses it. Use a Mermaid state diagram for more than a few transitions. Internal job, cache, retry, or persistence lifecycles belong in the technical design. -->
+
+---
+
+## 5. Behavior
+
+### 5.1. Decision logic
+<!-- Prompt: The product decision layer: when the feature should act from the user's point of view. Inputs (signals, configuration, user preferences), tunables (thresholds, durations, cool-downs), and the discipline: what the feature deliberately avoids. Most decision layers fail in one of two directions. Name both. Use a decision table when rules have multiple inputs or outcomes. Implementation algorithms and code structure belong in the technical design. -->
+
+### 5.2. Outputs
+<!-- Prompt: The user-visible channels through which the feature acts on the world. How they combine when more than one is active: stack, or deduplicate. User-facing controls for which channels are on. API responses, notifications, exports, UI state changes, CLI output, and files created by the feature all count. Internal events and queues belong in the technical design unless they are part of the public contract. -->
+
+---
+
+## 6. Persistence
+<!-- Prompt: What the feature needs to remember from the user's point of view: saved preferences, draft work, history, generated artifacts, exported files, or records that later surface back to the user. Say what is retained and why; leave table names, indexes, migrations, and cache shape to the technical design. For libraries or pure compute features that don't persist, say so plainly and delete the rest. -->
+
+---
+
+## 7. Performance budget
+<!-- Prompt: The targets this feature must hit. Keep it short. Pick the axes that matter for this project type:
+- **Latency** — p50 / p95 for API endpoints, frame time for UI features, cold-start time for apps.
+- **Memory** — peak working set, leak ceiling.
+- **Battery / CPU** — for mobile and always-on features.
+- **Binary / bundle size** — for libraries and client apps.
+- **Throughput** — for APIs and pipelines.
+Give a number for each, even if it's a guess marked as a guess. A budget without a number is a wish. -->
+
+---
+
+## 8. Telemetry
+<!-- Prompt: What this feature emits so we can tell whether it's working. Hard rules:
+- **Anonymous only.** No PII, no user identifiers, no anything that ties an event to a person.
+- **No external systems.** No third-party analytics, no SaaS observability services. Destinations are our own logs, our own metrics, our own storage — or nothing.
+
+For each event:
+- **Name** — stable, snake_case, the kind of thing you'd grep for.
+- **When it fires** — the condition or state transition.
+- **Payload** — fields and their types. Verify nothing in the payload could de-anonymize.
+- **Where it lands** — log stream, in-process counter, local file, persistent metric.
+
+If this feature has no measurable behavior worth tracking, write "No telemetry by design" and one line of why. That's a valid answer for OSS libraries and pure-compute features. -->
+
+---
+
+## 9. Edge cases
+<!-- Prompt: Product edge cases and user-visible failure behavior. Prefer specific scenarios ("device disconnects mid-session") over abstract categories ("network errors"). Include OS-level conditions that can silently break the feature: permissions denied, background limits, hardware unavailable. For APIs and libraries, include public bad-input behavior: malformed payload, exhausted iterator, unsupported option. Use a table with columns like Scenario, Expected behavior, User-visible message, and Follow-up. Internal partial writes, retries, races, and operator mistakes belong in the technical design. -->
+
+---
+
+## 10. Rollout
+<!-- Prompt: How this feature reaches users or adopters. Keep this focused on exposure, eligibility, communication, and product rollback. Deployment order, schema migrations, compatibility mechanics, and cleanup belong in the technical design.
+
+The shape varies by project type — pick the path that fits:
+- **App (iOS / Expo)** — internal build → TestFlight or internal beta → staged store rollout. Note minimum OS version, App Store review risks, forced-update behavior.
+- **Backend / API** — feature flag → canary or single-region → full deploy. Note schema migrations, backwards compatibility, deprecation window for old behavior.
+- **Library / SDK** — semver bump → release notes → optional pre-release tag. Note breaking-change handling and migration guide if any.
+- **CLI / tool** — version bump → changelog → distribution channel update (Homebrew, npm, cargo, etc.).
+
+Use a Markdown table for phases when there is more than one. For each phase: who sees it, how we'd know to roll back, and what the kill switch is. If there's no kill switch, say so honestly. -->
+
+---
+
+## 11. Non-goals
+<!-- Prompt: What this feature explicitly does not do. The lines it refuses to cross. Be opinionated. Vague non-goals are worse than none. -->

--- a/plugins/project-docs/documents/platform-dependency.md
+++ b/plugins/project-docs/documents/platform-dependency.md
@@ -1,0 +1,118 @@
+---
+title: Platform dependency
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - project-brief.md
+  - feature-spec.md
+  - release-readiness.md
+---
+
+# Platform dependency
+<!-- Prompt: Open with one short paragraph defining the external thing the product builds on, the part of it that matters here, and what lives elsewhere with links. Resist the urge to recap the whole product. -->
+
+<!-- Relationship guide for planners/AI: This document owns the truth about one external system. Link it from the project brief when the project commits to the dependency, from feature specs when behavior depends on it, and from release readiness when dependency risk affects shipping. -->
+
+## 1. The dependency
+<!-- Prompt: Describe what the dependency is, who owns it, and how the product relates to it. If there was a real choice, name the alternatives that were rejected and the trade-off each represented. If there wasn't a choice (the OS is the OS, the protocol is the protocol), say so plainly. Close with what the commitment locks in: audience, platforms, capabilities now available, capabilities now off the table. -->
+
+---
+
+## 2. Capabilities
+<!-- Prompt: List what the dependency offers that the product can act on. Be concrete: named features, endpoints, surfaces, data types, behaviors. Organize by relevance to our use, not by the structure of the vendor's docs. -->
+
+---
+
+## 3. Limits
+<!-- Prompt: Describe what the dependency does not do, does badly, or refuses to do. Cover three flavors, worth keeping straight even when they sit in one section:
+1. **Hard ceilings** — rate caps, regional gaps, missing features.
+2. **Soft degradation** — behavior under load, partial availability.
+3. **Absences** — the capability that simply isn't there.
+An absence shapes the design as much as a feature. -->
+
+---
+
+## 4. Interface
+<!-- Prompt: How the product talks to the dependency. The subsections below are framed to work whether this is an API, an OS framework, a hardware peripheral, a protocol, or a vendor SDK. Skip any subsection that genuinely doesn't apply, but be honest before you skip — most dependencies have an analog. -->
+
+### 4.1. Access
+<!-- Prompt: How we earn the right to talk to it. Authentication, authorization, capability grants, pairing, permissions, entitlements, identity. Include the failure modes of access itself: revoked tokens, denied permissions, unpaired devices, expired certificates. -->
+
+### 4.2. Exchange
+<!-- Prompt: The unit of communication and what flows across it. Request/response shapes for APIs; events, signals, and characteristics for hardware; messages for protocols; calls and callbacks for OS frameworks. Include data formats, encoding, payload size limits, and which direction the initiative flows in (we poll vs it pushes). -->
+
+### 4.3. Lifecycle
+<!-- Prompt: How a session, connection, or interaction opens, runs, and closes. State transitions, reconnection behavior, idle timeouts, backpressure, ordering guarantees, retry semantics. Where the contract is enforced strictly and where it's loose. -->
+
+---
+
+## 5. Variants and versions
+<!-- Prompt: The matrix of what's confirmed to work: products, plans, regions, OS versions, hardware generations, API versions. One line if the dependency is monolithic. A table if the surface is fragmented. Pre-empt the "what about X" questions with a row that names X.
+
+Sample structure:
+
+|Variant|Status|Notes|
+|---|---|---|
+|iOS 17+ on iPhone 14 Pro+|Confirmed|Tested on device, all capabilities present|
+|iOS 16|Partial|Capability X missing; falls back to Y|
+|iPadOS|Unsupported|Out of scope for v1|
+| Android | N/A | Different dependency entirely | -->
+
+---
+
+## 6. Behavior in practice
+<!-- Prompt: How the dependency actually behaves in the field, not how the docs describe it. Cover latency, accuracy, contention with other consumers, failure modes, and conditions that silently degrade it. Use concrete numbers where measured. Use honest "to verify on device" or "to confirm in production" markers where not. Separate measured baselines from assumptions. -->
+
+---
+
+## 7. Cost
+<!-- Prompt: What the dependency costs across whatever axes apply: money, user resources (battery, bandwidth, storage, attention), lock-in, complexity. Separate the marginal cost the product adds from the total cost the user or business already pays.
+
+Break monetary cost out by scale tier so the curve is visible:
+
+|Scale|Monthly cost|Notes|
+|---|---|---|
+|1k users|...|Free tier? Per-call?|
+|100k users|...|Tier change, bulk pricing, support upgrades|
+|1M users|...|Negotiated, hits hard caps, separate contract|
+
+Note the inflection points where pricing changes shape, not just amount. -->
+
+---
+
+## 8. Fallback and graceful degradation
+<!-- Prompt: What the product does when the dependency is unavailable, slow, partial, or denied. Map each major failure mode from section 3 (Limits) and section 6 (Behavior in practice) to a response:
+- **Hard failure** (no access, outage, hardware absent) — what the user sees, what still works without it.
+- **Soft failure** (slow, partial, rate-limited) — degraded experience, caching, queueing, retry strategy.
+- **Permission denied / opt-out** — the product's behavior when the user refuses access or revokes it later.
+Where the answer is "the product is broken," say so honestly. That's a real design decision. -->
+
+---
+
+## 9. Monitoring and observability
+<!-- Prompt: How we know when the dependency is misbehaving before users tell us. Cover:
+- **Signals** — what we measure (success rate, latency percentiles, error codes, throttling responses, queue depth).
+- **Where the data goes** — the dashboard, log stream, or telemetry pipeline that holds it.
+- **Thresholds and alerts** — what triggers a page vs a ticket vs a log line.
+- **Blind spots** — what we can't see from our side (vendor-side outages, partial regional failure, silent contract changes).
+Link to the actual dashboards and runbooks once they exist. -->
+
+---
+
+## 10. Risks
+<!-- Prompt: What could shift underneath the product. Deprecations, pricing changes, capability tightening, replacement by a competitor, capabilities we'd want but probably won't get. The job here is to track, not to pre-build. For each risk, note severity (how badly it would hurt) and likelihood (rough guess is fine). -->
+
+---
+
+## 11. Exit strategy
+<!-- Prompt: What it would take to leave this dependency. Not a plan to execute — a forced honesty about lock-in. Cover:
+- **What's portable** — code, data, contracts that would survive a switch.
+- **What's not** — capabilities only this dependency offers, integrations that would need rebuilding, retraining or migration costs to the user.
+- **Plausible replacements** — even if they're worse today, list what we'd reach for. "There is no replacement" is a valid and important answer.
+- **Trigger conditions** — the risk from section 10 that would actually force us to leave. Pricing past $X, deprecation, a specific capability removed, a competitor shipping a viable alternative. -->
+
+---
+
+## 12. References
+<!-- Prompt: Bullet points linking to relevant docs, specs, vendor pages, and internal notes. -->

--- a/plugins/project-docs/documents/post-release-review.md
+++ b/plugins/project-docs/documents/post-release-review.md
@@ -1,0 +1,49 @@
+---
+title: Post-release review
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - release-readiness.md
+  - project-brief.md
+  - feature-spec.md
+  - decision-record.md
+---
+
+# Post-release review
+<!-- Prompt: Use this after a product, feature, service change, library version, CLI update, or infrastructure change has shipped, stalled, or been abandoned. Keep it practical. The goal is to preserve what happened and turn useful lessons into follow-up work. -->
+
+<!-- Relationship guide for planners/AI: Use this after release to compare reality with the project brief, feature specs, release readiness doc, and decision records. File follow-up issues for debt or unresolved questions instead of burying new work in this review. -->
+
+## 1. What happened
+<!-- Prompt: Short factual account of the release or abandoned effort. Include what shipped, when it shipped, who received it, what did not ship, and where the canonical release artifacts live. If the work was stopped, state when and why. -->
+
+---
+
+## 2. What changed from the plan
+<!-- Prompt: Differences between the project brief, feature spec, technical design, release readiness doc, and what actually happened. Include scope changes, schedule changes, technical changes, rollout changes, and decision changes. Link decision records where they exist. -->
+
+---
+
+## 3. What worked
+<!-- Prompt: The parts worth repeating. Include product decisions, implementation choices, review habits, testing, rollout mechanics, collaboration patterns, customer signals, or operational preparation. Tie each item to evidence rather than taste. -->
+
+---
+
+## 4. What did not work
+<!-- Prompt: The parts that cost time, created confusion, failed users, made operations harder, or hid risk. Stay concrete. Name the situation, impact, and signal that showed it was a problem. -->
+
+---
+
+## 5. Decisions worth keeping
+<!-- Prompt: Decisions from the effort that should become precedent. For each, state why it still seems right after release and where future work should copy it. Link the decision record when there is one. -->
+
+---
+
+## 6. Debt created
+<!-- Prompt: Product, design, technical, operational, documentation, support, or process debt created by the release. Include what happens if it is ignored and the rough point where it becomes expensive. File follow-up issues for debt that needs action. -->
+
+---
+
+## 7. Follow-up issues
+<!-- Prompt: Links to issues created from the review. For each, include the reason it exists and whether it is required, optional, or only needed if a later signal appears. If no follow-up issue is needed, say so explicitly. -->

--- a/plugins/project-docs/documents/project-brief.md
+++ b/plugins/project-docs/documents/project-brief.md
@@ -1,0 +1,83 @@
+---
+title: Project brief
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - customer-profile.md
+  - platform-dependency.md
+  - feature-spec.md
+---
+
+# Project brief
+<!-- Relationship guide for planners/AI: This is the project-level anchor. Use customer-profile.md for audience detail, platform-dependency.md for external systems the project commits to, and feature-spec.md for scoped build work. Do not duplicate those docs here; link to them where a section depends on them. -->
+
+## 1. Summary
+<!-- Prompt: Describe the project in one short paragraph. Say what it is, what it is trying to achieve, and the main way it gets there. Give the reader a reason to care, but keep it grounded. -->
+
+---
+
+## 2. Why it should exist
+
+### 2.1. The problem
+<!-- Prompt: Describe the main issue this project addresses. Include who feels the problem, when it shows up, what makes it painful, and why existing ways of handling it are not good enough. -->
+
+### 2.2. The thesis
+<!-- Prompt: Describe how the project solves the problem above. Name the project's core approach, explain the operating principles behind it, and connect those principles to the main project features. -->
+
+### 2.3. Competition
+<!-- Prompt: Compare the project with the most relevant alternatives. Explain where those alternatives work, where they fall short, and what this project does differently or better. Keep this short — the customer profile holds the full picture; link to it. -->
+
+---
+
+## 3. Audience
+<!-- Prompt: One short paragraph summarizing who this is for and why they need it. Name the primary persona and the context where the product shows up. Do not duplicate the customer profile — link to it for personas, market sizing, alternatives, and acquisition. -->
+
+**Full audience detail:** [Customer profile](customer-profile.md)
+
+---
+
+## 4. Principles and tradeoffs
+<!-- Prompt: The opinions that drive design and scope decisions. What this project optimizes for, and what it deliberately gives up to get it. Three to six lines, each in the form "We choose X over Y because Z." A principle without a tradeoff attached is just a value statement. -->
+
+---
+
+## 5. Core experience
+<!-- Prompt: Describe the project from the user's perspective. The shape depends on what we're building — for an app, the user flow; for an API, the integration arc from auth to first useful call; for a library, the example code someone would copy from the README; for a CLI, the first session. Walk through what someone sees or does first, how they get value, and which parts of the experience need to feel especially clear or fast. -->
+
+---
+
+## 6. Scope
+
+### 6.1. In scope
+<!-- Prompt: Add numbered in-scope items in this format:
+1. **Item name**
+   Clarification on what this includes and why it belongs in the first version.
+2. **Item name**
+   Clarification on what this includes and how it supports the core project experience. -->
+
+### 6.2. Out of scope
+<!-- Prompt: Add numbered out-of-scope items in this format:
+1. **Item name**
+   Clarification on what is intentionally excluded and why it should wait.
+2. **Item name**
+   Clarification on the boundary so the first version does not expand beyond its purpose. -->
+
+---
+
+## 7. Success criteria
+<!-- Prompt: How we know this worked. Concrete signals, not vibes. Mix leading indicators (engagement, retention, qualitative feedback) with lagging ones (revenue, growth, conversion) as appropriate. Each criterion should have a target or threshold, even if it's a guess marked as a guess. If a criterion can't be measured, say how we'll know anyway. -->
+
+---
+
+## 8. Risks and assumptions
+<!-- Prompt: What this project is betting on, and what could break it. Cover three kinds:
+1. **Audience assumptions** — what we believe about who wants this and why. Link to the customer profile's assumption risks if they overlap.
+2. **Execution risks** — what could go wrong while building it (scope, timeline, team, tech).
+3. **External risks** — what could shift underneath us (platform changes, competitor moves, regulation). Link to platform-dependency docs where relevant.
+For each, a one-line mitigation or "accepted" if we're choosing to live with it. -->
+
+---
+
+## 9. Open questions
+<!-- Prompt: Add bullet points for the questions that still need answers before starting this project. -->

--- a/plugins/project-docs/documents/release-readiness.md
+++ b/plugins/project-docs/documents/release-readiness.md
@@ -1,0 +1,65 @@
+---
+title: Release readiness
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-15
+related:
+  - project-brief.md
+  - feature-spec.md
+  - platform-dependency.md
+  - testing-strategy.md
+  - post-release-review.md
+---
+
+# Release readiness
+<!-- Prompt: Use this before shipping a product, app release, feature launch, service change, library version, CLI update, or infrastructure change. The document should collect evidence for a release decision, not vague approvals. If something is unknown, write the unknown plainly and decide whether it blocks release. -->
+
+<!-- Relationship guide for planners/AI: Use this as the pre-ship evidence bundle. Pull scope from the project brief and feature specs, dependency risk from platform docs, and decision context from decision records. The post-release review should compare actual results against this document. -->
+
+## 1. Release summary
+<!-- Prompt: What is being released, to whom, and through what channel. Include version, build, deployment, package, flag, store release, or rollout identifier where one exists. One short paragraph. -->
+
+---
+
+## 2. User-facing scope
+<!-- Prompt: What users, developers, operators, or customers will notice. Include new behavior, changed behavior, removed behavior, migration impact, and anything intentionally invisible but user-affecting. Link the feature specs or project brief rather than repeating them. -->
+
+---
+
+## 3. Operational scope
+<!-- Prompt: What changes behind the scenes: database migrations, feature flags, jobs, queues, permissions, dependencies, monitoring, deployment topology, package distribution, support tooling, or manual operations. Include owner and current state for each item that must be true at release time. -->
+
+---
+
+## 4. Known risks
+<!-- Prompt: The risks we are knowingly carrying into release. For each, include impact, likelihood, mitigation, detection signal, and whether it blocks release. Be specific: "old clients may read a missing field" is useful; "backwards compatibility risk" is not. -->
+
+---
+
+## 5. Test coverage
+<!-- Prompt: Evidence that the release works. Include automated checks, manual QA, device or browser coverage, migration dry runs, load checks, accessibility checks, security checks, and test gaps. For each check, include the result or link to the run. If a check was skipped, say why. -->
+
+---
+
+## 6. Support and documentation
+<!-- Prompt: What users or operators need to understand the release. Include release notes, help docs, migration guides, runbooks, support macros, known-issue notes, internal handoff, and who is prepared to answer questions. -->
+
+---
+
+## 7. Privacy, security, and legal checks
+<!-- Prompt: Confirm whether the release changes data collection, data retention, permissions, authentication, authorization, encryption, third-party processors, public claims, licensing, export restrictions, or terms. Link the review or state why no review is needed. -->
+
+---
+
+## 8. Rollout plan
+<!-- Prompt: How the release reaches people or systems. Include phases, percentage or audience gates, timing dependencies, owner, monitoring window, promotion criteria, and the condition for stopping. For libraries and CLIs, describe publication and adoption path instead of staged rollout if that fits better. -->
+
+---
+
+## 9. Rollback plan
+<!-- Prompt: How to undo or contain the release. Include kill switch, revert, package yank, feature flag, database rollback or forward-fix plan, cache clearing, communications, and data cleanup. If rollback is impossible or partial, say that and name the fallback. -->
+
+---
+
+## 10. Launch decision
+<!-- Prompt: The final decision and evidence behind it. Use one of: Ship, Ship with conditions, Hold, or Cancel. List the conditions if any. Name the person making the call and the date. -->

--- a/plugins/project-docs/documents/research-brief.md
+++ b/plugins/project-docs/documents/research-brief.md
@@ -1,0 +1,58 @@
+---
+title: Research brief
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-14
+related:
+  - decision-record.md
+  - project-brief.md
+  - platform-dependency.md
+---
+
+# Research brief
+<!-- Prompt: Use this for focused research before a product, feature, dependency, market, or implementation decision. Keep the brief narrow. It should separate what was observed from what was inferred, and it should leave enough source trail for another person to check the conclusion. -->
+
+<!-- Relationship guide for planners/AI: Use this when evidence needs its own trail before a brief, dependency doc, feature spec, or decision record relies on it. Keep observations here so product docs can link to the evidence instead of carrying the whole research body. -->
+
+## 1. Research question
+<!-- Prompt: The question this brief answers. Write it as a question, not a topic. Include the decision it feeds if there is one. Example: "Can we rely on CloudKit sharing for the first collaborative version?" beats "CloudKit research." -->
+
+---
+
+## 2. Background
+<!-- Prompt: Why this question matters now. Include the project, feature, dependency, customer, or market context needed to read the findings. Link related docs or issues instead of re-explaining them. -->
+
+---
+
+## 3. Sources
+<!-- Prompt: The sources reviewed. Group them by type when useful: official docs, source code, market data, customer interviews, forum threads, competitor products, benchmarks, experiments. For each source, include the link or location, date checked, and what kind of evidence it provides. -->
+
+---
+
+## 4. Findings
+<!-- Prompt: The facts or observations that answer the research question. Keep each finding concrete and source-backed. Separate direct evidence from interpretation. If a finding depends on a small sample, old data, or an unverified assumption, say so in the finding rather than hiding it later. -->
+
+---
+
+## 5. Evidence quality
+<!-- Prompt: How much confidence we should place in the findings. Cover source reliability, sample size, recency, reproduction, measurement method, and gaps. Name anything that could make the conclusion wrong. -->
+
+---
+
+## 6. Implications
+<!-- Prompt: What the findings mean for the product, feature, technical design, dependency choice, market assumption, or rollout. This is interpretation. Tie each implication back to a finding so the reasoning can be checked. -->
+
+---
+
+## 7. Risks and unknowns
+<!-- Prompt: What remains uncertain after this research. Include unknowns that affect scope, cost, feasibility, user behavior, compliance, platform risk, or operations. Mark which ones must be answered before work continues and which can be tracked during implementation. -->
+
+---
+
+## 8. Recommendation
+<!-- Prompt: The recommended path, stated plainly. Include the confidence level, the trade-off being accepted, and the next decision or issue this should feed. If the research does not support a recommendation yet, say what evidence is missing. -->
+
+---
+
+## 9. Follow-up questions
+<!-- Prompt: Questions that fell out of the research but are outside this brief's scope. Link or file follow-up issues when the question needs actual work. -->

--- a/plugins/project-docs/documents/technical-design.md
+++ b/plugins/project-docs/documents/technical-design.md
@@ -1,0 +1,77 @@
+---
+title: Technical design
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-15
+related:
+  - feature-spec.md
+  - testing-strategy.md
+---
+
+# Technical design
+<!-- Prompt: Open with one or two short paragraphs naming the feature, system, workflow, or infrastructure change this design covers. Link to the project brief, feature spec, platform dependency docs, issues, prototypes, or previous decisions that set the boundary. State what this technical design adds beyond those docs.
+
+Use this template after product scope is clear enough to make implementation choices. The doc should answer how we will build the thing, what contracts it creates, and where it can fail. It should not re-spec product behavior already owned by the feature spec. Keep it practical: enough detail for someone to implement or review the plan, not a tour of every possible architecture. -->
+
+## 1. Goals
+<!-- Prompt: The engineering outcomes this design must make true. Prefer concrete behavior over broad qualities. For apps, reference the user-visible capability from the feature spec instead of repeating it. For services, include the contract or operational property. For infrastructure, include the state the platform needs to reach. Three to six bullets. -->
+
+---
+
+## 2. Non-goals
+<!-- Prompt: The tempting adjacent implementation work this design intentionally does not cover. Include boundaries that protect build scope: platforms not supported, old data not migrated, contracts left unchanged, observability deferred, or manual operations accepted for now. Product non-goals belong in the feature spec unless they change the engineering shape. -->
+
+---
+
+## 3. Proposed design
+<!-- Prompt: Describe the chosen implementation at the level needed for review. Cover the major components, where code will live, how data moves through them, and which parts are new vs reused. For a UI feature, include the state owner and rendering path. For an API or service, include request flow, background work, and persistence. For infrastructure, include resources, ownership, and lifecycle.
+
+Use visuals when structure is easier to review that way: Mermaid component diagrams for boundaries, sequence diagrams for request flows, state diagrams for internal lifecycles, and flowcharts for background work. Keep diagrams small enough that each one answers a specific review question. -->
+
+---
+
+## 4. Data or state model
+<!-- Prompt: Define the implementation model: stored records, in-memory state, configuration, derived values, caches, queues, and ownership. If the feature spec already defines the public domain model, reference it and only describe what changes for implementation.
+
+Use Markdown tables for schemas, config, state fields, defaults, ownership, and lifecycle. If the work has no persistent model, describe the runtime state instead. -->
+
+---
+
+## 5. Interfaces and contracts
+<!-- Prompt: The implementation boundaries other code or people depend on: API endpoints, function signatures, events, schemas, environment variables, CLI flags, file formats, component props, job payloads, permissions, or operational handoffs. Public product contracts should match the feature spec; this section explains the exact technical contract.
+
+Use Markdown tables for endpoints, events, payload fields, permissions, and environment variables. Include examples where they prevent ambiguity. -->
+
+---
+
+## 6. Failure modes
+<!-- Prompt: Concrete ways this implementation can fail and how each is handled. Cover bad input that crosses a technical boundary, missing permissions, unavailable dependencies, partial writes, retries, stale cache, race conditions, concurrency, degraded device or network state, and operator mistakes. Product edge cases belong in the feature spec; this section covers the engineering behavior behind them.
+
+Use a Markdown table when listing more than a few failures. Say when each failure is surfaced to a user, logged, retried, ignored, or treated as fatal. -->
+
+---
+
+## 7. Security and privacy
+<!-- Prompt: What this implementation exposes, stores, transmits, or trusts. Include authentication and authorization checks, secret handling, data minimization, retention, auditability, tenant or user boundaries, and privacy-sensitive telemetry. Use a table for trust boundaries, permissions, retained fields, or data flows when useful. If there is no sensitive data or trust boundary, say why. -->
+
+---
+
+## 8. Migration and rollout
+<!-- Prompt: How this implementation reaches production or adopters. Cover schema migrations, backfills, feature flags, compatibility with old clients or data, deployment order, rollback behavior, and cleanup. Link to the feature spec for the user-facing rollout plan instead of repeating it.
+
+Use a Markdown table for rollout phases, migration steps, compatibility windows, or rollback triggers. For local-only or library changes, cover versioning and how adopters move from the old shape to the new one. -->
+
+---
+
+## 9. Testing plan
+<!-- Prompt: The tests or checks that would prove this design works. Reference testing-strategy.md for the project-wide layers, tools, coverage expectations, fixture approach, CI gates, and flaky-test rules. This section should only add the feature-specific checks needed for this design. Include unit, integration, UI, contract, migration, load, manual, simulator/device, and operational checks only where they apply. Tie tests back to contracts, failure modes, and migration risk rather than restating acceptance criteria from the feature spec. Use a table when mapping risks to checks. Name any hard-to-test behavior and how we will inspect it anyway. -->
+
+---
+
+## 10. Alternatives considered
+<!-- Prompt: The real implementation alternatives, including doing nothing. For each: what it would have made easier, why it was rejected, and what would make us reconsider later. Use a decision table when comparing several options. Keep this section honest and short. -->
+
+---
+
+## 11. Open questions
+<!-- Prompt: Questions that still affect implementation choices. If a question does not need to be answered before build starts, mark the point where it must be resolved. -->

--- a/plugins/project-docs/documents/testing-strategy.md
+++ b/plugins/project-docs/documents/testing-strategy.md
@@ -1,0 +1,100 @@
+---
+title: Testing strategy
+status: Active
+owner: Luca Silverentand
+last_updated: 2026-05-15
+related:
+  - technical-design.md
+  - release-readiness.md
+---
+
+# Testing strategy
+<!-- Prompt: Use this once per app, product area, package, service, or repo when the team needs a shared testing contract. This document sets the test layers, confidence model, tools, data approach, and CI expectations for the whole project. Per-feature testing plans in technical-design.md should reference this strategy and only add the checks needed for that specific change. -->
+
+<!-- Relationship guide for planners/AI: This is the project-wide testing source of truth. It does not replace the technical design's Testing plan section, which should map feature-specific risks to checks. Release readiness should use this strategy to judge whether the evidence gathered for a release is enough. -->
+
+## 1. Summary
+<!-- Prompt: In one short paragraph, define the project, repo, product area, or app this strategy covers. State the testing goal in plain terms: what confidence the team needs before merging, releasing, or accepting operational risk. Name any important constraints such as supported platforms, offline behavior, regulated data, small team size, slow environments, or expensive dependencies. -->
+
+---
+
+## 2. Confidence model
+<!-- Prompt: Describe how the team thinks about confidence across the whole project. Avoid saying "more tests are better." Say which risks must be caught quickly during development, which risks need realistic integration, which risks require end-to-end proof, and which risks still need human judgment. If a layer is intentionally weak or absent, say what risk the team accepts. -->
+
+|Confidence question|Owned by|Why this belongs there|
+|---|---|---|
+|<!-- Example: Does one pure unit of behavior work for normal and edge input? -->|<!-- Example: Unit tests -->|<!-- Example: Fast feedback, narrow failure, no external systems. -->|
+|<!-- Example: Do two or more project-owned parts agree on their contract? -->|<!-- Example: Integration tests -->|<!-- Example: Catches wiring, serialization, persistence, and boundary assumptions. -->|
+|<!-- Example: Can a user, client, or operator complete a critical path? -->|<!-- Example: End-to-end or manual release checks -->|<!-- Example: Proves the real flow, not every branch. -->|
+
+---
+
+## 3. Test layers
+<!-- Prompt: Fill this table with the layers this project will actually maintain. Delete rows that do not apply and add project-specific layers such as contract tests, snapshot tests, accessibility checks, migration tests, performance tests, visual regression checks, security tests, device tests, simulator tests, package smoke tests, or operational drills. The point is to commit to which layer owns which kind of confidence, not to copy a generic pyramid. -->
+
+|Layer|What it proves|Use it for|Do not use it for|Expected speed or cadence|Owner|
+|---|---|---|---|---|---|
+|Unit|<!-- Prompt: The smallest useful behavior works without real external systems. -->|<!-- Prompt: Pure logic, validation, state transitions, error mapping, and edge cases where setup should be cheap. -->|<!-- Prompt: Cross-service behavior, browser or device behavior, persistence guarantees, or confidence that depends on real infrastructure. -->|<!-- Prompt: Runs locally and in CI on every change, unless this project chooses differently. -->|<!-- Prompt: Role or team responsible for keeping these useful. -->|
+|Integration|<!-- Prompt: Project-owned parts agree on contracts and data shape. -->|<!-- Prompt: Persistence, API boundaries, adapters, job queues, serialization, permissions, or dependency wrappers. -->|<!-- Prompt: Full user journeys, third-party production behavior, or visual polish. -->|<!-- Prompt: Name the local and CI cadence. -->|<!-- Prompt: Role or team. -->|
+|End-to-end|<!-- Prompt: The critical path works through the real user, client, CLI, API, or operator surface. -->|<!-- Prompt: A small set of merge or release gates that prove high-value flows. -->|<!-- Prompt: Exhaustive edge cases, every UI state, or logic that can be tested lower down. -->|<!-- Prompt: Name when these run and what blocks merge or release. -->|<!-- Prompt: Role or team. -->|
+|Manual|<!-- Prompt: Human judgment confirms what automation cannot cheaply prove. -->|<!-- Prompt: Exploratory checks, copy review, judgment-heavy UI states, app store behavior, hardware quirks, or one-off release validation. -->|<!-- Prompt: Repeatable regressions that should move into automation after they matter twice. -->|<!-- Prompt: Name when manual checks are required and how evidence is recorded. -->|<!-- Prompt: Role or team. -->|
+
+---
+
+## 4. Coverage expectations
+<!-- Prompt: Define where coverage matters and where it does not. Be specific by module, package, feature class, risk class, or layer. Avoid a global percentage unless the project has a real reason to enforce one. Name the code or behavior that must have strong automated coverage, the code that only needs smoke coverage, and the code that is acceptable to verify manually. -->
+
+|Area or behavior|Expected coverage|Reason|Evidence|
+|---|---|---|---|
+|<!-- Prompt: Example: Billing calculation, sync conflict resolver, public API parser, onboarding flow. -->|<!-- Prompt: High unit coverage, integration coverage, E2E smoke, manual only, etc. -->|<!-- Prompt: Why this risk deserves that level of proof. -->|<!-- Prompt: Test file pattern, CI job, checklist, dashboard, or release note link. -->|
+
+---
+
+## 5. Tools and frameworks
+<!-- Prompt: Name the tools the project commits to using. This template should not pick a stack for the project. Fillers like "Jest or Vitest" are not enough; choose the real runner, assertion library, browser/device tool, coverage reporter, fixture builder, mocking strategy, and CI service where they apply. For each choice, include why it fits and what would justify replacing it later. -->
+
+|Purpose|Tool or framework|Applies to|Why this choice|Replacement trigger|
+|---|---|---|---|---|
+|Test runner|<!-- Prompt: Chosen runner, command, or service. -->|<!-- Prompt: Layers or packages. -->|<!-- Prompt: Why this is the project default. -->|<!-- Prompt: What problem would make the team revisit it. -->|
+|Assertions and helpers|<!-- Prompt: Chosen assertion library, helpers, matchers, or test utilities. -->|<!-- Prompt: Layers or packages. -->|<!-- Prompt: Why this stays consistent. -->|<!-- Prompt: Revisit trigger. -->|
+|Browser, device, or external-system checks|<!-- Prompt: Chosen tool, simulator, emulator, local service, sandbox, or manual process. -->|<!-- Prompt: Layers or release checks. -->|<!-- Prompt: Why this gives the needed confidence. -->|<!-- Prompt: Revisit trigger. -->|
+|Coverage and reporting|<!-- Prompt: Chosen reporter, threshold tool, dashboard, or intentionally none. -->|<!-- Prompt: Layers or risk areas. -->|<!-- Prompt: Why this signal is worth tracking. -->|<!-- Prompt: Revisit trigger. -->|
+
+---
+
+## 6. Test data and fixtures
+<!-- Prompt: Explain how test data is created, stored, named, reset, and reviewed. Cover factories, fixtures, snapshots, seed data, generated data, mocked external responses, golden files, anonymized production samples, and local test accounts only where they apply. Say which data is allowed in the repo and which must stay out. -->
+
+|Data type|Source|Used by|Reset or cleanup rule|Privacy or maintenance rule|
+|---|---|---|---|---|
+|<!-- Prompt: Example: domain factories, HTTP fixtures, sample documents, seed database, fake users, media assets. -->|<!-- Prompt: Generated, checked-in, sandbox, local builder, etc. -->|<!-- Prompt: Test layers or tools. -->|<!-- Prompt: How stale state is avoided. -->|<!-- Prompt: What cannot be stored, logged, or copied. -->|
+
+---
+
+## 7. CI integration
+<!-- Prompt: Define which checks run in CI, what blocks merge, what runs after merge, and what is release-only. Include local commands that match CI so contributors can reproduce failures. If some checks are too slow or expensive for every PR, name the schedule or trigger and the risk this accepts. -->
+
+|Check|Command or workflow|Trigger|Blocks merge?|Failure owner|
+|---|---|---|---|---|
+|<!-- Prompt: Example: unit tests, lint, typecheck, integration tests, E2E smoke, coverage, package build, migration dry run. -->|<!-- Prompt: Local command, CI job, or manual checklist link. -->|<!-- Prompt: PR, main, nightly, release branch, tag, manual dispatch. -->|<!-- Prompt: Yes, no, or conditional. -->|<!-- Prompt: Who investigates first. -->|
+
+---
+
+## 8. Flaky test handling
+<!-- Prompt: Define what counts as flaky, how it is reported, and how long a flaky test may stay in the suite. Include quarantine rules, retries, labels, issue creation, ownership, and the standard for deleting or rewriting low-value tests. Do not let retry settings hide the problem; say what signal still fails loudly. -->
+
+|Scenario|Immediate action|Follow-up owner|Time limit|Merge or release impact|
+|---|---|---|---|---|
+|New flake on a required check|<!-- Prompt: Example: rerun once, inspect logs, file issue, mark owner. -->|<!-- Prompt: Role or team. -->|<!-- Prompt: Same PR, same day, sprint, etc. -->|<!-- Prompt: Whether merge is blocked. -->|
+|Known flake|<!-- Prompt: Example: quarantine, skip with issue link, lower priority, or remove. -->|<!-- Prompt: Role or team. -->|<!-- Prompt: Expiry date or review cadence. -->|<!-- Prompt: Whether release is blocked or risk is accepted. -->|
+|Test with poor signal|<!-- Prompt: Example: rewrite lower in the stack, delete if it only checks implementation details, replace with a better check. -->|<!-- Prompt: Role or team. -->|<!-- Prompt: Review cadence. -->|<!-- Prompt: Merge or release impact. -->|
+
+---
+
+## 9. Manual and exploratory testing
+<!-- Prompt: Name the human checks the project still expects and why automation does not own them yet. Include devices, browsers, operating systems, accessibility passes, copy review, install or upgrade paths, external integrations, destructive operations, or operator workflows. Link the checklist location if it lives outside this document. -->
+
+---
+
+## 10. Out of scope
+<!-- Prompt: List the testing topics this strategy intentionally does not cover. Good out-of-scope items include per-feature test cases, release-specific evidence, production incident response, performance budgets owned elsewhere, compliance audits, or experiments that need their own plan. For each boundary, point to the document or issue type that owns it instead. -->

--- a/plugins/project-docs/scripts/validate-refs.ts
+++ b/plugins/project-docs/scripts/validate-refs.ts
@@ -1,0 +1,318 @@
+import { existsSync } from "node:fs";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+type RelatedEntry = {
+  target: string;
+  line: number;
+};
+
+type ValidationError = {
+  file: string;
+  line: number;
+  message: string;
+};
+
+const root = process.cwd();
+const ignoredDirs = new Set([".git", "node_modules"]);
+const args = Bun.argv.slice(2);
+const targets = args.length > 0 ? args : ["."];
+const errors: ValidationError[] = [];
+
+const markdownFiles = await collectMarkdownFiles(targets);
+
+for (const file of markdownFiles) {
+  const content = await readFile(file, "utf8");
+  errors.push(...validateRelatedEntries(file, content));
+  errors.push(...validateMarkdownLinks(file, content));
+}
+
+if (errors.length > 0) {
+  console.error("Broken document references found:");
+
+  for (const error of errors) {
+    console.error(
+      `- ${path.relative(root, error.file)}:${error.line}: ${error.message}`
+    );
+  }
+
+  process.exit(1);
+}
+
+console.log(`Validated references in ${markdownFiles.length} markdown files.`);
+
+async function collectMarkdownFiles(inputPaths: string[]): Promise<string[]> {
+  const files = new Set<string>();
+
+  for (const inputPath of inputPaths) {
+    const absolutePath = path.resolve(root, inputPath);
+
+    if (!existsSync(absolutePath)) {
+      errors.push({
+        file: absolutePath,
+        line: 1,
+        message: "configured validation path does not exist",
+      });
+      continue;
+    }
+
+    await collectPath(absolutePath, files);
+  }
+
+  return [...files].sort();
+}
+
+async function collectPath(inputPath: string, files: Set<string>) {
+  const inputStat = await stat(inputPath);
+
+  if (inputStat.isDirectory()) {
+    const basename = path.basename(inputPath);
+
+    if (ignoredDirs.has(basename)) {
+      return;
+    }
+
+    const entries = await readdir(inputPath);
+
+    for (const entry of entries) {
+      await collectPath(path.join(inputPath, entry), files);
+    }
+
+    return;
+  }
+
+  if (inputStat.isFile() && inputPath.endsWith(".md")) {
+    files.add(inputPath);
+  }
+}
+
+function validateRelatedEntries(
+  file: string,
+  content: string
+): ValidationError[] {
+  const frontmatter = readFrontmatter(content);
+
+  if (!frontmatter) {
+    return [];
+  }
+
+  return parseRelated(frontmatter.text, frontmatter.startLine).flatMap(
+    (entry) => validateLocalTarget(file, entry.target, entry.line, "related")
+  );
+}
+
+function validateMarkdownLinks(
+  file: string,
+  content: string
+): ValidationError[] {
+  const stripped = stripIgnoredMarkdown(content);
+  const linkRegex = /(?<!!)\[[^\]\n]+\]\(([^)\n]+)\)/g;
+  const errors: ValidationError[] = [];
+
+  for (const match of stripped.matchAll(linkRegex)) {
+    const rawDestination = match[1];
+    const destination = parseMarkdownDestination(rawDestination);
+
+    if (!destination || shouldSkipMarkdownTarget(destination)) {
+      continue;
+    }
+
+    errors.push(
+      ...validateLocalTarget(
+        file,
+        destination,
+        lineNumberForIndex(stripped, match.index ?? 0),
+        "markdown link"
+      )
+    );
+  }
+
+  return errors;
+}
+
+function readFrontmatter(
+  content: string
+): { text: string; startLine: number } | null {
+  if (!content.startsWith("---\n")) {
+    return null;
+  }
+
+  const endIndex = content.indexOf("\n---", 4);
+
+  if (endIndex === -1) {
+    return null;
+  }
+
+  return {
+    text: content.slice(4, endIndex),
+    startLine: 2,
+  };
+}
+
+function parseRelated(frontmatter: string, startLine: number): RelatedEntry[] {
+  const lines = frontmatter.split("\n");
+  const entries: RelatedEntry[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const relatedMatch = line.match(/^related:\s*(.*)$/);
+
+    if (!relatedMatch) {
+      continue;
+    }
+
+    const inlineValue = relatedMatch[1].trim();
+    const lineNumber = startLine + index;
+
+    if (inlineValue.startsWith("[") && inlineValue.endsWith("]")) {
+      for (const target of inlineValue.slice(1, -1).split(",")) {
+        const cleaned = cleanYamlScalar(target);
+
+        if (cleaned) {
+          entries.push({ target: cleaned, line: lineNumber });
+        }
+      }
+
+      continue;
+    }
+
+    if (inlineValue) {
+      const cleaned = cleanYamlScalar(inlineValue);
+
+      if (cleaned) {
+        entries.push({ target: cleaned, line: lineNumber });
+      }
+
+      continue;
+    }
+
+    for (
+      let blockIndex = index + 1;
+      blockIndex < lines.length;
+      blockIndex += 1
+    ) {
+      const blockLine = lines[blockIndex];
+
+      if (blockLine.trim() === "") {
+        continue;
+      }
+
+      if (!/^\s+/.test(blockLine)) {
+        break;
+      }
+
+      const listMatch = blockLine.match(/^\s*-\s*(.*)$/);
+
+      if (!listMatch) {
+        continue;
+      }
+
+      const listValue = listMatch[1].trim();
+      const objectValueMatch = listValue.match(/^(?:file|path|href):\s*(.*)$/);
+      const target = cleanYamlScalar(objectValueMatch?.[1] ?? listValue);
+
+      if (target) {
+        entries.push({ target, line: startLine + blockIndex });
+      }
+    }
+  }
+
+  return entries;
+}
+
+function validateLocalTarget(
+  sourceFile: string,
+  rawTarget: string,
+  line: number,
+  label: string
+): ValidationError[] {
+  const target = rawTarget.trim();
+
+  if (!target || target.startsWith("#")) {
+    return [];
+  }
+
+  if (isExternalTarget(target)) {
+    return [
+      {
+        file: sourceFile,
+        line,
+        message: `${label} must be repo-local: ${target}`,
+      },
+    ];
+  }
+
+  const pathWithoutFragment = target.split("#", 1)[0];
+
+  if (!pathWithoutFragment) {
+    return [];
+  }
+
+  const resolvedPath = path.isAbsolute(pathWithoutFragment)
+    ? path.join(root, pathWithoutFragment)
+    : path.resolve(path.dirname(sourceFile), pathWithoutFragment);
+
+  if (existsSync(resolvedPath)) {
+    return [];
+  }
+
+  return [
+    {
+      file: sourceFile,
+      line,
+      message: `${label} target does not exist: ${target}`,
+    },
+  ];
+}
+
+function shouldSkipMarkdownTarget(destination: string): boolean {
+  if (
+    destination.startsWith("#") ||
+    isExternalTarget(destination) ||
+    destination.startsWith("//")
+  ) {
+    return true;
+  }
+
+  return path.extname(destination.split("#", 1)[0]) !== ".md";
+}
+
+function isExternalTarget(target: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(target);
+}
+
+function parseMarkdownDestination(rawDestination: string): string | null {
+  const trimmed = rawDestination.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("<")) {
+    const end = trimmed.indexOf(">");
+    return end === -1 ? null : trimmed.slice(1, end);
+  }
+
+  return trimmed.split(/\s+/, 1)[0];
+}
+
+function stripIgnoredMarkdown(content: string): string {
+  return content
+    .replace(/<!--[\s\S]*?-->/g, (match) => "\n".repeat(countLines(match) - 1))
+    .replace(/```[\s\S]*?```/g, (match) => "\n".repeat(countLines(match) - 1));
+}
+
+function cleanYamlScalar(value: string): string {
+  return value
+    .replace(/\s+#.*$/, "")
+    .trim()
+    .replace(/^["']|["']$/g, "");
+}
+
+function lineNumberForIndex(content: string, index: number): number {
+  return countLines(content.slice(0, index));
+}
+
+function countLines(value: string): number {
+  return value.split("\n").length;
+}

--- a/plugins/project-docs/skills/create-doc-template/SKILL.md
+++ b/plugins/project-docs/skills/create-doc-template/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: create-doc-template
+description: Creates or updates Markdown document templates in the project-docs plugin, especially files under documents/. Guides research, structure, section prompts, README updates, and validation. Use when the user asks to add a project document template, update an existing planning template, change the project-docs template library, or create docs like a feature spec, project brief, testing strategy, release readiness checklist, research brief, or decision record.
+---
+
+# Create Doc Template
+Create document templates that fit the project-docs library instead of importing a generic industry checklist.
+
+## What good looks like
+- The template has a clear owner in the document system: when to write it, how many copies exist, and which other templates it should link to instead of repeating.
+- The empty template is useful. Headings and prompts tell the writer what belongs there, what evidence helps, and what to leave out.
+- The outline borrows from industry practice, then cuts anything that would create stale paperwork.
+- The template works across project types unless the requested document is intentionally narrow.
+
+## Workflow
+1. Read `README.md` and nearby templates before drafting. Use the closest existing template for pacing, prompt density, and section size.
+2. Define the template contract in plain language: when it is written, who reads it, what decision or review it supports, and which template owns adjacent details.
+3. Do a lightweight research pass on current examples, standards, or common outlines for the document type. Keep notes on useful section ideas, not source prose.
+4. Build the outline by subtraction. Start from the common industry shape, then remove sections that duplicate another template, ask for facts no one will maintain, or exist only to look complete.
+5. Draft the Markdown using the repo conventions below.
+6. Update `README.md` when adding a public template under `documents/`: add the table row and any relationship note needed to prevent duplicate ownership.
+7. Run `bun run check` before finishing. If dependencies are missing, run `bun install` first.
+
+## Repo conventions
+- Use YAML frontmatter with `title`, `status`, `owner`, and `last_updated`. Match the existing templates for default values unless the user gives different values.
+- Use one H1 matching the template title.
+- Use sentence-case headings.
+- Use numbered H2 sections. Use H3/H4 only when the section genuinely has repeated parts or a stable internal structure.
+- Put `---` between every H2 section, but not before the first or after the last.
+- Avoid generic "Scope" openers. If the document needs orientation, put a short prompt under the H1. Keep `## 1. Summary` only when summary is the first real section.
+- Use Markdown tables for matrices, schemas, acceptance criteria, contracts, options, risks, and rollout phases when a table makes review easier.
+- Use Mermaid for flows, state machines, sequences, component boundaries, and rollout paths when a small diagram answers a review question better than prose.
+- Keep Markdown Prettier-friendly with `proseWrap: never`.
+
+## Prompt writing
+- Put section instructions in HTML comments using `<!-- Prompt: ... -->`.
+- Write prompts as instructions for the person or LLM filling the section, not as descriptions of the section.
+- Include the shape of the expected answer: paragraph, bullets, numbered list, table, Mermaid diagram, links, or examples.
+- Name useful evidence: issues, source docs, customer signals, measurements, prototypes, decisions, releases, or code locations.
+- Name boundaries. Tell the writer which related template owns details that should be linked instead of copied.
+- Keep the wording concrete. Prefer "Name the decision, the constraint that forced it, and the trade-off accepted" over "describe context."
+- Tell the writer when to delete a section, say "not applicable," or leave a question open. Empty template sections should not survive by accident.
+- Preserve the repo's privacy posture. Do not ask writers to collect personal data unless the template's purpose truly requires it.
+
+## Final check
+Before handing off, verify:
+
+- The new or changed template matches the README conventions.
+- The template contract is clear enough to add to the README table.
+- Each section has a useful prompt or intentionally needs no prompt.
+- The outline is short enough to fill during real project work.
+- Tables and diagrams are suggested where they clarify review, not everywhere.
+- `README.md` lists the template if it belongs in `documents/`.
+- `bun run check` passes, or the blocker is recorded with the exact failure.


### PR DESCRIPTION
## Summary

- import the Ambiently document templates as a standalone `project-docs` plugin
- add the template-authoring skill and plugin-local reference validator
- register `project-docs` in the skills marketplace metadata
- remove the old local Ambiently `doc-templates` working copy after import validation

## Checks

- `bun plugins/project-docs/scripts/validate-refs.ts plugins/project-docs`
- `bun run check`
- `bun run marketplace`