### PR TITLE
feat(linear-planner): add pickup work skill

### DIFF
--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -112,7 +112,8 @@
 			"shortDescription": "Create Linear planning projects",
 			"category": "Productivity",
 			"keywords": ["linear", "planning", "projects", "issues"],
-			"skills": ["create-planner-project"],
+			"skills": ["create-planner-project", "pickup-work"],
+			"commands": ["pickup-work"],
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"

--- a/plugins/linear-planner/.claude-plugin/plugin.json
+++ b/plugins/linear-planner/.claude-plugin/plugin.json
@@ -3,7 +3,8 @@
 	"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live.",
 	"version": "1.1.0",
 	"skills": [
-		"./skills/create-planner-project"
+		"./skills/create-planner-project",
+		"./skills/pickup-work"
 	],
 	"author": {
 		"name": "Luca Silverentand",
@@ -17,5 +18,8 @@
 		"planning",
 		"projects",
 		"issues"
+	],
+	"commands": [
+		"./commands/pickup-work.md"
 	]
 }

--- a/plugins/linear-planner/README.md
+++ b/plugins/linear-planner/README.md
@@ -3,6 +3,9 @@ Linear planning workflows for creating real project records from reusable planne
 
 ## Skills
 - `linear-planner:create-planner-project`
+- `linear-planner:pickup-work`
+
+Claude Code also exposes legacy command shims for this plugin: `/linear-planner:pickup-work`. Prefer the portable skills above for Codex and other agents.
 
 ## Install
 Codex:

--- a/plugins/linear-planner/commands/pickup-work.md
+++ b/plugins/linear-planner/commands/pickup-work.md
@@ -1,0 +1,8 @@
+---
+description: Picks up the next actionable Linear issue for the product represented by the current repo
+allowed-tools: Read Bash Glob Grep Edit AskUserQuestion mcp__linear__* mcp__codex_apps__linear__*
+---
+
+Pick up the next actionable Linear issue for the project represented by the current working directory using the `pickup-work` skill.
+
+Use the directory where `/pickup-work` was run as the product context. Let the skill detect the repo and Linear context, choose one issue, assign it to me, move it to an in-progress status, and report the selected issue plus the first implementation step.

--- a/plugins/linear-planner/skills/pickup-work/SKILL.md
+++ b/plugins/linear-planner/skills/pickup-work/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: pickup-work
+description: Picks up the next actionable Linear issue for the product represented by the current repository. Use when the user says "/pickup-work", "pickup work", "pick up an issue", "what should I work on next", or asks to start Linear work from a repo. Use when a local monorepo should be mapped to its Linear product initiative or project before assigning and starting an issue.
+---
+
+# Pickup Work
+Use this skill to choose and reserve the next Linear issue for the product represented by the current working directory.
+
+## Workflow
+1. Run `bun plugins/linear-planner/skills/pickup-work/scripts/detect-linear-context.ts` from the skills repo, passing the user's current working directory as the first argument when needed.
+2. Read the JSON evidence: git root, repo name, remote names, detected Linear URLs, issue IDs, project hints, and initiative/product terms.
+3. Search Linear using the strongest product candidates first. Prefer initiative and project matches over loose issue-title matches.
+4. Fetch the most likely project or initiative, then list candidate issues for that project. If only an initiative is found, search/list issues across its product terms and linked projects.
+5. Prefer issues that are unassigned or assigned to `me`, not blocked, not archived, not completed, and in Todo/Backlog/Suggestion-ready states. Exclude planning-template work unless the repo itself is the planner plugin.
+6. Rank candidates by priority first, then whether the issue is already in the current cycle, then clarity of acceptance criteria, then recency.
+7. Before mutating Linear, confirm the candidate is not blocked by open issues. If the tool output is ambiguous, fetch the issue and its blockers.
+8. Assign the selected issue to `me` and move it to the team's best in-progress state. Use `Started`, `In Progress`, or the closest available in-progress status from the team status list.
+9. Report the issue identifier, title, project, status change, selection rationale, and first concrete implementation step.
+
+## Fallbacks
+- If no confident product match exists, summarize the local evidence and ask for the Linear project or initiative.
+- If no actionable issue exists, say which project was searched and list the reason each close candidate was skipped.
+- If Linear update fails, report the selected issue and the failed mutation separately so the user can retry or update it manually.
+
+## Field rules
+- Treat Linear as the source of truth for assignment and workflow state.
+- Do not create new issues from this workflow.
+- Do not pick completed, canceled, duplicate, archived, blocked, or dependency-only issues.
+- Do not change labels, estimates, due dates, cycles, descriptions, projects, or milestones.
+- Do not assign a different person unless the user explicitly asks.

