### PR TITLE
Add PR CI workflow and stricter validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What changed and why -->
+
+## Checklist
+
+- [ ] Edited `plugins/<plugin>/skills/…` and updated `plugin-groups.json` if membership or plugin metadata changed
+- [ ] Ran `bun run marketplace:write` when sources affect generated manifests, READMEs, or marketplaces
+- [ ] Ran `bun run ci` locally, or confirmed the **`validate`** CI check is green

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.15"
+
+      - name: Validate marketplace, skills, and markdown
+        run: bun run ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,17 +19,22 @@ The `plugins/` tree is committed because it is both the installable package tree
 - Run `bun run marketplace:write` after changing plugin membership, skill metadata, plugin README source, command lists, or anything that affects generated manifests or marketplaces.
 - Run `bun run marketplace` after generation; it should report everything up to date.
 - Run `bun run check` before finishing docs or skill changes.
+- Run `bun run ci` before opening a PR; it matches the GitHub Actions `validate` job.
 
 Useful commands:
 
 ```bash
+bun run ci
 bun run check
 bun run check:fix
 bun run marketplace
 bun run marketplace:write
 ```
 
-`bun run check` validates token and structure expectations for Markdown skills and docs. `bun run check:fix` applies safe Markdown compaction only; use it deliberately and review the diff.
+`bun run ci` runs `marketplace` (dry-run, fails if generated files are stale), `check --strict` (fails on skill errors and uncommitted markdown compaction), and JSON smoke-parse of manifests. `bun run check` validates token and structure expectations for Markdown skills and docs; warnings are informational. `bun run check:fix` applies safe Markdown compaction only; use it deliberately and review the diff.
+
+## Continuous integration
+GitHub Actions workflow [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `bun run ci` on pull requests and pushes to `main`. After merging, enable branch protection on `main` and require the **`validate`** status check before merge.
 
 ## Generated Artifacts
 - Do not hand-edit generated plugin manifests, generated plugin READMEs, or marketplace JSON unless the generator is being changed.
@@ -61,6 +66,6 @@ Omit skill names to install every skill. Add `--symlink` for local development a
 ## Cursor Cloud specific instructions
 - **Runtime**: Bun is the sole runtime dependency. There are no `node_modules`, no lockfile, and no npm/yarn/pnpm usage. The update script ensures Bun is installed and on `PATH`.
 - **No services to start**: This is a content-only repo (Markdown skills + TypeScript validation scripts). There are no servers, databases, or Docker containers.
-- **Validation commands** are documented in the Development Workflow section above. After any skill or metadata change, run `bun run marketplace:write` then `bun run marketplace` then `bun run check`.
-- **`bun run check` exit codes**: exit 0 means pass (warnings are informational only). Exit 1 means there are errors that must be fixed.
+- **Validation commands** are documented in the Development Workflow section above. After any skill or metadata change, run `bun run marketplace:write` then `bun run ci` (or `marketplace` then `check --strict`).
+- **`bun run check` exit codes**: exit 0 means pass (warnings are informational only). Exit 1 means there are errors that must be fixed. `check --strict` also fails when markdown would be reformatted without `--fix`.
 - **Generated plugin READMEs**: `marketplace:write` regenerates `plugins/*/README.md` files. If your diff includes only these generated files, that is expected—commit them alongside source changes.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Edit `plugins/<plugin>/skills/`, update `plugin-groups.json` when plugin members
 
 ```bash
 bun run marketplace:write
-bun run marketplace
-bun run check
+bun run ci
 ```
+
+`bun run ci` is the same validation GitHub Actions runs on pull requests (marketplace sync, skill checks, markdown format, JSON manifests). Use `bun run check` locally for a non-strict dry-run with warnings only.
 
 Agent and contributor guidance lives in `AGENTS.md`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"check": "bun scripts/check.ts",
 		"check:fix": "bun scripts/check.ts --fix",
+		"ci": "bun run marketplace && bun run check --strict && bun scripts/validate-json.ts",
 		"install:claude-skills": "bun scripts/install-skills.ts --target claude",
 		"install:codex-skills": "bun scripts/install-skills.ts --target codex",
 		"marketplace": "bun scripts/marketplace.ts",

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -6,6 +6,7 @@
  * Usage:
  *   bun run check          # dry-run — show what would change
  *   bun run check:fix      # apply changes in-place
+ *   bun run check --strict # fail if markdown would be reformatted (CI)
  *   bun run check --stdin   # read from stdin, write optimized to stdout (for editors)
  */
 
@@ -15,6 +16,8 @@ import { relative } from "node:path";
 
 const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 const fix = process.argv.includes("--fix");
+const strict =
+	process.argv.includes("--strict") || process.env.CHECK_STRICT === "1";
 const stdin = process.argv.includes("--stdin");
 
 // ── Stdin mode (for editors: stdin → optimized stdout) ──────────────
@@ -443,7 +446,11 @@ console.log(fix ? green(summary) : bold(summary));
 
 if (!fix && filesChanged > 0) {
 	console.log(dim("Run with --fix to apply changes."));
+	if (strict) {
+		console.log(red("Strict mode: commit formatted markdown or run `bun run check:fix`."));
+	}
 }
 
 const hasErrors = allFlags.some((f) => f.severity === "error");
-process.exit(hasErrors ? 1 : 0);
+const hasStrictFailure = strict && !fix && filesChanged > 0;
+process.exit(hasErrors || hasStrictFailure ? 1 : 0);

--- a/scripts/marketplace.ts
+++ b/scripts/marketplace.ts
@@ -495,6 +495,7 @@ async function main() {
 	} else {
 		console.log(bold(`${changes.length} generated path(s) to update.`));
 		console.log(dim("Run with --write to apply changes."));
+		process.exit(1);
 	}
 }
 

