### PR TITLE
Add Cursor marketplace and align with team template

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,6 +2,7 @@
 	"name": "skills-of-luca",
 	"owner": {
 		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com",
 		"url": "https://github.com/lucasilverentand"
 	},
 	"description": "Reusable agent skills by Luca Silverentand.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,189 +1,65 @@
 {
 	"name": "skills-of-luca",
+	"displayName": "Skills of Luca",
 	"owner": {
 		"name": "Luca Silverentand",
-		"url": "https://github.com/lucasilverentand"
+		"email": "dev@lucasilverentand.com"
 	},
 	"metadata": {
 		"description": "Reusable agent skills by Luca Silverentand.",
 		"version": "1.1.0",
-		"homepage": "https://github.com/lucasilverentand/skills",
-		"repository": "https://github.com/lucasilverentand/skills",
-		"license": "MIT"
+		"pluginRoot": "plugins"
 	},
 	"plugins": [
 		{
 			"name": "apple-design",
-			"source": "./plugins/apple-design",
-			"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "luca.silverentand@gmail.com"
-			},
-			"category": "Design",
-			"keywords": [
-				"apple",
-				"design",
-				"hig",
-				"ios",
-				"macos",
-				"visionos"
-			]
+			"source": "apple-design",
+			"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform."
 		},
 		{
 			"name": "documentation",
-			"source": "./plugins/documentation",
-			"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Documentation",
-			"keywords": [
-				"documentation",
-				"adr",
-				"c4",
-				"decision-tree"
-			]
+			"source": "documentation",
+			"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees."
 		},
 		{
 			"name": "frontend",
-			"source": "./plugins/frontend",
-			"description": "Frontend design exploration toolkit for interactive HTML design options.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Development",
-			"keywords": [
-				"frontend",
-				"design",
-				"ui",
-				"prototype"
-			]
+			"source": "frontend",
+			"description": "Frontend design exploration toolkit for interactive HTML design options."
 		},
 		{
 			"name": "git",
-			"source": "./plugins/git",
-			"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Development",
-			"keywords": [
-				"git",
-				"commits",
-				"rebase",
-				"conflicts"
-			]
+			"source": "git",
+			"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup."
 		},
 		{
 			"name": "github",
-			"source": "./plugins/github",
-			"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Development",
-			"keywords": [
-				"github",
-				"pull-request",
-				"ci",
-				"merge-readiness"
-			]
+			"source": "github",
+			"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge."
 		},
 		{
 			"name": "linear-planner",
-			"source": "./plugins/linear-planner",
-			"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Productivity",
-			"keywords": [
-				"linear",
-				"planning",
-				"projects",
-				"issues"
-			]
+			"source": "linear-planner",
+			"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live."
 		},
 		{
 			"name": "project",
-			"source": "./plugins/project",
-			"description": "Project setup and context management skills for requirements and shared agent context.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Development",
-			"keywords": [
-				"project",
-				"requirements",
-				"context"
-			]
+			"source": "project",
+			"description": "Project setup and context management skills for requirements and shared agent context."
 		},
 		{
 			"name": "project-docs",
-			"source": "./plugins/project-docs",
-			"description": "Project document templates with one authoring skill for briefs, specs, designs, decisions, release checks, and reviews.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Documentation",
-			"keywords": [
-				"project-docs",
-				"templates",
-				"briefs",
-				"specs",
-				"designs",
-				"release-readiness"
-			]
+			"source": "project-docs",
+			"description": "Project document templates with one authoring skill for briefs, specs, designs, decisions, release checks, and reviews."
 		},
 		{
 			"name": "skill-creation",
-			"source": "./plugins/skill-creation",
-			"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Development",
-			"keywords": [
-				"skills",
-				"authoring",
-				"publishing",
-				"tooling"
-			]
+			"source": "skill-creation",
+			"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills."
 		},
 		{
 			"name": "systems-design",
-			"source": "./plugins/systems-design",
-			"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
-			"version": "1.1.0",
-			"author": {
-				"name": "Luca Silverentand",
-				"email": "dev@lucasilverentand.com"
-			},
-			"category": "Architecture",
-			"keywords": [
-				"architecture",
-				"api",
-				"database",
-				"design-review"
-			]
+			"source": "systems-design",
+			"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review."
 		}
 	]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,189 @@
+{
+	"name": "skills-of-luca",
+	"owner": {
+		"name": "Luca Silverentand",
+		"url": "https://github.com/lucasilverentand"
+	},
+	"metadata": {
+		"description": "Reusable agent skills by Luca Silverentand.",
+		"version": "1.1.0",
+		"homepage": "https://github.com/lucasilverentand/skills",
+		"repository": "https://github.com/lucasilverentand/skills",
+		"license": "MIT"
+	},
+	"plugins": [
+		{
+			"name": "apple-design",
+			"source": "./plugins/apple-design",
+			"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "luca.silverentand@gmail.com"
+			},
+			"category": "Design",
+			"keywords": [
+				"apple",
+				"design",
+				"hig",
+				"ios",
+				"macos",
+				"visionos"
+			]
+		},
+		{
+			"name": "documentation",
+			"source": "./plugins/documentation",
+			"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Documentation",
+			"keywords": [
+				"documentation",
+				"adr",
+				"c4",
+				"decision-tree"
+			]
+		},
+		{
+			"name": "frontend",
+			"source": "./plugins/frontend",
+			"description": "Frontend design exploration toolkit for interactive HTML design options.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Development",
+			"keywords": [
+				"frontend",
+				"design",
+				"ui",
+				"prototype"
+			]
+		},
+		{
+			"name": "git",
+			"source": "./plugins/git",
+			"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Development",
+			"keywords": [
+				"git",
+				"commits",
+				"rebase",
+				"conflicts"
+			]
+		},
+		{
+			"name": "github",
+			"source": "./plugins/github",
+			"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Development",
+			"keywords": [
+				"github",
+				"pull-request",
+				"ci",
+				"merge-readiness"
+			]
+		},
+		{
+			"name": "linear-planner",
+			"source": "./plugins/linear-planner",
+			"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Productivity",
+			"keywords": [
+				"linear",
+				"planning",
+				"projects",
+				"issues"
+			]
+		},
+		{
+			"name": "project",
+			"source": "./plugins/project",
+			"description": "Project setup and context management skills for requirements and shared agent context.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Development",
+			"keywords": [
+				"project",
+				"requirements",
+				"context"
+			]
+		},
+		{
+			"name": "project-docs",
+			"source": "./plugins/project-docs",
+			"description": "Project document templates with one authoring skill for briefs, specs, designs, decisions, release checks, and reviews.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Documentation",
+			"keywords": [
+				"project-docs",
+				"templates",
+				"briefs",
+				"specs",
+				"designs",
+				"release-readiness"
+			]
+		},
+		{
+			"name": "skill-creation",
+			"source": "./plugins/skill-creation",
+			"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Development",
+			"keywords": [
+				"skills",
+				"authoring",
+				"publishing",
+				"tooling"
+			]
+		},
+		{
+			"name": "systems-design",
+			"source": "./plugins/systems-design",
+			"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Architecture",
+			"keywords": [
+				"architecture",
+				"api",
+				"database",
+				"design-review"
+			]
+		}
+	]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # Skills of Luca
-Reusable Agent Skills for Codex, Claude Code, and other agents that understand the open `SKILL.md` format.
+Reusable Agent Skills for Codex, Claude Code, Cursor, and other agents that understand the open `SKILL.md` format.
 
 ## Repository Layout
 |Path|Purpose|
