### PR TITLE
Add Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,10 @@ bun run install:claude-skills -- creating-commits creating-prs
 ```
 
 Omit skill names to install every skill. Add `--symlink` for local development and `--force` to replace existing installed skills. Skill names can be plain (`creating-commits`) or plugin-qualified (`git:creating-commits`).
+
+## Cursor Cloud specific instructions
+- **Runtime**: Bun is the sole runtime dependency. There are no `node_modules`, no lockfile, and no npm/yarn/pnpm usage. The update script ensures Bun is installed and on `PATH`.
+- **No services to start**: This is a content-only repo (Markdown skills + TypeScript validation scripts). There are no servers, databases, or Docker containers.
+- **Validation commands** are documented in the Development Workflow section above. After any skill or metadata change, run `bun run marketplace:write` then `bun run marketplace` then `bun run check`.
+- **`bun run check` exit codes**: exit 0 means pass (warnings are informational only). Exit 1 means there are errors that must be fixed.
+- **Generated plugin READMEs**: `marketplace:write` regenerates `plugins/*/README.md` files. If your diff includes only these generated files, that is expected—commit them alongside source changes.

--- a/plugins/linear-planner/README.md
+++ b/plugins/linear-planner/README.md
@@ -6,7 +6,7 @@ Linear planning workflows for creating real project records from reusable planne
 - `linear-planner:estimate-issue-complexity`
 - `linear-planner:pickup-work`
 
-Claude Code also exposes legacy command shims for this plugin: `/linear-planner:pickup-work`. Prefer the portable skills above for Codex and other agents.
+Codex and Claude Code also expose command shims for this plugin: `/linear-planner:pickup-work`. Prefer the portable skills above for automatic loading.
 
 ## Install
 Codex:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Cursor Cloud specific instructions to `AGENTS.md` and refreshes a stale generated README.

### Changes
- **`AGENTS.md`**: Added `## Cursor Cloud specific instructions` section with runtime info, validation workflow notes, and exit-code semantics for `bun run check`.
- **`plugins/linear-planner/README.md`**: Regenerated by `bun run marketplace:write` to fix stale command-shim wording.

### Validation
All four dev commands pass:
- `bun run marketplace` — "Everything up to date"
- `bun run check` — exit 0, warnings only
- `bun run marketplace:write` — generated artifacts updated
- `bun run install:codex-skills -- creating-commits creating-prs` — skills installed successfully

[marketplace_output.log](https://cursor.com/agents/bc-1135442e-5989-4bbe-9e89-ec12b50f1e9f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmarketplace_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1135442e-5989-4bbe-9e89-ec12b50f1e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1135442e-5989-4bbe-9e89-ec12b50f1e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

