### PR TITLE
feat(github): add PR merge readiness skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,7 +86,7 @@
 		{
 			"name": "github",
 			"source": "./plugins/github",
-			"description": "GitHub workflow toolkit for creating pull requests and monitoring CI.",
+			"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 			"version": "1.1.0",
 			"author": {
 				"name": "Luca Silverentand",
@@ -96,7 +96,8 @@
 			"keywords": [
 				"github",
 				"pull-request",
-				"ci"
+				"ci",
+				"merge-readiness"
 			]
 		},
 		{

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -71,8 +71,8 @@
 			"shortDescription": "Pull request and CI workflows",
 			"category": "Development",
 			"keywords": ["github", "pull-request", "ci", "merge-readiness"],
-			"skills": ["creating-prs", "monitoring-ci", "preparing-prs-to-merge"],
-			"commands": ["ci", "create-draft-pr", "create-pr"],
+			"skills": ["creating-prs", "fix-pr", "monitoring-ci"],
+			"commands": ["ci", "create-draft-pr", "create-pr", "fix-pr"],
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -67,11 +67,11 @@
 		{
 			"name": "github",
 			"displayName": "GitHub",
-			"description": "GitHub workflow toolkit for creating pull requests and monitoring CI.",
+			"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 			"shortDescription": "Pull request and CI workflows",
 			"category": "Development",
-			"keywords": ["github", "pull-request", "ci"],
-			"skills": ["creating-prs", "monitoring-ci"],
+			"keywords": ["github", "pull-request", "ci", "merge-readiness"],
+			"skills": ["creating-prs", "monitoring-ci", "preparing-prs-to-merge"],
 			"commands": ["ci", "create-draft-pr", "create-pr"],
 			"author": {
 				"name": "Luca Silverentand",

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -6,7 +6,7 @@ Git workflow toolkit for commits, conflict resolution, rebases, and repository c
 - `git:creating-commits`
 - `git:resolving-conflicts`
 
-Claude Code also exposes legacy command shims for this plugin: `/git:clean-repo`, `/git:create-commit`, `/git:rebase`. Prefer the portable skills above for Codex and other agents.
+Codex and Claude Code also expose command shims for this plugin: `/git:clean-repo`, `/git:create-commit`, `/git:rebase`. Prefer the portable skills above for automatic loading.
 
 ## Install
 Codex:

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,10 +1,11 @@
 {
 	"name": "github",
-	"description": "GitHub workflow toolkit for creating pull requests and monitoring CI.",
+	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 	"version": "1.1.0",
 	"skills": [
 		"./skills/creating-prs",
-		"./skills/monitoring-ci"
+		"./skills/monitoring-ci",
+		"./skills/preparing-prs-to-merge"
 	],
 	"author": {
 		"name": "Luca Silverentand",
@@ -16,7 +17,8 @@
 	"keywords": [
 		"github",
 		"pull-request",
-		"ci"
+		"ci",
+		"merge-readiness"
 	],
 	"commands": [
 		"./commands/ci.md",

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -4,8 +4,8 @@
 	"version": "1.1.0",
 	"skills": [
 		"./skills/creating-prs",
-		"./skills/monitoring-ci",
-		"./skills/preparing-prs-to-merge"
+		"./skills/fix-pr",
+		"./skills/monitoring-ci"
 	],
 	"author": {
 		"name": "Luca Silverentand",
@@ -23,6 +23,7 @@
 	"commands": [
 		"./commands/ci.md",
 		"./commands/create-draft-pr.md",
-		"./commands/create-pr.md"
+		"./commands/create-pr.md",
+		"./commands/fix-pr.md"
 	]
 }

--- a/plugins/github/.codex-plugin/plugin.json
+++ b/plugins/github/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "github",
 	"version": "1.1.0",
-	"description": "GitHub workflow toolkit for creating pull requests and monitoring CI.",
+	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
@@ -12,13 +12,14 @@
 	"keywords": [
 		"github",
 		"pull-request",
-		"ci"
+		"ci",
+		"merge-readiness"
 	],
 	"skills": "./skills/",
 	"interface": {
 		"displayName": "GitHub",
 		"shortDescription": "Pull request and CI workflows",
-		"longDescription": "GitHub workflow toolkit for creating pull requests and monitoring CI.",
+		"longDescription": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 		"developerName": "Luca Silverentand",
 		"category": "Development",
 		"capabilities": [

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -3,10 +3,10 @@ GitHub workflow toolkit for creating pull requests, monitoring CI, and getting P
 
 ## Skills
 - `github:creating-prs`
+- `github:fix-pr`
 - `github:monitoring-ci`
-- `github:preparing-prs-to-merge`
 
-Claude Code also exposes legacy command shims for this plugin: `/github:ci`, `/github:create-draft-pr`, `/github:create-pr`. Prefer the portable skills above for Codex and other agents.
+Codex and Claude Code also expose command shims for this plugin: `/github:ci`, `/github:create-draft-pr`, `/github:create-pr`, `/github:fix-pr`. Prefer the portable skills above for automatic loading.
 
 ## Install
 Codex:

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -1,9 +1,10 @@
 # GitHub
-GitHub workflow toolkit for creating pull requests and monitoring CI.
+GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.
 
 ## Skills
 - `github:creating-prs`
 - `github:monitoring-ci`
+- `github:preparing-prs-to-merge`
 
 Claude Code also exposes legacy command shims for this plugin: `/github:ci`, `/github:create-draft-pr`, `/github:create-pr`. Prefer the portable skills above for Codex and other agents.
 

--- a/plugins/github/commands/fix-pr.md
+++ b/plugins/github/commands/fix-pr.md
@@ -1,0 +1,17 @@
+---
+description: Gets an existing pull request ready to merge
+allowed-tools: Read Bash Glob Grep Edit Agent AskUserQuestion
+---
+
+Get the pull request ready to merge.
+
+The user invoked this command with: $ARGUMENTS
+
+## Current state
+- Repository: !`git remote get-url origin 2>/dev/null || echo "no origin"`
+- Branch: !`git branch --show-current || echo "detached"`
+- PR: !`gh pr view --json number,url --jq '"#\(.number) \(.url)"' 2>/dev/null || echo "no PR for current branch"`
+- Merge state: !`gh pr view --json mergeStateStatus,reviewDecision,isDraft --jq '"merge=\(.mergeStateStatus // "unknown") review=\(.reviewDecision // "unknown") draft=\(.isDraft)"' 2>/dev/null || echo "unknown"`
+- Failed checks: !`gh pr checks --json name,state --jq '[.[] | select(.state == "FAILURE")] | length' 2>/dev/null || echo "unknown"`
+
+Follow the full workflow in the `fix-pr` skill. If `$ARGUMENTS` contains a PR number, use that PR. Otherwise, use the current branch PR from the state above when one exists. Use the current state above to avoid repeating checks that are already answered.

--- a/plugins/github/skills/fix-pr/SKILL.md
+++ b/plugins/github/skills/fix-pr/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: preparing-prs-to-merge
+name: fix-pr
 description: Gets an existing GitHub pull request ready to merge when the user gives only a PR number. Checks out the PR, inspects mergeability, resolves or reports conflicts, syncs with the base branch, runs appropriate local validation, watches CI until green, handles draft/review/conversation blockers, pushes fixes when needed, and reports the exact remaining merge blockers. Use when the user asks to get a PR ready to merge, prepare a PR for merge, make PR #123 mergeable, or verify whether a PR can be merged.
 allowed-tools: Read Bash Glob Grep Edit Agent AskUserQuestion
 ---
 
-# Preparing PRs To Merge
+# Fix PR
 Use this when the user gives a PR number and wants the PR ready to merge. Assume the current repository is the target repo unless the PR lookup fails.
 
 Do not merge the PR unless the user explicitly asks for that. The job is to make the PR merge-ready and report the exact state.

--- a/plugins/github/skills/preparing-prs-to-merge/SKILL.md
+++ b/plugins/github/skills/preparing-prs-to-merge/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: preparing-prs-to-merge
+description: Gets an existing GitHub pull request ready to merge when the user gives only a PR number. Checks out the PR, inspects mergeability, resolves or reports conflicts, syncs with the base branch, runs appropriate local validation, watches CI until green, handles draft/review/conversation blockers, pushes fixes when needed, and reports the exact remaining merge blockers. Use when the user asks to get a PR ready to merge, prepare a PR for merge, make PR #123 mergeable, or verify whether a PR can be merged.
+allowed-tools: Read Bash Glob Grep Edit Agent AskUserQuestion
+---
+
+# Preparing PRs To Merge
+Use this when the user gives a PR number and wants the PR ready to merge. Assume the current repository is the target repo unless the PR lookup fails.
+
+Do not merge the PR unless the user explicitly asks for that. The job is to make the PR merge-ready and report the exact state.
+
+## Inputs
+Expected input: a PR number, for example `123` or `PR #123`.
+
+If the user gives only a number:
+
+1. Confirm you are inside a GitHub-backed git repo.
+2. Infer `owner/repo` from `origin`.
+3. Use `gh pr view <number>` and continue.
+
+Ask for more information only when the current directory does not identify a GitHub repo or the PR number does not exist there.
+
+## Starting State
+Before touching the branch:
+
+```bash
+git status --short
+```
+
+If there are local changes, do not overwrite them. If they are unrelated and the repo supports worktrees, create or use a clean worktree. Otherwise stop and ask how to handle them.
+
+Fetch the latest remote state:
+
+```bash
+git fetch --all --prune
+```
+
+Read the PR:
+
+```bash
+gh pr view <number> --json number,title,url,state,isDraft,baseRefName,headRefName,headRepositoryOwner,author,mergeable,mergeStateStatus,reviewDecision,reviewRequests,statusCheckRollup,latestReviews,commits
+```
+
+Stop immediately if the PR is closed or merged. Report that there is nothing to prepare.
+
+## Checklist
+Work through this checklist in order. Keep going until the PR is merge-ready or a blocker needs the user's judgment.
+
+### 1. Check Out The PR
+```bash
+gh pr checkout <number>
+```
+
+After checkout, confirm:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+If checkout lands in a detached state, create a local branch matching the PR head name.
+
+### 2. Handle Draft State
+If `isDraft` is true:
+
+- Continue preparing the branch.
+- Do not mark it ready for review unless all checks pass and the user's request clearly implies readiness.
+- If leaving it as draft, report draft state as a remaining blocker.
+
+### 3. Sync With The Base Branch
+Fetch the base branch:
+
+```bash
+git fetch origin <baseRefName>
+```
+
+Determine whether the PR branch is behind:
+
+```bash
+git log --oneline HEAD..origin/<baseRefName>
+```
+
+If the branch is behind, update it using the repo's established pattern:
+
+- Prefer the repo's documented convention from `AGENTS.md`, `CONTRIBUTING.md`, or existing branch history.
+- If no convention is clear, rebase local PR branches and merge upstream branches from forks only when rebasing would rewrite another contributor's branch unexpectedly.
+- Resolve trivial conflicts yourself: generated files, formatting-only conflicts, import ordering, changelog placement, lockfile refreshes.
+- Stop for semantic conflicts where both sides changed behavior and the correct result is not obvious.
+
+After resolving conflicts:
+
+```bash
+git status --short
+```
+
+Commit conflict resolutions with a signed, co-authored commit if the repo requires signed commits.
+
+### 4. Check GitHub Mergeability
+Refresh the PR state:
+
+```bash
+gh pr view <number> --json mergeable,mergeStateStatus
+```
+
+Interpret blockers:
+
+- `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY` means conflicts remain.
+- `mergeStateStatus: BEHIND` means the branch still needs base updates if the repo requires up-to-date branches.
+- `mergeStateStatus: BLOCKED` usually means reviews, conversations, or required checks are blocking merge.
+- `UNKNOWN` can be transient; wait briefly and query again before treating it as a blocker.
+
+### 5. Run Local Validation
+Inspect the repo and run the checks that fit the project before relying on CI:
+
+- Package scripts: `bun run`, `npm run`, `pnpm run`, `yarn run`
+- Common checks: lint, format check, typecheck, test, build
+- Language-specific checks: `cargo test`, `go test ./...`, `pytest`, `ruff`, `swift test`, `xcodebuild test`, etc.
+- Repo-specific commands from `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, task runners, or CI workflow files.
+
+If a check fails:
+
+1. Diagnose the failure locally.
+2. Make the smallest correct fix.
+3. Re-run the failing check.
+4. Commit and push the fix.
+
+If a check cannot run because of missing secrets, unavailable services, or machine-specific tooling, report it clearly and rely on CI for that part.
+
+### 6. Push Needed Updates
+If you changed the branch:
+
+```bash
+git push
+```
+
+If you rebased and the push is rejected, use:
+
+```bash
+git push --force-with-lease
+```
+
+Never force-push a branch owned by someone else without checking the PR author/head repository and being explicit about the risk.
+
+### 7. Get CI Green
+Watch required checks first:
+
+```bash
+gh pr checks <number> --required --watch --fail-fast
+```
+
+Then inspect all checks:
+
+```bash
+gh pr checks <number>
+```
+
+If checks fail, use the `monitoring-ci` skill's diagnose-fix-watch loop:
+
+1. Find the failed run or job.
+2. Read the failed logs.
+3. Fix lint, type, test, or build failures locally when possible.
+4. Push the fix.
+5. Watch the new run.
+
+For flaky infrastructure failures, rerun only failed jobs once. If the same check fails again, treat it as real.
+
+### 8. Review And Conversation Blockers
+Check review state:
+
+```bash
+gh pr view <number> --json reviewDecision,latestReviews,reviewRequests
+```
+
+Review readiness:
+
+- `APPROVED` is ready from a review standpoint.
+- `CHANGES_REQUESTED` is a blocker; read the requested changes and fix what is clear.
+- `REVIEW_REQUIRED` is a remaining blocker unless the repo allows self-merge without approval.
+- Pending requested reviewers are not necessarily blockers, but report them.
+
+Check unresolved review threads when GraphQL access is available:
+
+```bash
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes { isResolved path line }
+      }
+    }
+  }
+}' -F owner=<owner> -F repo=<repo> -F number=<number>
+```
+
+Unresolved threads are blockers unless they are clearly informational and the repo does not require conversation resolution. Do not resolve conversations just to make the checklist pass; resolve only when the underlying issue has actually been addressed.
+
+### 9. Final Merge Readiness Check
+Query the final PR state:
+
+```bash
+gh pr view <number> --json url,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+gh pr checks <number>
+```
+
+The PR is merge-ready only when:
+
+- It is open.
+- It is not draft, unless the user explicitly wants it kept draft.
+- GitHub reports it as mergeable or has no unresolved conflict state.
+- Required CI checks are green.
+- Local validation that fits the project has passed or any skipped check is explained.
+- Required reviews are approved or no approval is required.
+- There are no unresolved required conversations.
+- The branch is pushed and up to date with the remote.
+
+## Final Response
+Report the result plainly:
+
+- PR URL
+- Branch and base branch
+- Whether it is merge-ready
+- Checks run locally and their results
+- CI status
+- Fix commits pushed, if any
+- Remaining blockers, if any, with the exact owner/action needed
+
+If everything is ready, say that the PR is ready to merge. Do not say you merged it unless you actually did.

--- a/plugins/skill-creation/skills/publishing/SKILL.md
+++ b/plugins/skill-creation/skills/publishing/SKILL.md
@@ -57,7 +57,7 @@ See `references/marketplace-schema.md` for the full schema. Key conventions:
 - **Versioning**: `plugin-groups.json` `metadata.version` tracks both marketplace versions using semver
 - **Codex marketplace**: generated at `.agents/plugins/marketplace.json`
 - **Claude marketplace**: generated at `.claude-plugin/marketplace.json`
-- **Commands**: legacy command shims stay Claude-only; portable workflows should be skills
+- **Commands**: command shims may be used for explicit Codex and Claude slash-command entrypoints; portable workflows should still be skills
 
 ## Key references
 |File|What it covers|

--- a/plugins/skill-creation/skills/publishing/references/marketplace-schema.md
+++ b/plugins/skill-creation/skills/publishing/references/marketplace-schema.md
@@ -44,7 +44,7 @@ Plugin group fields:
 |`shortDescription`|Yes|Codex short display copy|
 |`category`|Yes|Install-surface category|
 |`skills`|Yes|Skill directory names owned by this plugin under `plugins/<name>/skills/`|
-|`commands`|No|Claude-only legacy command shims under `plugins/<name>/commands/*.md`|
+|`commands`|No|Command shims under `plugins/<name>/commands/*.md` for explicit slash-command entrypoints|
 |`author`|Yes|Plugin author metadata|
 |`keywords`|No|Discovery tags|
 
@@ -132,7 +132,7 @@ Generated at `plugins/<name>/.claude-plugin/plugin.json`:
 }
 ```
 
-Commands are included only in Claude plugin manifests. New portable workflows should be authored as skills.
+Commands are included in Claude plugin manifests and kept under the plugin `commands/` directory for Codex. New portable workflows should still be authored as skills.
 
 ## Direct skill installation
 Direct skill consumers can install from the plugin-owned skill tree:

--- a/scripts/marketplace.ts
+++ b/scripts/marketplace.ts
@@ -340,7 +340,7 @@ function marketplaceSource(metadata: PluginGroups["metadata"]): string {
 
 function pluginReadme(group: PluginGroup, marketplaceName: string, source: string, readmeBody = ""): string {
 	const commandNote = group.commands?.length
-		? `\nClaude Code also exposes legacy command shims for this plugin: ${group.commands.map((c) => `\`/${group.name}:${c}\``).join(", ")}. Prefer the portable skills above for Codex and other agents.\n`
+		? `\nCodex and Claude Code also expose command shims for this plugin: ${group.commands.map((c) => `\`/${group.name}:${c}\``).join(", ")}. Prefer the portable skills above for automatic loading.\n`
 		: "";
 	const body = readmeBody.trim();
 	const bodySection = body ? `\n${body}\n` : "";


### PR DESCRIPTION
## Summary

Adds `github:preparing-prs-to-merge`, a GitHub skill for taking only a PR number and working through the merge-readiness checklist.

- Checks out the PR and protects local work before touching the branch.
- Covers base-branch sync, conflict handling, local validation, CI watching, review state, unresolved conversations, and final blocker reporting.
- Regenerates the GitHub plugin manifests, marketplace entry, and README so the skill is published with the plugin.

## Test plan

- [x] `bun run marketplace:write`
- [x] `bun run marketplace`
- [x] `bun run check`
- [x] `git diff --check`

## Deploy notes

The live Codex skill link was refreshed with `bun scripts/install-skills.ts --target codex --symlink --force github:preparing-prs-to-merge`.