@@ -8,8 +8,10 @@ Reusable Agent Skills for Codex, Claude Code, and other agents that understand t
 |`plugin-groups.json`|Defines plugin metadata and the skills owned by each plugin.|
 |`plugins/<name>/.codex-plugin/plugin.json`|Generated Codex plugin manifest.|
 |`plugins/<name>/.claude-plugin/plugin.json`|Generated Claude Code plugin manifest.|
+|`plugins/<name>/.cursor-plugin/plugin.json`|Generated Cursor plugin manifest.|
 |`.agents/plugins/marketplace.json`|Generated Codex marketplace.|
 |`.claude-plugin/marketplace.json`|Generated Claude Code marketplace.|
+|`.cursor-plugin/marketplace.json`|Generated Cursor marketplace.|
 
 The `plugins/` tree is committed because it is both the installable package tree and the authored skill source. Generated files are limited to plugin manifests, marketplaces, and plugin READMEs.
 
@@ -48,6 +50,8 @@ bun run marketplace:write
 Codex reads `.agents/plugins/marketplace.json`, then loads plugin manifests from `plugins/<name>/.codex-plugin/plugin.json`.
 
 Claude Code reads `.claude-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.claude-plugin/plugin.json`. Claude-only legacy command shims live under `plugins/<name>/commands/`; prefer skills for portable workflows.
+
+Cursor reads `.cursor-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.cursor-plugin/plugin.json`. Command shims under `plugins/<name>/commands/` are also available in Cursor plugins; prefer skills for portable workflows.
 
 Direct local skill installs are available for personal skills directories:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Codex reads `.agents/plugins/marketplace.json`, then loads plugin manifests from
 
 Claude Code reads `.claude-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.claude-plugin/plugin.json`. Claude-only legacy command shims live under `plugins/<name>/commands/`; prefer skills for portable workflows.
 
-Cursor reads `.cursor-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.cursor-plugin/plugin.json`. Command shims under `plugins/<name>/commands/` are also available in Cursor plugins; prefer skills for portable workflows.
+Cursor reads `.cursor-plugin/marketplace.json` (team-marketplace layout with `metadata.pluginRoot: "plugins"`), then loads plugin manifests from `plugins/<name>/.cursor-plugin/plugin.json`. Skills and commands are folder-discovered; prefer skills for portable workflows. Run `bun run validate:cursor` before publishing Cursor marketplace changes.
 
 Direct local skill installs are available for personal skills directories:
 

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -1,0 +1,14 @@
+# Skills of Luca
+This repo uses `AGENTS.md` as the canonical agent guide. Read it first for layout, generated-file rules, skill authoring constraints, and validation commands.
+
+## Cursor Notes
+Add the marketplace and install a plugin with Cursor slash commands:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install git@skills-of-luca
+```
+
+Cursor reads `.cursor-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.cursor-plugin/plugin.json`. Command shims under `plugins/<name>/commands/` are available in Cursor plugins; prefer skills for portable workflows.
+
+To submit this marketplace to the official Cursor catalog, see [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -2,13 +2,26 @@
 This repo uses `AGENTS.md` as the canonical agent guide. Read it first for layout, generated-file rules, skill authoring constraints, and validation commands.
 
 ## Cursor Notes
-Add the marketplace and install a plugin with Cursor slash commands:
 
+### Team marketplace (recommended)
+Matches the [cursor-team-marketplace-template](https://github.com/fieldsphere/cursor-team-marketplace-template) layout (`metadata.pluginRoot`, lean manifests).
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Mark each plugin **Required** or **Optional**
+
+### IDE slash commands
 ```text
 /plugin marketplace add lucasilverentand/skills
 /plugin install git@skills-of-luca
 ```
 
-Cursor reads `.cursor-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.cursor-plugin/plugin.json`. Command shims under `plugins/<name>/commands/` are available in Cursor plugins; prefer skills for portable workflows.
+Cursor reads `.cursor-plugin/marketplace.json`, then loads plugin manifests from `plugins/<name>/.cursor-plugin/plugin.json`. Skills and commands are discovered from each plugin's `skills/` and `commands/` directories; prefer skills for portable workflows.
 
-To submit this marketplace to the official Cursor catalog, see [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).
+Validate before publishing:
+
+```bash
+bun run validate:cursor
+```
+
+To submit to the official Cursor catalog, see [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Skills of Luca
-Reusable Agent Skills for Codex, Claude Code, and other agents that understand the open `SKILL.md` format.
+Reusable Agent Skills for Codex, Claude Code, Cursor, and other agents that understand the open `SKILL.md` format.
 
-Each plugin is the source of truth for its own skills under `plugins/<plugin>/skills/<skill>/`. The repo publishes both Codex and Claude Code marketplaces from those plugin packages.
+Each plugin is the source of truth for its own skills under `plugins/<plugin>/skills/<skill>/`. The repo publishes Codex, Claude Code, and Cursor marketplaces from those plugin packages.
 
 ## Install
 Codex:
@@ -11,6 +11,13 @@ codex plugin marketplace add lucasilverentand/skills
 ```
 
 Claude Code:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install git@skills-of-luca
+```
+
+Cursor:
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Claude Code:
 /plugin install git@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install plugins as Required or Optional
+
+Cursor (IDE):
 
 ```text
 /plugin marketplace add lucasilverentand/skills