--- a/plugins/linear-planner/skills/pickup-work/scripts/detect-linear-context.ts
+++ b/plugins/linear-planner/skills/pickup-work/scripts/detect-linear-context.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+type Evidence = {
+	type: "linear-url" | "issue-id" | "project-hint" | "initiative-hint" | "product-hint";
+	value: string;
+	file?: string;
+	line?: number;
+};
+
+type Candidate = {
+	value: string;
+	score: number;
+	reasons: string[];
+};
+
+const startCwd = resolve(process.argv[2] ?? process.cwd());
+const maxFiles = 80;
+const maxBytes = 200_000;
+
+function git(args: string[], cwd: string): string | null {
+	const result = spawnSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	});
+	if (result.status !== 0) return null;
+	return result.stdout.trim() || null;
+}
+
+function unique<T>(values: T[]): T[] {
+	return [...new Set(values)];
+}
+
+function remoteRepoName(remote: string): string | null {
+	const normalized = remote.trim().replace(/\.git$/, "");
+	const match = normalized.match(/[:/]([^/:]+\/[^/]+)$/);
+	if (!match) return null;
+	return match[1].split("/").pop() ?? null;
+}
+
+function titleizeSlug(value: string): string {
+	return value
+		.replace(/[_-]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+		.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function addCandidate(map: Map<string, Candidate>, value: string, score: number, reason: string) {
+	const cleaned = value.trim();
+	if (!cleaned) return;
+	const key = cleaned.toLowerCase();
+	const current = map.get(key);
+	if (current) {
+		current.score += score;
+		current.reasons.push(reason);
+		return;
+	}
+	map.set(key, { value: cleaned, score, reasons: [reason] });
+}
+
+function isIgnoredDir(name: string): boolean {
+	return [
+		".git",
+		"node_modules",
+		"vendor",
+		"dist",
+		"build",
+		"coverage",
+		".next",
+		".nuxt",
+		".cache",
+		"target",
+		".turbo",
+	].includes(name);
+}
+
+function shouldScanFile(path: string): boolean {
+	const lower = path.toLowerCase();
+	return [
+		"readme",
+		"linear",
+		"context",
+		"agent",
+		"agents",
+		"claude",
+		"codex",
+		"project",
+		"product",
+		"planning",
+		"roadmap",
+		"spec",
+		"brief",
+		"adr",
+		"docs",
+		"document",
+	].some((part) => lower.includes(part));
+}
+
+function collectFiles(root: string): string[] {
+	const files: string[] = [];
+	const stack = [root];
+
+	while (stack.length && files.length < maxFiles) {
+		const dir = stack.pop()!;
+		let entries;
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+
+		for (const entry of entries) {
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				if (!isIgnoredDir(entry.name)) stack.push(path);
+				continue;
+			}
+			if (!entry.isFile() || !shouldScanFile(path)) continue;
+			try {
+				if (statSync(path).size <= maxBytes) files.push(path);
+			} catch {
+				continue;
+			}
+			if (files.length >= maxFiles) break;
+		}
+	}
+
+	return files;
+}
+
+const gitRoot = git(["rev-parse", "--show-toplevel"], startCwd);
+const root = gitRoot ?? startCwd;
+const repoName = basename(root);
+const remoteLines = git(["remote", "-v"], root)?.split("\n").filter(Boolean) ?? [];
+const remotes = unique(remoteLines.map((line) => line.split(/\s+/)[1]).filter(Boolean));
+const remoteRepoNames = unique(remotes.map(remoteRepoName).filter((name): name is string => Boolean(name)));
+
+const evidence: Evidence[] = [];
+const candidates = new Map<string, Candidate>();
+
+addCandidate(candidates, repoName, 10, "repository directory name");
+addCandidate(candidates, titleizeSlug(repoName), 8, "titleized repository directory name");
+for (const name of remoteRepoNames) {
+	addCandidate(candidates, name, 12, "git remote repository name");
+	addCandidate(candidates, titleizeSlug(name), 9, "titleized git remote repository name");
+}
+
+const linearUrl = /https?:\/\/(?:[a-z0-9-]+\.)?linear\.app\/[^\s)>"']+/gi;
+const issueId = /\b[A-Z][A-Z0-9]+-\d+\b/g;
+const namedHint = /^\s*(?:[-*]\s*)?(?:Linear\s+)?(project|initiative|product)(?:\s+(?:name|slug|url|id))?\s*[:=]\s*([A-Za-z0-9][A-Za-z0-9 _./-]{1,80})/i;
+const nonIssuePrefixes = new Set(["SHA", "UTF", "ISO", "RFC", "HTTP", "TLS"]);
+
+for (const file of collectFiles(root)) {
+	let content;
+	try {
+		content = readFileSync(file, "utf8");
+	} catch {
+		continue;
+	}
+	const relFile = file.startsWith(root) ? file.slice(root.length + 1) : file;
+	const lines = content.split("\n");
+
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		for (const match of line.matchAll(linearUrl)) {
+			evidence.push({ type: "linear-url", value: match[0], file: relFile, line: index + 1 });
+			addCandidate(candidates, match[0], 5, `Linear URL in ${relFile}:${index + 1}`);
+		}
+		for (const match of line.matchAll(issueId)) {
+			const prefix = match[0].split("-")[0];
+			if (nonIssuePrefixes.has(prefix)) continue;
+			evidence.push({ type: "issue-id", value: match[0], file: relFile, line: index + 1 });
+		}
+		const hint = line.match(namedHint);
+		if (hint) {
+			const hintType = `${hint[1].toLowerCase()}-hint` as Evidence["type"];
+			const value = hint[2].replace(/[.,;:]$/, "").trim();
+			evidence.push({ type: hintType, value, file: relFile, line: index + 1 });
+			addCandidate(candidates, value, hint[1].toLowerCase() === "product" ? 9 : 11, `${hint[1]} hint in ${relFile}:${index + 1}`);
+		}
+	}
+}
+
+const output = {
+	cwd: startCwd,
+	gitRoot,
+	repoName,
+	remotes,
+	remoteRepoNames,
+	candidates: [...candidates.values()]
+		.sort((a, b) => b.score - a.score || a.value.localeCompare(b.value))
+		.slice(0, 20),
+	evidence: evidence.slice(0, 80),
+};
+
+process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);


### PR DESCRIPTION
## Summary

Adds a Linear pickup workflow for choosing the next actionable issue from the repo context where the command is run.

- Add a `linear-planner:pickup-work` skill with issue selection, assignment, status update, and fallback rules.
- Add a read-only detector script that extracts repo, remote, Linear URL, issue ID, project, initiative, and product evidence.
- Add a `/pickup-work` command shim and refresh the Linear plugin manifest/readme.

## Test plan

- [x] `bun run check`
- [x] `bun run marketplace`
- [x] Smoke-test detector against this repo
- [x] Smoke-test detector against a temporary repo with fake Linear hints