--- a/scripts/validate-json.ts
+++ b/scripts/validate-json.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+/**
+ * Smoke-parse committed JSON config and generated manifests.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const errors: string[] = [];
+
+async function parseJson(path: string): Promise<void> {
+	const rel = path.replace(`${ROOT}/`, "");
+	try {
+		JSON.parse(await readFile(path, "utf-8"));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		errors.push(`${rel}: ${message}`);
+	}
+}
+
+const staticPaths = [
+	join(ROOT, "plugin-groups.json"),
+	join(ROOT, ".claude-plugin/marketplace.json"),
+	join(ROOT, ".agents/plugins/marketplace.json"),
+];
+
+for (const path of staticPaths) {
+	if (existsSync(path)) await parseJson(path);
+}
+
+const pluginsDir = join(ROOT, "plugins");
+if (existsSync(pluginsDir)) {
+	for (const plugin of await readdir(pluginsDir, { withFileTypes: true })) {
+		if (!plugin.isDirectory()) continue;
+		const root = join(pluginsDir, plugin.name);
+		for (const sub of [".codex-plugin/plugin.json", ".claude-plugin/plugin.json"]) {
+			const path = join(root, sub);
+			if (existsSync(path)) await parseJson(path);
+		}
+	}
+}
+
+if (errors.length > 0) {
+	console.error("Invalid JSON:");
+	for (const error of errors) console.error(`  ${error}`);
+	process.exit(1);
+}
+
+console.log("All JSON files parse successfully.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds sensible merge gates for this content-first repo without unit-test theater.

## Changes

- **GitHub Actions** (`.github/workflows/ci.yml`): `validate` job runs `bun run ci` on PRs and pushes to `main`.
- **`bun run ci`**: `marketplace` (dry-run) + `check --strict` + JSON smoke-parse of manifests.
- **`marketplace`**: exits non-zero when generated manifests/READMEs/marketplaces are stale (forgot `marketplace:write`).
- **`check --strict`**: exits non-zero when markdown would be reformatted without `check:fix` (CI only; local `check` stays lenient).
- **`scripts/validate-json.ts`**: parses `plugin-groups.json`, marketplaces, and per-plugin manifests.
- **Docs**: `AGENTS.md` and `README.md` document local parity with CI.
- **PR template**: checklist for generator runs and `bun run ci`.

## Branch protection (manual step)

After this PR merges, enable branch protection on `main`:

**Settings → Branches → Add rule for `main` → Require status checks → select `validate`.**

The integration token cannot configure branch protection on this repo.

## Test plan

- [x] `bun run ci` passes on this branch
- [x] GitHub Actions `validate` is green on the PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-248c8388-fd90-4c5d-9006-d3ade4125e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-248c8388-fd90-4c5d-9006-d3ade4125e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