@@ -37,6 +43,7 @@ Edit `plugins/<plugin>/skills/`, update `plugin-groups.json` when plugin members
 ```bash
 bun run marketplace:write
 bun run marketplace
+bun run validate:cursor
 bun run check
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"install:claude-skills": "bun scripts/install-skills.ts --target claude",
 		"install:codex-skills": "bun scripts/install-skills.ts --target codex",
 		"marketplace": "bun scripts/marketplace.ts",
-		"marketplace:write": "bun scripts/marketplace.ts --write"
+		"marketplace:write": "bun scripts/marketplace.ts --write",
+		"validate:cursor": "bun scripts/validate-cursor-marketplace.ts"
 	}
 }

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -2,6 +2,7 @@
 	"name": "skills-of-luca",
 	"owner": {
 		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com",
 		"url": "https://github.com/lucasilverentand"
 	},
 	"metadata": {

--- a/plugins/apple-design/.cursor-plugin/plugin.json
+++ b/plugins/apple-design/.cursor-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+	"name": "apple-design",
+	"displayName": "Apple Design",
+	"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "luca.silverentand@gmail.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"apple",
+		"design",
+		"hig",
+		"ios",
+		"macos",
+		"visionos"
+	],
+	"category": "Design",
+	"skills": "./skills/"
+}

--- a/plugins/apple-design/.cursor-plugin/plugin.json
+++ b/plugins/apple-design/.cursor-plugin/plugin.json
@@ -1,14 +1,12 @@
 {
 	"name": "apple-design",
 	"displayName": "Apple Design",
-	"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
 	"version": "1.1.0",
+	"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "luca.silverentand@gmail.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"apple",
@@ -17,7 +15,5 @@
 		"ios",
 		"macos",
 		"visionos"
-	],
-	"category": "Design",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/apple-design/README.md
+++ b/plugins/apple-design/README.md
@@ -24,7 +24,13 @@ Claude Code:
 /plugin install apple-design@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `apple-design` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/apple-design/README.md
+++ b/plugins/apple-design/README.md
@@ -24,4 +24,11 @@ Claude Code:
 /plugin install apple-design@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install apple-design@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/apple-design/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/documentation/.cursor-plugin/plugin.json
+++ b/plugins/documentation/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+	"name": "documentation",
+	"displayName": "Documentation",
+	"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"documentation",
+		"adr",
+		"c4",
+		"decision-tree"
+	],
+	"category": "Documentation",
+	"skills": "./skills/"
+}

--- a/plugins/documentation/.cursor-plugin/plugin.json
+++ b/plugins/documentation/.cursor-plugin/plugin.json
@@ -1,21 +1,17 @@
 {
 	"name": "documentation",
 	"displayName": "Documentation",
-	"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
 	"version": "1.1.0",
+	"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"documentation",
 		"adr",
 		"c4",
 		"decision-tree"
-	],
-	"category": "Documentation",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/documentation/README.md
+++ b/plugins/documentation/README.md
@@ -21,4 +21,11 @@ Claude Code:
 /plugin install documentation@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install documentation@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/documentation/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/documentation/README.md
+++ b/plugins/documentation/README.md
@@ -21,7 +21,13 @@ Claude Code:
 /plugin install documentation@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `documentation` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/frontend/.cursor-plugin/plugin.json
+++ b/plugins/frontend/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+	"name": "frontend",
+	"displayName": "Frontend",
+	"description": "Frontend design exploration toolkit for interactive HTML design options.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"frontend",
+		"design",
+		"ui",
+		"prototype"
+	],
+	"category": "Development",
+	"skills": "./skills/"
+}

--- a/plugins/frontend/.cursor-plugin/plugin.json
+++ b/plugins/frontend/.cursor-plugin/plugin.json
@@ -1,21 +1,17 @@
 {
 	"name": "frontend",
 	"displayName": "Frontend",
-	"description": "Frontend design exploration toolkit for interactive HTML design options.",
 	"version": "1.1.0",
+	"description": "Frontend design exploration toolkit for interactive HTML design options.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"frontend",
 		"design",
 		"ui",
 		"prototype"
-	],
-	"category": "Development",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/frontend/README.md
+++ b/plugins/frontend/README.md
@@ -18,7 +18,13 @@ Claude Code:
 /plugin install frontend@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `frontend` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/frontend/README.md
+++ b/plugins/frontend/README.md
@@ -18,4 +18,11 @@ Claude Code:
 /plugin install frontend@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install frontend@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/frontend/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/git/.cursor-plugin/plugin.json
+++ b/plugins/git/.cursor-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+	"name": "git",
+	"displayName": "Git",
+	"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"git",
+		"commits",
+		"rebase",
+		"conflicts"
+	],
+	"category": "Development",
+	"skills": "./skills/",
+	"commands": [
+		"./commands/clean-repo.md",
+		"./commands/create-commit.md",
+		"./commands/rebase.md"
+	]
+}

--- a/plugins/git/.cursor-plugin/plugin.json
+++ b/plugins/git/.cursor-plugin/plugin.json
@@ -1,26 +1,17 @@
 {
 	"name": "git",
 	"displayName": "Git",
-	"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
 	"version": "1.1.0",
+	"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"git",
 		"commits",
 		"rebase",
 		"conflicts"
-	],
-	"category": "Development",
-	"skills": "./skills/",
-	"commands": [
-		"./commands/clean-repo.md",
-		"./commands/create-commit.md",
-		"./commands/rebase.md"
 	]
 }

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -22,7 +22,13 @@ Claude Code:
 /plugin install git@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `git` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -22,4 +22,11 @@ Claude Code:
 /plugin install git@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install git@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/git/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/github/.cursor-plugin/plugin.json
+++ b/plugins/github/.cursor-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+	"name": "github",
+	"displayName": "GitHub",
+	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"github",
+		"pull-request",
+		"ci",
+		"merge-readiness"
+	],
+	"category": "Development",
+	"skills": "./skills/",
+	"commands": [
+		"./commands/ci.md",
+		"./commands/create-draft-pr.md",
+		"./commands/create-pr.md",
+		"./commands/fix-pr.md"
+	]
+}

--- a/plugins/github/.cursor-plugin/plugin.json
+++ b/plugins/github/.cursor-plugin/plugin.json
@@ -1,27 +1,17 @@
 {
 	"name": "github",
 	"displayName": "GitHub",
-	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 	"version": "1.1.0",
+	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"github",
 		"pull-request",
 		"ci",
 		"merge-readiness"
-	],
-	"category": "Development",
-	"skills": "./skills/",
-	"commands": [
-		"./commands/ci.md",
-		"./commands/create-draft-pr.md",
-		"./commands/create-pr.md",
-		"./commands/fix-pr.md"
 	]
 }

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -22,4 +22,11 @@ Claude Code:
 /plugin install github@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install github@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/github/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -22,7 +22,13 @@ Claude Code:
 /plugin install github@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `github` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/linear-planner/.cursor-plugin/plugin.json
+++ b/plugins/linear-planner/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+	"name": "linear-planner",
+	"displayName": "Linear Planner",
+	"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"linear",
+		"planning",
+		"projects",
+		"issues"
+	],
+	"category": "Productivity",
+	"skills": "./skills/",
+	"commands": [
+		"./commands/pickup-work.md"
+	]
+}

--- a/plugins/linear-planner/.cursor-plugin/plugin.json
+++ b/plugins/linear-planner/.cursor-plugin/plugin.json
@@ -1,24 +1,17 @@
 {
 	"name": "linear-planner",
 	"displayName": "Linear Planner",
-	"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live.",
 	"version": "1.1.0",
+	"description": "Linear planning workflows for creating real project records from reusable planner structures without keeping template issues live.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"linear",
 		"planning",
 		"projects",
 		"issues"
-	],
-	"category": "Productivity",
-	"skills": "./skills/",
-	"commands": [
-		"./commands/pickup-work.md"
 	]
 }

--- a/plugins/linear-planner/README.md
+++ b/plugins/linear-planner/README.md
@@ -22,4 +22,11 @@ Claude Code:
 /plugin install linear-planner@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install linear-planner@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/linear-planner/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/linear-planner/README.md
+++ b/plugins/linear-planner/README.md
@@ -22,7 +22,13 @@ Claude Code:
 /plugin install linear-planner@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `linear-planner` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/project-docs/.cursor-plugin/plugin.json
+++ b/plugins/project-docs/.cursor-plugin/plugin.json
@@ -1,14 +1,12 @@
 {
 	"name": "project-docs",
 	"displayName": "Project Docs",
-	"description": "Project document templates with one authoring skill for briefs, specs, designs, decisions, release checks, and reviews.",
 	"version": "1.1.0",
+	"description": "Project document templates with one authoring skill for briefs, specs, designs, decisions, release checks, and reviews.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"project-docs",
@@ -17,7 +15,5 @@
 		"specs",
 		"designs",
 		"release-readiness"
-	],
-	"category": "Documentation",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/project-docs/.cursor-plugin/plugin.json
+++ b/plugins/project-docs/.cursor-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+	"name": "project-docs",
+	"displayName": "Project Docs",
+	"description": "Project document templates with one authoring skill for briefs, specs, designs, decisions, release checks, and reviews.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"project-docs",
+		"templates",
+		"briefs",
+		"specs",
+		"designs",
+		"release-readiness"
+	],
+	"category": "Documentation",
+	"skills": "./skills/"
+}

--- a/plugins/project-docs/README.md
+++ b/plugins/project-docs/README.md
@@ -19,6 +19,13 @@ Claude Code:
 /plugin install project-docs@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install project-docs@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/project-docs/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.
 
 ## Template library

--- a/plugins/project-docs/README.md
+++ b/plugins/project-docs/README.md
@@ -19,7 +19,13 @@ Claude Code:
 /plugin install project-docs@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `project-docs` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/project/.cursor-plugin/plugin.json
+++ b/plugins/project/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+	"name": "project",
+	"displayName": "Project",
+	"description": "Project setup and context management skills for requirements and shared agent context.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"project",
+		"requirements",
+		"context"
+	],
+	"category": "Development",
+	"skills": "./skills/"
+}

--- a/plugins/project/.cursor-plugin/plugin.json
+++ b/plugins/project/.cursor-plugin/plugin.json
@@ -1,20 +1,16 @@
 {
 	"name": "project",
 	"displayName": "Project",
-	"description": "Project setup and context management skills for requirements and shared agent context.",
 	"version": "1.1.0",
+	"description": "Project setup and context management skills for requirements and shared agent context.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"project",
 		"requirements",
 		"context"
-	],
-	"category": "Development",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/project/README.md
+++ b/plugins/project/README.md
@@ -20,4 +20,11 @@ Claude Code:
 /plugin install project@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install project@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/project/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/project/README.md
+++ b/plugins/project/README.md
@@ -20,7 +20,13 @@ Claude Code:
 /plugin install project@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `project` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/skill-creation/.cursor-plugin/plugin.json
+++ b/plugins/skill-creation/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+	"name": "skill-creation",
+	"displayName": "Skill Creation",
+	"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"skills",
+		"authoring",
+		"publishing",
+		"tooling"
+	],
+	"category": "Development",
+	"skills": "./skills/"
+}

--- a/plugins/skill-creation/.cursor-plugin/plugin.json
+++ b/plugins/skill-creation/.cursor-plugin/plugin.json
@@ -1,21 +1,17 @@
 {
 	"name": "skill-creation",
 	"displayName": "Skill Creation",
-	"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
 	"version": "1.1.0",
+	"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"skills",
 		"authoring",
 		"publishing",
 		"tooling"
-	],
-	"category": "Development",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/skill-creation/README.md
+++ b/plugins/skill-creation/README.md
@@ -22,7 +22,13 @@ Claude Code:
 /plugin install skill-creation@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `skill-creation` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/plugins/skill-creation/README.md
+++ b/plugins/skill-creation/README.md
@@ -22,4 +22,11 @@ Claude Code:
 /plugin install skill-creation@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install skill-creation@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/skill-creation/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/skill-creation/skills/publishing/SKILL.md
+++ b/plugins/skill-creation/skills/publishing/SKILL.md
@@ -59,7 +59,8 @@ See `references/marketplace-schema.md` for the full schema. Key conventions:
 - **Versioning**: `plugin-groups.json` `metadata.version` tracks both marketplace versions using semver
 - **Codex marketplace**: generated at `.agents/plugins/marketplace.json`
 - **Claude marketplace**: generated at `.claude-plugin/marketplace.json`
-- **Cursor marketplace**: generated at `.cursor-plugin/marketplace.json`
+- **Cursor marketplace**: generated at `.cursor-plugin/marketplace.json` (team-template layout with `metadata.pluginRoot`)
+- **Cursor validation**: `bun run validate:cursor` after regenerating Cursor artifacts
 - **Commands**: command shims may be used for explicit Codex, Claude, and Cursor slash-command entrypoints; portable workflows should still be skills
 
 ## Key references

--- a/plugins/skill-creation/skills/publishing/SKILL.md
+++ b/plugins/skill-creation/skills/publishing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publishing
-description: Manages dual Codex and Claude Code skill marketplaces — publishes plugin-owned skills, updates plugin groups, removes entries, packages skills for distribution, regenerates plugin manifests, and validates catalog integrity. Use when publishing a skill to the marketplace, bumping a version, removing a skill from the catalog, packaging a skill as a .skill file, regenerating marketplace files, moving a skill between plugins, or fixing marketplace validation errors.
+description: Manages Codex, Claude Code, and Cursor skill marketplaces — publishes plugin-owned skills, updates plugin groups, removes entries, packages skills for distribution, regenerates plugin manifests, and validates catalog integrity. Use when publishing a skill to the marketplace, bumping a version, removing a skill from the catalog, packaging a skill as a .skill file, regenerating marketplace files, moving a skill between plugins, or fixing marketplace validation errors.
 allowed-tools: Read Grep Glob Bash Write Edit
 ---
 
@@ -26,8 +26,10 @@ allowed-tools: Read Grep Glob Bash Write Edit
 4. Run `bun run marketplace:write` to regenerate:
    - `plugins/<name>/.claude-plugin/plugin.json`
    - `plugins/<name>/.codex-plugin/plugin.json`
+   - `plugins/<name>/.cursor-plugin/plugin.json`
    - `plugins/<name>/README.md`
    - `.claude-plugin/marketplace.json`
+   - `.cursor-plugin/marketplace.json`
    - `.agents/plugins/marketplace.json`
 5. Run `bun run marketplace` again; it must report everything up to date
 
@@ -45,7 +47,7 @@ To rebuild plugin manifests and marketplaces from the plugin-owned source tree:
 1. Edit skills under `plugins/<plugin>/skills/`
 2. Edit plugin metadata or skill ownership in `plugin-groups.json`
 3. Run `bun run marketplace:write`
-4. Review the generated diff under plugin manifests, plugin READMEs, `.claude-plugin/`, and `.agents/plugins/`
+4. Review the generated diff under plugin manifests, plugin READMEs, `.claude-plugin/`, `.cursor-plugin/`, and `.agents/plugins/`
 5. Run `bun run marketplace` to confirm no generated files are stale
 
 ## Marketplace conventions
@@ -57,12 +59,13 @@ See `references/marketplace-schema.md` for the full schema. Key conventions:
 - **Versioning**: `plugin-groups.json` `metadata.version` tracks both marketplace versions using semver
 - **Codex marketplace**: generated at `.agents/plugins/marketplace.json`
 - **Claude marketplace**: generated at `.claude-plugin/marketplace.json`
-- **Commands**: command shims may be used for explicit Codex and Claude slash-command entrypoints; portable workflows should still be skills
+- **Cursor marketplace**: generated at `.cursor-plugin/marketplace.json`
+- **Commands**: command shims may be used for explicit Codex, Claude, and Cursor slash-command entrypoints; portable workflows should still be skills
 
 ## Key references
 |File|What it covers|
 |---|---|
-|`references/marketplace-schema.md`|Codex + Claude marketplace schemas, plugin manifests, and source types|
+|`references/marketplace-schema.md`|Codex, Claude, and Cursor marketplace schemas, plugin manifests, and source types|
 |`references/marketplace-errors.md`|Validation error codes and fixes|
 |`plugin-groups.json`|Source of truth for plugin grouping and metadata|
 |`scripts/marketplace.ts`|Regenerates both marketplaces and plugin manifests|

--- a/plugins/skill-creation/skills/publishing/references/marketplace-schema.md
+++ b/plugins/skill-creation/skills/publishing/references/marketplace-schema.md
@@ -137,30 +137,32 @@ Generated at `plugins/<name>/.claude-plugin/plugin.json`:
 Commands are included in Claude plugin manifests and kept under the plugin `commands/` directory for Codex. New portable workflows should still be authored as skills.
 
 ## Cursor marketplace shape
-Generated at `.cursor-plugin/marketplace.json`:
+Generated at `.cursor-plugin/marketplace.json` (aligned with [cursor-team-marketplace-template](https://github.com/fieldsphere/cursor-team-marketplace-template)):
 
 ```json
 {
   "name": "skills-of-luca",
+  "displayName": "Skills of Luca",
   "owner": {
-    "name": "Luca Silverentand"
+    "name": "Luca Silverentand",
+    "email": "dev@lucasilverentand.com"
   },
   "metadata": {
     "description": "Reusable agent skills by Luca Silverentand.",
-    "version": "1.1.0"
+    "version": "1.1.0",
+    "pluginRoot": "plugins"
   },
   "plugins": [
     {
       "name": "git",
-      "source": "./plugins/git",
-      "description": "Git workflow toolkit",
-      "version": "1.1.0"
+      "source": "git",
+      "description": "Git workflow toolkit"
     }
   ]
 }
 ```
 
-Relative plugin sources resolve from the repository root containing `.cursor-plugin/`.
+Plugin `source` values are plugin folder names relative to `metadata.pluginRoot`, not full repo paths like Codex or Claude use. Codex and Claude marketplaces keep their own path conventions.
 
 ## Cursor plugin shape
 Generated at `plugins/<name>/.cursor-plugin/plugin.json`:
@@ -169,15 +171,15 @@ Generated at `plugins/<name>/.cursor-plugin/plugin.json`:
 {
   "name": "git",
   "displayName": "Git",
-  "description": "Git workflow toolkit",
   "version": "1.1.0",
-  "skills": "./skills/",
-  "commands": ["./commands/create-commit.md"],
-  "category": "Development"
+  "description": "Git workflow toolkit",
+  "author": { "name": "Luca Silverentand", "email": "dev@lucasilverentand.com" },
+  "license": "MIT",
+  "keywords": ["git", "commits"]
 }
 ```
 
