### PR TITLE
Add AGENTS.md as canonical agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Skills of Luca
+Reusable Agent Skills for Codex, Claude Code, and other agents that understand the open `SKILL.md` format.
+
+## Repository Layout
+|Path|Purpose|
+|---|---|
+|`plugins/<name>/skills/<skill-name>/`|Authored skill source for that plugin. Edit these files first.|
+|`plugin-groups.json`|Defines plugin metadata and the skills owned by each plugin.|
+|`plugins/<name>/.codex-plugin/plugin.json`|Generated Codex plugin manifest.|
+|`plugins/<name>/.claude-plugin/plugin.json`|Generated Claude Code plugin manifest.|
+|`.agents/plugins/marketplace.json`|Generated Codex marketplace.|
+|`.claude-plugin/marketplace.json`|Generated Claude Code marketplace.|
+
+The `plugins/` tree is committed because it is both the installable package tree and the authored skill source. Generated files are limited to plugin manifests, marketplaces, and plugin READMEs.
+
+## Development Workflow
+- Edit authored skill content under `plugins/<plugin>/skills/<skill-name>/`.
+- Update `plugin-groups.json` when plugin membership, plugin metadata, commands, or skill ownership changes.
+- Run `bun run marketplace:write` after changing plugin membership, skill metadata, plugin README source, command lists, or anything that affects generated manifests or marketplaces.
+- Run `bun run marketplace` after generation; it should report everything up to date.
+- Run `bun run check` before finishing docs or skill changes.
+
+Useful commands:
+
+```bash
+bun run check
+bun run check:fix
+bun run marketplace
+bun run marketplace:write
+```
+
+`bun run check` validates token and structure expectations for Markdown skills and docs. `bun run check:fix` applies safe Markdown compaction only; use it deliberately and review the diff.
+
+## Generated Artifacts
+- Do not hand-edit generated plugin manifests, generated plugin READMEs, or marketplace JSON unless the generator is being changed.
+- If generated files are stale, update the source files first, then run `bun run marketplace:write`.
+- Keep generated output committed when the source change requires it.
+- `bun run marketplace` is the dry-run validation that confirms generated artifacts match the sources.
+
+## Skill Authoring Rules
+- Keep `SKILL.md` files close to the open Agent Skills spec: concise frontmatter, clear trigger language, and agent-readable workflow steps.
+- Put reusable supporting material under the skill's own directory, usually in `references/` or `scripts/`, and load it progressively from `SKILL.md`.
+- Keep product-specific behavior in generated plugin manifests or product-specific metadata where possible.
+- A skill belongs to exactly one plugin. Cross-plugin workflows should reference the other skill by name instead of copying its files.
+- Prefer compact, concrete instructions over broad policy text. The check script flags large context-injected files because `SKILL.md` content is loaded when a skill triggers.
+
+## Install Notes
+Codex reads `.agents/plugins/marketplace.json`, then loads plugin manifests from `plugins/<name>/.codex-plugin/plugin.json`.
+
+Claude Code reads `.claude-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.claude-plugin/plugin.json`. Claude-only legacy command shims live under `plugins/<name>/commands/`; prefer skills for portable workflows.
+
+Direct local skill installs are available for personal skills directories:
+
+```bash
+bun run install:codex-skills -- creating-commits creating-prs
+bun run install:claude-skills -- creating-commits creating-prs
+```
+
+Omit skill names to install every skill. Add `--symlink` for local development and `--force` to replace existing installed skills. Skill names can be plain (`creating-commits`) or plugin-qualified (`git:creating-commits`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,36 +1,8 @@
 # Skills of Luca
-Reusable Agent Skills for Codex, Claude Code, and other agents that understand the open `SKILL.md` format.
+This repo uses `AGENTS.md` as the canonical agent guide. Read it first for layout, generated-file rules, skill authoring constraints, and validation commands.
 
-## Layout
-|Path|Purpose|
-|---|---|
-|`plugins/<name>/skills/<skill-name>/`|Authored skill source for that plugin. Edit these files first.|
-|`plugin-groups.json`|Defines plugin metadata and the skills owned by each plugin.|
-|`plugins/<name>/.codex-plugin/plugin.json`|Generated Codex plugin manifest.|
-|`plugins/<name>/.claude-plugin/plugin.json`|Generated Claude Code plugin manifest.|
-|`.agents/plugins/marketplace.json`|Generated Codex marketplace.|
-|`.claude-plugin/marketplace.json`|Generated Claude Code marketplace.|
-
-The `plugins/` tree is committed because it is the installable package tree and the authored skill source. Generated files are limited to manifests, marketplaces, and plugin READMEs.
-
-## Install
-### Codex
-Add the marketplace, then install plugins from the Codex plugin directory:
-
-```bash
-codex plugin marketplace add lucasilverentand/skills
-```
-
-For local development:
-
-```bash
-codex plugin marketplace add ./path/to/skills
-```
-
-Codex reads `.agents/plugins/marketplace.json`, then loads plugin manifests from `plugins/<name>/.codex-plugin/plugin.json`.
-
-### Claude Code
-Add the marketplace and install a plugin:
+## Claude Code Notes
+Add the marketplace and install a plugin with Claude Code slash commands:
 
 ```text
 /plugin marketplace add lucasilverentand/skills
@@ -38,42 +10,3 @@ Add the marketplace and install a plugin:
 ```
 
 Claude Code reads `.claude-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.claude-plugin/plugin.json`. Claude-only legacy command shims live under `plugins/<name>/commands/`; prefer skills for portable workflows.
-
-### Direct Skills
-Install plugin-owned skills directly into a personal skills directory:
-
-```bash
-bun run install:codex-skills -- creating-commits creating-prs
-bun run install:claude-skills -- creating-commits creating-prs
-```
-
-Omit skill names to install every skill. Add `--symlink` for local development and `--force` to replace existing installed skills. Skill names can be plain (`creating-commits`) or plugin-qualified (`git:creating-commits`).
-
-## Development
-- `bun run check` — token and structure check for Markdown skills and docs
-- `bun run check:fix` — apply safe Markdown compaction
-- `bun run marketplace` — dry-run generator and validation
-- `bun run marketplace:write` — regenerate plugin manifests, plugin READMEs, and both marketplaces
-
-Workflow:
-
-1. Edit `plugins/<plugin>/skills/<skill-name>/`.
-2. Update `plugin-groups.json` if plugin membership changes.
-3. Run `bun run marketplace:write`.
-4. Run `bun run marketplace`; it should report everything up to date.
-5. Run `bun run check`.
-
-## Plugin Bundles
-- `apple-design` — Apple HIG guidance by platform
-- `documentation` — C4 diagrams, decision trees, ADRs, design docs
-- `frontend` — interactive design option prototypes
-- `git` — commits, repo cleanup, conflict resolution
-- `github` — pull requests and CI monitoring
-- `project` — project context and requirements
-- `skill-creation` — skill authoring, publishing, tooling, retrospectives
-- `systems-design` — requirements through architecture, data modeling, API design, docs, diagrams, ADRs, and review
-
-## Notes for Agents
-- Use `plugins/<name>/skills/` as the source of truth.
-- Keep `SKILL.md` files close to the open Agent Skills spec. Put product-specific behavior in generated plugin manifests or product-specific metadata where possible.
-- A skill belongs to exactly one plugin. Cross-plugin workflows should reference the other skill by name instead of copying its files.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ bun run marketplace:write
 bun run marketplace
 bun run check
 ```
+
+Agent and contributor guidance lives in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- add AGENTS.md as the canonical agent guide
- trim CLAUDE.md to Claude Code-specific notes
- add a README pointer to AGENTS.md

## Tests
- bun run marketplace
- bun run check
- git diff --check