-Cursor discovers skills under the plugin skills directory when the manifest uses the same skills path as Codex (see the Cursor plugin shape example above). Commands are optional and mirror Claude plugin command paths.
+Cursor discovers `skills/`, `commands/`, `rules/`, and `agents/` by folder; manifests omit explicit component paths. Validate with `bun run validate:cursor`.
 
 ## Direct skill installation
 Direct skill consumers can install from the plugin-owned skill tree:

--- a/plugins/skill-creation/skills/publishing/references/marketplace-schema.md
+++ b/plugins/skill-creation/skills/publishing/references/marketplace-schema.md
@@ -1,5 +1,5 @@
 # Marketplace & Plugin Schema
-This repository has plugin-owned skills and two generated marketplace surfaces.
+This repository has plugin-owned skills and three generated marketplace surfaces.
 
 ## Source of truth
 |Path|Purpose|
@@ -17,6 +17,8 @@ Edit skills in place under their owning plugin. Do not create root-level skill c
 |Codex plugin manifest|`plugins/<name>/.codex-plugin/plugin.json`|Required Codex plugin entry point|
 |Claude marketplace|`.claude-plugin/marketplace.json`|Claude Code plugin catalog|
 |Claude plugin manifest|`plugins/<name>/.claude-plugin/plugin.json`|Claude Code plugin entry point|
+|Cursor marketplace|`.cursor-plugin/marketplace.json`|Cursor plugin catalog|
+|Cursor plugin manifest|`plugins/<name>/.cursor-plugin/plugin.json`|Cursor plugin entry point|
 |Plugin README|`plugins/<name>/README.md`|Generated install notes for that plugin|
 
 Codex can also read `.claude-plugin/marketplace.json` as a legacy-compatible marketplace, but this repo generates the Codex-native `.agents/plugins/marketplace.json` so install behavior is explicit.
@@ -133,6 +135,49 @@ Generated at `plugins/<name>/.claude-plugin/plugin.json`:
 ```
 
 Commands are included in Claude plugin manifests and kept under the plugin `commands/` directory for Codex. New portable workflows should still be authored as skills.
+
+## Cursor marketplace shape
+Generated at `.cursor-plugin/marketplace.json`:
+
+```json
+{
+  "name": "skills-of-luca",
+  "owner": {
+    "name": "Luca Silverentand"
+  },
+  "metadata": {
+    "description": "Reusable agent skills by Luca Silverentand.",
+    "version": "1.1.0"
+  },
+  "plugins": [
+    {
+      "name": "git",
+      "source": "./plugins/git",
+      "description": "Git workflow toolkit",
+      "version": "1.1.0"
+    }
+  ]
+}
+```
+
+Relative plugin sources resolve from the repository root containing `.cursor-plugin/`.
+
+## Cursor plugin shape
+Generated at `plugins/<name>/.cursor-plugin/plugin.json`:
+
+```json
+{
+  "name": "git",
+  "displayName": "Git",
+  "description": "Git workflow toolkit",
+  "version": "1.1.0",
+  "skills": "./skills/",
+  "commands": ["./commands/create-commit.md"],
+  "category": "Development"
+}
+```
+
+Cursor discovers skills under the plugin skills directory when the manifest uses the same skills path as Codex (see the Cursor plugin shape example above). Commands are optional and mirror Claude plugin command paths.
 
 ## Direct skill installation
 Direct skill consumers can install from the plugin-owned skill tree:

--- a/plugins/systems-design/.cursor-plugin/plugin.json
+++ b/plugins/systems-design/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+	"name": "systems-design",
+	"displayName": "Systems Design",
+	"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
+	"version": "1.1.0",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"architecture",
+		"api",
+		"database",
+		"design-review"
+	],
+	"category": "Architecture",
+	"skills": "./skills/"
+}

--- a/plugins/systems-design/.cursor-plugin/plugin.json
+++ b/plugins/systems-design/.cursor-plugin/plugin.json
@@ -1,21 +1,17 @@
 {
 	"name": "systems-design",
 	"displayName": "Systems Design",
-	"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
 	"version": "1.1.0",
+	"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
 	},
-	"homepage": "https://github.com/lucasilverentand/skills",
-	"repository": "https://github.com/lucasilverentand/skills",
 	"license": "MIT",
 	"keywords": [
 		"architecture",
 		"api",
 		"database",
 		"design-review"
-	],
-	"category": "Architecture",
-	"skills": "./skills/"
+	]
 }

--- a/plugins/systems-design/README.md
+++ b/plugins/systems-design/README.md
@@ -22,4 +22,11 @@ Claude Code:
 /plugin install systems-design@skills-of-luca
 ```
 
+Cursor:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install systems-design@skills-of-luca
+```
+
 This plugin owns its skill source under `plugins/systems-design/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/systems-design/README.md
+++ b/plugins/systems-design/README.md
@@ -22,7 +22,13 @@ Claude Code:
 /plugin install systems-design@skills-of-luca
 ```
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `systems-design` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 ```text
 /plugin marketplace add lucasilverentand/skills

--- a/scripts/marketplace.ts
+++ b/scripts/marketplace.ts
@@ -9,8 +9,10 @@
  * Generated output:
  *   - plugins/<plugin>/.claude-plugin/plugin.json
  *   - plugins/<plugin>/.codex-plugin/plugin.json
+ *   - plugins/<plugin>/.cursor-plugin/plugin.json
  *   - plugins/<plugin>/README.md
  *   - .claude-plugin/marketplace.json
+ *   - .cursor-plugin/marketplace.json
  *   - .agents/plugins/marketplace.json
  */
 
@@ -22,6 +24,7 @@ const ROOT = resolve(import.meta.dir, "..");
 const PLUGINS_DIR = resolve(ROOT, "plugins");
 const GROUPS_PATH = resolve(ROOT, "plugin-groups.json");
 const CLAUDE_MARKETPLACE_PATH = resolve(ROOT, ".claude-plugin/marketplace.json");
+const CURSOR_MARKETPLACE_PATH = resolve(ROOT, ".cursor-plugin/marketplace.json");
 const CODEX_MARKETPLACE_PATH = resolve(ROOT, ".agents/plugins/marketplace.json");
 const OBSOLETE_ROOT_CODEX_PLUGIN_DIR = resolve(ROOT, ".codex-plugin");
 const OBSOLETE_ROOT_SKILLS_DIR = resolve(ROOT, "skills");
@@ -289,6 +292,28 @@ function codexPluginManifest(group: PluginGroup, version: string, metadata: Plug
 	};
 }
 
+function cursorPluginManifest(group: PluginGroup, version: string, metadata: PluginGroups["metadata"]) {
+	const manifest: Record<string, unknown> = {
+		name: group.name,
+		displayName: group.displayName,
+		description: group.description,
+		version,
+		author: group.author,
+		homepage: metadata.homepage,
+		repository: metadata.repository,
+		license: metadata.license,
+		keywords: group.keywords ?? [],
+		category: group.category,
+		skills: "./skills/",
+	};
+
+	if (group.commands?.length) {
+		manifest.commands = group.commands.map((command) => `./commands/${command}.md`).sort();
+	}
+
+	return manifest;
+}
+
 function claudeMarketplace(groups: PluginGroups) {
 	return {
 		name: groups.name,
@@ -296,6 +321,26 @@ function claudeMarketplace(groups: PluginGroups) {
 		description: "Reusable agent skills by Luca Silverentand.",
 		version: groups.metadata.version,
 		metadata: groups.metadata,
+		plugins: groups.plugins.map((group) => ({
+			name: group.name,
+			source: `./plugins/${group.name}`,
+			description: group.description,
+			version: groups.metadata.version,
+			author: group.author,
+			category: group.category,
+			keywords: group.keywords ?? [],
+		})),
+	};
+}
+
+function cursorMarketplace(groups: PluginGroups) {
+	return {
+		name: groups.name,
+		owner: groups.owner,
+		metadata: {
+			description: "Reusable agent skills by Luca Silverentand.",
+			...groups.metadata,
+		},
 		plugins: groups.plugins.map((group) => ({
 			name: group.name,
 			source: `./plugins/${group.name}`,
@@ -359,6 +404,13 @@ codex plugin marketplace add ${source}
 \`\`\`
 
 Claude Code:
+
+\`\`\`text
+/plugin marketplace add ${source}
+/plugin install ${group.name}@${marketplaceName}
+\`\`\`
+
+Cursor:
 
 \`\`\`text
 /plugin marketplace add ${source}
@@ -461,6 +513,10 @@ async function main() {
 			json(codexPluginManifest(group, groups.metadata.version, groups.metadata)),
 		);
 		await writeIfChanged(
+			resolve(root, ".cursor-plugin/plugin.json"),
+			json(cursorPluginManifest(group, groups.metadata.version, groups.metadata)),
+		);
+		await writeIfChanged(
 			resolve(root, "README.md"),
 			pluginReadme(
 				group,
@@ -472,6 +528,7 @@ async function main() {
 	}
 
 	await writeIfChanged(CLAUDE_MARKETPLACE_PATH, json(claudeMarketplace(groups)));
+	await writeIfChanged(CURSOR_MARKETPLACE_PATH, json(cursorMarketplace(groups)));
 	await writeIfChanged(CODEX_MARKETPLACE_PATH, json(codexMarketplace(groups)));
 
 	if (write || changes.length === 0) {

--- a/scripts/marketplace.ts
+++ b/scripts/marketplace.ts
@@ -293,25 +293,21 @@ function codexPluginManifest(group: PluginGroup, version: string, metadata: Plug
 }
 
 function cursorPluginManifest(group: PluginGroup, version: string, metadata: PluginGroups["metadata"]) {
-	const manifest: Record<string, unknown> = {
+	return {
 		name: group.name,
 		displayName: group.displayName,
-		description: group.description,
 		version,
+		description: group.description,
 		author: group.author,
-		homepage: metadata.homepage,
-		repository: metadata.repository,
 		license: metadata.license,
 		keywords: group.keywords ?? [],
-		category: group.category,
-		skills: "./skills/",
 	};
+}
 
-	if (group.commands?.length) {
-		manifest.commands = group.commands.map((command) => `./commands/${command}.md`).sort();
-	}
-
-	return manifest;
+function cursorMarketplaceOwner(owner: Owner): { name: string; email?: string } {
+	const cursorOwner: { name: string; email?: string } = { name: owner.name };
+	if (owner.email) cursorOwner.email = owner.email;
+	return cursorOwner;
 }
 
 function claudeMarketplace(groups: PluginGroups) {
@@ -336,19 +332,17 @@ function claudeMarketplace(groups: PluginGroups) {
 function cursorMarketplace(groups: PluginGroups) {
 	return {
 		name: groups.name,
-		owner: groups.owner,
+		displayName: "Skills of Luca",
+		owner: cursorMarketplaceOwner(groups.owner),
 		metadata: {
 			description: "Reusable agent skills by Luca Silverentand.",
-			...groups.metadata,
+			version: groups.metadata.version,
+			pluginRoot: "plugins",
 		},
 		plugins: groups.plugins.map((group) => ({
 			name: group.name,
-			source: `./plugins/${group.name}`,
+			source: group.name,
 			description: group.description,
-			version: groups.metadata.version,
-			author: group.author,
-			category: group.category,
-			keywords: group.keywords ?? [],
 		})),
 	};
 }
@@ -410,7 +404,13 @@ Claude Code:
 /plugin install ${group.name}@${marketplaceName}
 \`\`\`
 
-Cursor:
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste \`https://github.com/${source}\`
+3. Install \`${group.name}\` (Required or Optional)
+
+Cursor (IDE slash commands):
 
 \`\`\`text
 /plugin marketplace add ${source}

--- a/scripts/validate-cursor-marketplace.ts
+++ b/scripts/validate-cursor-marketplace.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env bun
+/**
+ * Validates .cursor-plugin/marketplace.json and per-plugin manifests
+ * against the fieldsphere cursor-team-marketplace-template conventions.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { basename, dirname, extname, join, posix, relative, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const MARKETPLACE_PATH = resolve(ROOT, ".cursor-plugin/marketplace.json");
+
+const pluginNamePattern = /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const marketplaceNamePattern = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+const errors: string[] = [];
+const warnings: string[] = [];
+
+function addError(message: string): void {
+	errors.push(message);
+}
+
+function addWarning(message: string): void {
+	warnings.push(message);
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+	return existsSync(targetPath);
+}
+
+async function ensureDirectory(targetPath: string, context: string): Promise<boolean> {
+	try {
+		const info = await stat(targetPath);
+		if (!info.isDirectory()) {
+			addError(`${context} exists but is not a directory: ${targetPath}`);
+			return false;
+		}
+		return true;
+	} catch {
+		addError(`${context} directory is missing: ${targetPath}`);
+		return false;
+	}
+}
+
+async function readJsonFile<T>(filePath: string, context: string): Promise<T | null> {
+	try {
+		return JSON.parse(await readFile(filePath, "utf-8")) as T;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!existsSync(filePath)) {
+			addError(`${context} is missing: ${filePath}`);
+		} else {
+			addError(`${context} contains invalid JSON (${filePath}): ${message}`);
+		}
+		return null;
+	}
+}
+
+function normalizeNewlines(content: string): string {
+	return content.replace(/\r\n/g, "\n");
+}
+
+function parseFrontmatter(content: string): Record<string, string> | null {
+	const normalized = normalizeNewlines(content);
+	if (!normalized.startsWith("---\n")) return null;
+
+	const closingIndex = normalized.indexOf("\n---\n", 4);
+	if (closingIndex === -1) return null;
+
+	const fields: Record<string, string> = {};
+	for (const line of normalized.slice(4, closingIndex).split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const separator = line.indexOf(":");
+		if (separator === -1) continue;
+		const key = line.slice(0, separator).trim();
+		const value = line.slice(separator + 1).trim();
+		fields[key] = value;
+	}
+	return fields;
+}
+
+async function walkFiles(dirPath: string): Promise<string[]> {
+	const files: string[] = [];
+	const stack = [dirPath];
+
+	while (stack.length > 0) {
+		const current = stack.pop()!;
+		const entries = await readdir(current, { withFileTypes: true });
+		for (const entry of entries) {
+			const entryPath = join(current, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(entryPath);
+			} else if (entry.isFile()) {
+				files.push(entryPath);
+			}
+		}
+	}
+
+	return files;
+}
+
+function isSafeRelativePath(value: string): boolean {
+	if (typeof value !== "string" || value.length === 0) return false;
+	if (value.startsWith("http://") || value.startsWith("https://")) return true;
+	const normalized = posix.normalize(value.replace(/\\/g, "/"));
+	return !normalized.startsWith("../") && normalized !== "..";
+}
+
+function extractPathValues(value: unknown): string[] {
+	if (typeof value === "string") return [value];
+	if (Array.isArray(value)) return value.flatMap((entry) => extractPathValues(entry));
+	if (value && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		const candidates: string[] = [];
+		if (typeof record.path === "string") candidates.push(record.path);
+		if (typeof record.file === "string") candidates.push(record.file);
+		return candidates;
+	}
+	return [];
+}
+
+async function validateReferencedPath(
+	pluginDir: string,
+	fieldName: string,
+	pathValue: string,
+	pluginName: string,
+): Promise<void> {
+	if (pathValue.startsWith("http://") || pathValue.startsWith("https://")) return;
+	if (!isSafeRelativePath(pathValue)) {
+		addError(
+			`${pluginName}: field "${fieldName}" has invalid path "${pathValue}". Use a relative path without ".." or absolute prefixes.`,
+		);
+		return;
+	}
+	const resolved = resolve(pluginDir, pathValue);
+	if (!(await pathExists(resolved))) {
+		addError(`${pluginName}: field "${fieldName}" references missing path "${pathValue}".`);
+	}
+}
+
+async function validateFrontmatterFile(
+	filePath: string,
+	componentName: string,
+	requiredKeys: string[],
+	pluginName: string,
+): Promise<void> {
+	const content = await readFile(filePath, "utf-8");
+	const parsed = parseFrontmatter(content);
+	const relativeFile = relative(ROOT, filePath);
+
+	if (!parsed) {
+		addError(`${pluginName}: ${componentName} file missing YAML frontmatter: ${relativeFile}`);
+		return;
+	}
+
+	for (const key of requiredKeys) {
+		if (!parsed[key] || parsed[key].length === 0) {
+			addError(`${pluginName}: ${componentName} file missing "${key}" in frontmatter: ${relativeFile}`);
+		}
+	}
+}
+
+async function validateComponentFrontmatter(pluginDir: string, pluginName: string): Promise<void> {
+	const rulesDir = join(pluginDir, "rules");
+	if (await pathExists(rulesDir)) {
+		for (const file of await walkFiles(rulesDir)) {
+			const ext = extname(file).toLowerCase();
+			if (ext === ".md" || ext === ".mdc" || ext === ".markdown") {
+				await validateFrontmatterFile(file, "rule", ["description"], pluginName);
+			}
+		}
+	}
+
+	const skillsDir = join(pluginDir, "skills");
+	if (await pathExists(skillsDir)) {
+		for (const file of await walkFiles(skillsDir)) {
+			if (basename(file) === "SKILL.md") {
+				await validateFrontmatterFile(file, "skill", ["name", "description"], pluginName);
+			}
+		}
+	}
+
+	const agentsDir = join(pluginDir, "agents");
+	if (await pathExists(agentsDir)) {
+		for (const file of await walkFiles(agentsDir)) {
+			const ext = extname(file).toLowerCase();
+			if (ext === ".md" || ext === ".mdc" || ext === ".markdown") {
+				await validateFrontmatterFile(file, "agent", ["name", "description"], pluginName);
+			}
+		}
+	}
+
+	const commandsDir = join(pluginDir, "commands");
+	if (await pathExists(commandsDir)) {
+		for (const file of await walkFiles(commandsDir)) {
+			const ext = extname(file).toLowerCase();
+			if (ext === ".md" || ext === ".mdc" || ext === ".markdown" || ext === ".txt") {
+				await validateFrontmatterFile(file, "command", ["description"], pluginName);
+			}
+		}
+	}
+}
+
+function resolveMarketplaceSource(source: string, pluginRoot: string | undefined): string {
+	if (!pluginRoot) return source;
+	const normalizedRoot = pluginRoot.replace(/\\/g, "/").replace(/\/+$/, "");
+	const normalizedSource = source.replace(/\\/g, "/");
+	if (normalizedSource === normalizedRoot || normalizedSource.startsWith(`${normalizedRoot}/`)) {
+		return normalizedSource;
+	}
+	return `${normalizedRoot}/${normalizedSource}`;
+}
+
+interface MarketplaceEntry {
+	name?: string;
+	source?: string;
+}
+
+interface Marketplace {
+	name?: string;
+	displayName?: string;
+	owner?: { name?: string; email?: string };
+	metadata?: { pluginRoot?: string };
+	plugins?: MarketplaceEntry[];
+}
+
+interface PluginManifest {
+	name?: string;
+	logo?: string;
+	rules?: unknown;
+	skills?: unknown;
+	agents?: unknown;
+	commands?: unknown;
+	hooks?: unknown;
+	mcpServers?: unknown;
+}
+
+async function main(): Promise<void> {
+	const marketplace = await readJsonFile<Marketplace>(MARKETPLACE_PATH, "Marketplace manifest");
+	if (!marketplace) {
+		summarizeAndExit();
+		return;
+	}
+
+	if (typeof marketplace.name !== "string" || !marketplaceNamePattern.test(marketplace.name)) {
+		addError('Marketplace "name" must be lowercase kebab-case and start/end with an alphanumeric character.');
+	}
+
+	if (typeof marketplace.displayName !== "string" || marketplace.displayName.length === 0) {
+		addError('Marketplace "displayName" is required.');
+	}
+
+	if (!marketplace.owner || typeof marketplace.owner.name !== "string" || marketplace.owner.name.length === 0) {
+		addError('Marketplace "owner.name" is required.');
+	}
+
+	if (!marketplace.owner?.email) {
+		addWarning('Marketplace "owner.email" is missing (recommended for team marketplace import).');
+	}
+
+	if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+		addError('Marketplace "plugins" must be a non-empty array.');
+		summarizeAndExit();
+		return;
+	}
+
+	const pluginRoot = marketplace.metadata?.pluginRoot;
+	if (pluginRoot !== undefined) {
+		if (typeof pluginRoot !== "string" || !isSafeRelativePath(pluginRoot)) {
+			addError('Marketplace "metadata.pluginRoot" must be a safe relative path.');
+		} else {
+			await ensureDirectory(join(ROOT, pluginRoot), 'Marketplace "metadata.pluginRoot"');
+		}
+	} else {
+		addError('Marketplace "metadata.pluginRoot" is required (use "plugins").');
+	}
+
+	const seenNames = new Set<string>();
+	for (const [index, entry] of marketplace.plugins.entries()) {
+		const label = `plugins[${index}]`;
+
+		if (!entry || typeof entry !== "object") {
+			addError(`${label} must be an object.`);
+			continue;
+		}
+
+		if (typeof entry.name !== "string" || !pluginNamePattern.test(entry.name)) {
+			addError(`${label}.name must be lowercase and use only alphanumerics, hyphens, and periods.`);
+			continue;
+		}
+
+		if (seenNames.has(entry.name)) {
+			addError(`Duplicate plugin name in marketplace manifest: "${entry.name}"`);
+		}
+		seenNames.add(entry.name);
+
+		const sourcePath = resolveMarketplaceSource(entry.source ?? "", pluginRoot ?? "");
+		if (!sourcePath) {
+			addError(`${label}.source must be a string path.`);
+			continue;
+		}
+		if (!isSafeRelativePath(sourcePath)) {
+			addError(`${label}.source is not a safe relative path: "${sourcePath}"`);
+			continue;
+		}
+
+		const pluginDir = join(ROOT, sourcePath);
+		if (!(await ensureDirectory(pluginDir, `${label}.source`))) continue;
+
+		const manifestPath = join(pluginDir, ".cursor-plugin", "plugin.json");
+		const pluginManifest = await readJsonFile<PluginManifest>(manifestPath, `${entry.name} plugin manifest`);
+		if (!pluginManifest) continue;
+
+		if (typeof pluginManifest.name !== "string" || !pluginNamePattern.test(pluginManifest.name)) {
+			addError(
+				`${entry.name}: "name" in plugin.json must be lowercase and use only alphanumerics, hyphens, and periods.`,
+			);
+		}
+
+		if (pluginManifest.name && pluginManifest.name !== entry.name) {
+			addError(
+				`${entry.name}: marketplace entry name does not match plugin.json name ("${pluginManifest.name}").`,
+			);
+		}
+
+		const manifestFields = ["logo", "rules", "skills", "agents", "commands", "hooks", "mcpServers"] as const;
+		for (const field of manifestFields) {
+			for (const value of extractPathValues(pluginManifest[field])) {
+				await validateReferencedPath(pluginDir, field, value, entry.name);
+			}
+		}
+
+		await validateComponentFrontmatter(pluginDir, entry.name);
+
+		const hooksPath = join(pluginDir, "hooks", "hooks.json");
+		if (!(await pathExists(hooksPath))) {
+			addWarning(`${entry.name}: no hooks/hooks.json file found (only needed when using hooks).`);
+		}
+
+		const mcpPath = join(pluginDir, "mcp.json");
+		if (!(await pathExists(mcpPath))) {
+			addWarning(`${entry.name}: no mcp.json file found (only needed when using MCP servers).`);
+		}
+	}
+
+	summarizeAndExit();
+}
+
+function summarizeAndExit(): void {
+	if (warnings.length > 0) {
+		console.log("Warnings:");
+		for (const warning of warnings) {
+			console.log(`- ${warning}`);
+		}
+		console.log("");
+	}
+
+	if (errors.length > 0) {
+		console.error("Validation failed:");
+		for (const error of errors) {
+			console.error(`- ${error}`);
+		}
+		process.exit(1);
+	}
+
+	console.log("Cursor marketplace validation passed.");
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor as a third generated marketplace surface (alongside Codex and Claude Code) and aligns `.cursor-plugin/` output with the [fieldsphere/cursor-team-marketplace-template](https://github.com/fieldsphere/cursor-team-marketplace-template) team-marketplace conventions.

## Changes

**Generator** ([`scripts/marketplace.ts`](scripts/marketplace.ts))
- `cursorMarketplace()`: `displayName`, `metadata.pluginRoot: "plugins"`, minimal plugin entries (`name`, `source`, `description`), Cursor-only owner `{ name, email }`
- `cursorPluginManifest()`: lean manifests (folder discovery for skills/commands; no explicit paths)
- `pluginReadme()`: team dashboard import steps + existing Codex/Claude blocks

**Validation**
- New [`scripts/validate-cursor-marketplace.ts`](scripts/validate-cursor-marketplace.ts) — `bun run validate:cursor`

**Source**
- [`plugin-groups.json`](plugin-groups.json): additive `owner.email` (Claude marketplace passes through unchanged)

**Docs**: `CURSOR.md`, `README.md`, `AGENTS.md`, publishing schema/skill

## Triple-consumer safety

| Consumer | Changed in this PR? |
|----------|---------------------|
| Codex (`.agents/plugins/`, `.codex-plugin/`) | No |
| Claude (`.claude-plugin/` manifests) | No |
| Claude marketplace | Only `owner.email` added (from `plugin-groups.json`) |
| Cursor (`.cursor-plugin/`) | Yes — template-aligned |

## Validation

```bash
bun run marketplace:write
bun run marketplace
bun run validate:cursor
bun run check
```

## Install (Cursor team)

1. Dashboard → Settings → Plugins → Import
2. `https://github.com/lucasilverentand/skills`
3. Mark plugins Required or Optional
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cce9e2d-1822-45f6-b8aa-7797c4be98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cce9e2d-1822-45f6-b8aa-7797c4be98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

