### PR TITLE
docs: remove churny metadata counts

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -17,7 +17,7 @@
 			"category": "Design",
 			"interface": {
 				"displayName": "Apple Design",
-				"shortDescription": "Apple HIG guidance by platform"
+				"shortDescription": "Apple HIG guidance"
 			}
 		},
 		{

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
 		{
 			"name": "apple-design",
 			"source": "./plugins/apple-design",
-			"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+			"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 			"version": "1.1.0",
 			"author": {
 				"name": "Luca Silverentand",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -14,7 +14,7 @@
 		{
 			"name": "apple-design",
 			"source": "apple-design",
-			"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform."
+			"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services."
 		},
 		{
 			"name": "documentation",

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -15,8 +15,8 @@
 		{
 			"name": "apple-design",
 			"displayName": "Apple Design",
-			"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
-			"shortDescription": "Apple HIG guidance by platform",
+			"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
+			"shortDescription": "Apple HIG guidance",
 			"category": "Design",
 			"keywords": ["apple", "design", "hig", "ios", "macos", "visionos"],
 			"skills": ["foundations", "ios", "macos", "services", "tvos", "visionos", "watchos"],

--- a/plugins/apple-design/.claude-plugin/plugin.json
+++ b/plugins/apple-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "apple-design",
-	"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+	"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 	"version": "1.1.0",
 	"skills": [
 		"./skills/foundations",

--- a/plugins/apple-design/.codex-plugin/plugin.json
+++ b/plugins/apple-design/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "apple-design",
 	"version": "1.1.0",
-	"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+	"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "luca.silverentand@gmail.com"
@@ -20,8 +20,8 @@
 	"skills": "./skills/",
 	"interface": {
 		"displayName": "Apple Design",
-		"shortDescription": "Apple HIG guidance by platform",
-		"longDescription": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+		"shortDescription": "Apple HIG guidance",
+		"longDescription": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 		"developerName": "Luca Silverentand",
 		"category": "Design",
 		"capabilities": [

--- a/plugins/apple-design/.cursor-plugin/plugin.json
+++ b/plugins/apple-design/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"name": "apple-design",
 	"displayName": "Apple Design",
 	"version": "1.1.0",
-	"description": "Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.",
+	"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "luca.silverentand@gmail.com"

--- a/plugins/apple-design/README.md
+++ b/plugins/apple-design/README.md
@@ -1,5 +1,5 @@
 # Apple Design
-Apple Human Interface Guidelines as a single plugin: foundations, services, and a skill per Apple platform.
+Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.
 
 ## Skills
 - `apple-design:foundations`

--- a/plugins/apple-design/skills/foundations/SKILL.md
+++ b/plugins/apple-design/skills/foundations/SKILL.md
@@ -16,57 +16,57 @@ Foundational HIG topics shared across all Apple platforms — design principles,
 ## Glossary
 |Topic|Reference|Summary|
 |---|---|---|
-|`accessibility`|`accessibility/` ×7|Intuitive|
+|`accessibility`|`accessibility/`|Intuitive|
 |`activity-views`|`activity-views.md`|You have the ability to supply app-specific activities that appear in a share…|
-|`app-icons`|`app-icons/` ×16|While a flattened image can be used for your icon, utilizing layers provides…|
+|`app-icons`|`app-icons/`|While a flattened image can be used for your icon, utilizing layers provides…|
 |`branding`|`branding.md`|Applications and games should convey their distinct brand identity in ways that…|
 |`charting-data`|`charting-data.md`|chart can serve different roles, from a straightforward graphic offering quick…|
-|`charts`|`charts/` ×9|Determine how forecasted weather conditions may affect their plans|
-|`color`|`color/` ×12|However, you might also choose custom colors to enhance your app or game's…|
+|`charts`|`charts/`|Determine how forecasted weather conditions may affect their plans|
+|`color`|`color/`|However, you might also choose custom colors to enhance your app or game's…|
 |`components`|`components.md`|Understand how to utilize and tailor system-provided components to ensure a…|
 |`content`|`content.md`|Charts — Organize data visually into a chart to clearly and appealingly…|
-|`dark-mode`|`dark-mode/` ×2|Avoid offering an app-specific appearance setting|
-|`designing-for-games`|`designing-for-games/` ×5|Integrate Game Center to enable players to find your game across devices and…|
+|`dark-mode`|`dark-mode/`|Avoid offering an app-specific appearance setting|
+|`designing-for-games`|`designing-for-games/`|Integrate Game Center to enable players to find your game across devices and…|
 |`digit-entry-views`|`digit-entry-views.md`|digit entry view occupies the entire screen, prompting users to input a…|
 |`disclosure-controls`|`disclosure-controls.md`|Disclosure controls determine the visibility of information and functionality…|
-|`eyes`|`eyes/` ×5|In certain situations, the system may automatically display an expanded view of…|
+|`eyes`|`eyes/`|In certain situations, the system may automatically display an expanded view of…|
 |`feedback`|`feedback.md`|Feedback informs users about the current state, guides them on subsequent…|
 |`foundations`|`foundations.md`|Accessibility — Accessible user interfaces enable everyone to have a positive…|
-|`gestures`|`gestures/` ×10|All platforms support fundamental gestures like tap, swipe, and drag|
+|`gestures`|`gestures/`|All platforms support fundamental gestures like tap, swipe, and drag|
 |`getting-started`|`getting-started.md`|Develop an application or game that delivers a cohesive, native experience…|
-|`icons`|`icons/` ×3|You may either design interface icons—also referred to as *glyphs*—or select…|
+|`icons`|`icons/`|You may either design interface icons—also referred to as *glyphs*—or select…|
 |`image-wells`|`image-wells.md`|image well serves as an editable version of an image view|
-|`inclusion`|`inclusion/` ×9|As with any design project, developing an inclusive application is a…|
+|`inclusion`|`inclusion/`|As with any design project, developing an inclusive application is a…|
 |`inputs`|`inputs.md`|Overview of Application/Game Control and Data Input Mechanisms|
-|`keyboards`|`keyboards/` ×5|Keyboard users often appreciate using shortcuts to accelerate their…|
-|`launching`|`launching/` ×5|smooth launch experience enables users to begin using your app or game…|
-|`layout`|`layout/` ×13|Apple provides templates, guides, and other resources to help you integrate…|
+|`keyboards`|`keyboards/`|Keyboard users often appreciate using shortcuts to accelerate their…|
+|`launching`|`launching/`|smooth launch experience enables users to begin using your app or game…|
+|`layout`|`layout/`|Apple provides templates, guides, and other resources to help you integrate…|
 |`layout-and-organization`|`layout-and-organization.md`|Boxes — A box defines a visually distinct grouping for logically related…|
 |`loading`|`loading.md`|Optimal content loading occurs when the user remains unaware of the process|
 |`lockups`|`lockups.md`|lockup integrates multiple distinct views into a single, interactive unit|
-|`materials`|`materials/` ×5|Apple platforms utilize two types of materials: Liquid Glass and standard…|
+|`materials`|`materials/`|Apple platforms utilize two types of materials: Liquid Glass and standard…|
 |`menus-and-actions`|`menus-and-actions.md`|Activity views — An activity view, often referred to as a *share sheet*,…|
 |`modality`|`modality.md`|Modality is a design method where content appears in a standalone, dedicated…|
-|`motion`|`motion/` ×2|When designing custom motion, please follow the guidelines provided below|
+|`motion`|`motion/`|When designing custom motion, please follow the guidelines provided below|
 |`navigation-and-search`|`navigation-and-search.md`|Path controls — Displays the file system location of a selected file or…|
 |`offering-help`|`offering-help.md`|While optimal experiences are inherently intuitive and accessible, you retain…|
 |`onboarding`|`onboarding.md`|Onboarding assists users in achieving a rapid start with your application or…|
 |`outline-views`|`outline-views.md`|outline view displays structured data hierarchically within a scrollable…|
 |`patterns`|`patterns.md`|Please provide the Apple design guideline prose you would like me to paraphrase|
-|`pointing-devices`|`pointing-devices/` ×12|Maintain consistency in how you respond to mouse and trackpad gestures|
+|`pointing-devices`|`pointing-devices/`|Maintain consistency in how you respond to mouse and trackpad gestures|
 |`presentation`|`presentation.md`|Action sheets — An action sheet is a modal display used to present options…|
-|`privacy`|`privacy/` ×7|Upon submitting a new or revised application, you must furnish specifics…|
+|`privacy`|`privacy/`|Upon submitting a new or revised application, you must furnish specifics…|
 |`rating-indicators`|`rating-indicators.md`|rating indicator conveys a ranking level using a sequence of horizontally…|
-|`right-to-left`|`right-to-left/` ×6|System-provided UI frameworks inherently support right-to-left (RTL), enabling…|
+|`right-to-left`|`right-to-left/`|System-provided UI frameworks inherently support right-to-left (RTL), enabling…|
 |`searching`|`searching.md`|Users employ diverse methods to locate information across their device, within…|
 |`selection-and-input`|`selection-and-input.md`|Color wells — A color well allows users to modify the hue of text, shapes,…|
-|`sf-symbols`|`sf-symbols/` ×8|availability of specific symbols and features depends on the target system…|
+|`sf-symbols`|`sf-symbols/`|availability of specific symbols and features depends on the target system…|
 |`status`|`status.md`|Activity rings — Activity rings visualize a user's daily advancement toward the…|
 |`status-bars`|`status-bars.md`|status bar occupies the upper edge of the display and provides indicators…|
 |`system-experiences`|`system-experiences.md`|App Shortcuts — Allows users to access your application's critical functions or…|
 |`technologies`|`technologies.md`|Explore the Apple technologies, features, and services available for…|
-|`typography`|`typography/` ×11|Modify font weight, size, and color to highlight critical information and…|
-|`virtual-keyboards`|`virtual-keyboards/` ×5|If appropriate for your application, you have the option to substitute the…|
+|`typography`|`typography/`|Modify font weight, size, and color to highlight critical information and…|
+|`virtual-keyboards`|`virtual-keyboards/`|If appropriate for your application, you have the option to substitute the…|
 |`voiceover`|`voiceover.md`|VoiceOver functions as a screen reader, allowing users to interact with your…|
 |`web-views`|`web-views.md`|web view enables your application to load and render rich internet content,…|
-|`writing`|`writing/` ×2|Define your app's voice|
+|`writing`|`writing/`|Define your app's voice|

--- a/plugins/apple-design/skills/ios/SKILL.md
+++ b/plugins/apple-design/skills/ios/SKILL.md
@@ -9,7 +9,7 @@ Platform-specific HIG for iOS & iPadOS. Components, controls, navigation pattern
 
 ## How to use
 1. **Match the user's UI element to a topic** — most map directly to component or pattern names.
-2. **Read only the matched references**. Multi-file topics (`×N`) live in `references/<topic>/`.
+2. **Read only the matched references**. Directory topics live in `references/<topic>/`.
 3. **Pull in `foundations`** for shared principles (color, typography, layout, accessibility, shared UI like rating indicators).
 4. **Pull in `services`** when integrating Apple frameworks (Pay, HealthKit, Siri, sensors, media playback).
 5. **Stay on iOS & iPadOS.** For another Apple platform, point to the matching skill.
@@ -26,20 +26,20 @@ Platform-specific HIG for iOS & iPadOS. Components, controls, navigation pattern
 |`context-menus`|`context-menus.md`|system-defined touch or pinch and hold gesture in visionOS, iOS, and iPadOS|
 |`designing-for-ios`|`designing-for-ios.md`|iPhone serves as a central device for users to maintain connectivity, engage in…|
 |`designing-for-ipados`|`designing-for-ipados.md`|iPad is valued for its power, portability, and versatility, enabling users to…|
-|`drag-and-drop`|`drag-and-drop/` ×4|Depending on different factors, the drag and drop action may *move* the…|
+|`drag-and-drop`|`drag-and-drop/`|Depending on different factors, the drag and drop action may *move* the…|
 |`edit-menus`|`edit-menus.md`|edit menu allows users to modify selected content within the current view,…|
 |`file-management`|`file-management.md`|Users also anticipate being able to browse documents without first launching a…|
 |`going-full-screen`|`going-full-screen.md`|iPhone, iPad, and Mac devices support full-screen modes, allowing users to…|
 |`image-views`|`image-views.md`|image view presents either a static image or an animated sequence against a…|
 |`images`|`images.md`|To ensure optimal visual quality across all supported devices, familiarize…|
 |`lists-and-tables`|`lists-and-tables.md`|Tables and lists display information arranged across one or more columns of rows|
-|`menus`|`menus/` ×7||
+|`menus`|`menus/`||
 |`multitasking`|`multitasking.md`|Multitasking enables users to rapidly transition between applications and…|
 |`page-controls`|`page-controls.md`|page control presents a horizontal row of indicator images, with each image…|
 |`pickers`|`pickers.md`|picker presents one or more scrollable lists containing unique values from…|
 |`playing-audio`|`playing-audio.md`|Silence|
 |`playing-haptics`|`playing-haptics.md`|Beyond inherent haptic capabilities, certain external input devices can also…|
-|`playing-video`|`playing-video/` ×3|system-provided video players support different aspect ratio playback modes…|
+|`playing-video`|`playing-video/`|system-provided video players support different aspect ratio playback modes…|
 |`popovers`|`popovers.md`|popover functions as a temporary view that overlays other content upon…|
 |`progress-indicators`|`progress-indicators.md`|Progress indicators inform users that your application is actively working,…|
 |`pull-down-buttons`|`pull-down-buttons.md`|pull-down button reveals a menu containing items or actions directly related to…|
@@ -55,6 +55,6 @@ Platform-specific HIG for iOS & iPadOS. Components, controls, navigation pattern
 |`text-fields`|`text-fields.md`|text field is a rectangular region where users input or modify brief, specific…|
 |`text-views`|`text-views.md`|TextView presents multi-line, styled text content that may or may not be…|
 |`toggles`|`toggles.md`|toggle enables users to select between two opposing states, such as on or off,…|
-|`toolbars`|`toolbars/` ×8|Toolbars perform actions on content within the view, facilitate movement…|
+|`toolbars`|`toolbars/`|Toolbars perform actions on content within the view, facilitate movement…|
 |`undo-and-redo`|`undo-and-redo.md`|Undo and redo provide users with simple mechanisms to reverse different actions|
 |`windows`|`windows.md`|window displays the user interface views and components within your application…|

--- a/plugins/apple-design/skills/macos/SKILL.md
+++ b/plugins/apple-design/skills/macos/SKILL.md
@@ -9,7 +9,7 @@ Platform-specific HIG for macOS. Components, controls, navigation patterns, and 
 
 ## How to use
 1. **Match the user's UI element to a topic** — most map directly to component or pattern names.
-2. **Read only the matched references**. Multi-file topics (`×N`) live in `references/<topic>/`.
+2. **Read only the matched references**. Directory topics live in `references/<topic>/`.
 3. **Pull in `foundations`** for shared principles (color, typography, layout, accessibility, shared UI like rating indicators).
 4. **Pull in `services`** when integrating Apple frameworks (Pay, HealthKit, Siri, sensors, media playback).
 5. **Stay on macOS.** For another Apple platform, point to the matching skill.
@@ -19,14 +19,14 @@ Platform-specific HIG for macOS. Components, controls, navigation patterns, and 
 |---|---|---|
 |`alerts`|`alerts.md`|Use alerts sparingly|
 |`boxes`|`boxes.md`|box groups related information and components into a visually distinct unit|
-|`buttons`|`buttons/` ×5|Style|
+|`buttons`|`buttons/`|Style|
 |`color-wells`|`color-wells.md`|color well enables users to modify the hue of text, shapes, guides, and other…|
 |`column-views`|`column-views.md`|column view, also referred to as a *browser*, allows users to visualize and…|
 |`combo-boxes`|`combo-boxes.md`|combo box integrates a text field and a pull-down button into a single control|
 |`context-menus`|`context-menus.md`|context menu grants access to item-specific functionality without adding visual…|
 |`designing-for-macos`|`designing-for-macos.md`|Macs are relied upon for demanding tasks—including deep productivity work,…|
 |`dock-menus`|`dock-menus.md`|On macOS, a secondary click on an application or game icon in the Dock displays…|
-|`drag-and-drop`|`drag-and-drop/` ×5|Depending on different factors, the drag and drop action may *move* the…|
+|`drag-and-drop`|`drag-and-drop/`|Depending on different factors, the drag and drop action may *move* the…|
 |`edit-menus`|`edit-menus.md`|edit menu allows users to modify selected content within the current view,…|
 |`entering-data`|`entering-data.md`|When collecting information from users, design processes that facilitate…|
 |`file-management`|`file-management.md`|Users also anticipate being able to browse documents without first launching a…|
@@ -36,7 +36,7 @@ Platform-specific HIG for macOS. Components, controls, navigation patterns, and 
 |`images`|`images.md`|To ensure optimal visual quality across all supported devices, familiarize…|
 |`labels`|`labels.md`|label is static text that users can read and often copy, but they cannot modify|
 |`lists-and-tables`|`lists-and-tables.md`|Tables and lists display information arranged across one or more columns of rows|
-|`mac-catalyst`|`mac-catalyst/` ×3|Many iPad applications are excellent candidates for conversion into a Mac…|
+|`mac-catalyst`|`mac-catalyst/`|Many iPad applications are excellent candidates for conversion into a Mac…|
 |`multitasking`|`multitasking.md`|Multitasking enables users to rapidly transition between applications and…|
 |`page-controls`|`page-controls.md`|page control presents a horizontal row of indicator images, with each image…|
 |`panels`|`panels.md`|On macOS, a panel typically overlays other open windows, providing…|
@@ -44,7 +44,7 @@ Platform-specific HIG for macOS. Components, controls, navigation patterns, and 
 |`pickers`|`pickers.md`|picker presents one or more scrollable lists containing unique values from…|
 |`playing-audio`|`playing-audio.md`|Silence|
 |`playing-haptics`|`playing-haptics.md`|Beyond inherent haptic capabilities, certain external input devices can also…|
-|`playing-video`|`playing-video/` ×3|system-provided video players support different aspect ratio playback modes…|
+|`playing-video`|`playing-video/`|system-provided video players support different aspect ratio playback modes…|
 |`pop-up-buttons`|`pop-up-buttons.md`|pop-up button presents a menu containing options that are mutually exclusive|
 |`popovers`|`popovers.md`|popover functions as a temporary view that overlays other content upon…|
 |`printing`|`printing.md`|Apps targeting iOS, iPadOS, macOS, or visionOS may incorporate the operating…|
@@ -60,9 +60,9 @@ Platform-specific HIG for macOS. Components, controls, navigation patterns, and 
 |`steppers`|`steppers.md`|stepper is a dual-segmented control used to increment or decrement an…|
 |`tab-bars`|`tab-bars.md`|tab bar enables users to navigate between the application's highest-level…|
 |`text-fields`|`text-fields.md`|text field is a rectangular region where users input or modify brief, specific…|
-|`the-menu-bar`|`the-menu-bar/` ×13|Menu bar menus on iPad are comparable to those on Mac, appearing in the same…|
+|`the-menu-bar`|`the-menu-bar/`|Menu bar menus on iPad are comparable to those on Mac, appearing in the same…|
 |`toggles`|`toggles.md`|Furthermore, all platforms support buttons that function as toggles if they…|
 |`token-fields`|`token-fields.md`|token field is a specialized text input that transforms entered text into…|
-|`toolbars`|`toolbars/` ×6|Toolbars perform actions on content within the view, facilitate movement…|
+|`toolbars`|`toolbars/`|Toolbars perform actions on content within the view, facilitate movement…|
 |`undo-and-redo`|`undo-and-redo.md`|Undo and redo provide users with simple mechanisms to reverse different actions|
 |`windows`|`windows.md`|Conceptually, applications utilize two kinds of windows to display content:|

--- a/plugins/apple-design/skills/services/SKILL.md
+++ b/plugins/apple-design/skills/services/SKILL.md
@@ -9,7 +9,7 @@ Apple framework/service integration guidance — design rules and constraints fo
 
 ## How to use
 1. **Identify the framework or service** the user wants to integrate, find it in the glossary.
-2. **Read the topic's references**. Multi-file topics (`×N`) typically split overview, design, privacy, and platform notes.
+2. **Read the topic's references**. Directory topics typically split overview, design, privacy, and platform notes.
 3. **Combine with the platform skill** when the service surfaces UI on a specific device (e.g., Apple Pay button on iOS).
 4. **Honor service-mandated rules strictly** — many services (Pay, Sign in with Apple, Wallet) carry legal/branding requirements.
 
@@ -17,41 +17,41 @@ Apple framework/service integration guidance — design rules and constraints fo
 |Topic|Reference|Summary|
 |---|---|---|
 |`airplay`|`airplay.md`|Prefer the system-provided media player|
-|`app-clips`|`app-clips/` ×14|Users encounter and initiate App Clips across many scenarios and contexts|
-|`app-shortcuts`|`app-shortcuts/` ×2|Since App Shortcuts are integral to your application, they become available…|
-|`apple-pay`|`apple-pay/` ×13|Apps and websites that accept Apple Pay must display it as a payment option and…|
-|`apple-pencil-and-scribble`|`apple-pencil-and-scribble/` ×8|For comprehensive information regarding Apple Pencil features and…|
+|`app-clips`|`app-clips/`|Users encounter and initiate App Clips across many scenarios and contexts|
+|`app-shortcuts`|`app-shortcuts/`|Since App Shortcuts are integral to your application, they become available…|
+|`apple-pay`|`apple-pay/`|Apps and websites that accept Apple Pay must display it as a payment option and…|
+|`apple-pencil-and-scribble`|`apple-pencil-and-scribble/`|For comprehensive information regarding Apple Pencil features and…|
 |`camera-control`|`camera-control.md`|Camera Control grants immediate access to your application's camera…|
-|`carekit`|`carekit/` ×8|CareKit 2.0 comprises two distinct projects: CareKit UI and CareKit Store|
+|`carekit`|`carekit/`|CareKit 2.0 comprises two distinct projects: CareKit UI and CareKit Store|
 |`carplay`|`carplay.md`|CarPlay is specifically engineered for drivers to use while operating a vehicle|
 |`controls`|`controls.md`|Users can add controls to Control Center by pressing and holding in an empty…|
-|`game-center`|`game-center/` ×8|Find new games that their friends are playing|
-|`generative-ai`|`generative-ai/` ×7|Design your experience responsibly|
+|`game-center`|`game-center/`|Find new games that their friends are playing|
+|`generative-ai`|`generative-ai/`|Design your experience responsibly|
 |`gyro-and-accelerometer`|`gyro-and-accelerometer.md`|On-device gyroscopes and accelerometers provide information regarding a…|
-|`healthkit`|`healthkit/` ×5|For instance, a nutrition application may need permission to retrieve users'…|
+|`healthkit`|`healthkit/`|For instance, a nutrition application may need permission to retrieve users'…|
 |`home-screen-quick-actions`|`home-screen-quick-actions.md`|Home Screen quick actions allow users to execute app-specific functions…|
-|`homekit`|`homekit/` ×7|Your application (iOS, tvOS, or watchOS) can integrate with HomeKit—and…|
+|`homekit`|`homekit/`|Your application (iOS, tvOS, or watchOS) can integrate with HomeKit—and…|
 |`icloud`|`icloud.md`|iCloud is a service that allows users to access their important…|
 |`id-verifier`|`id-verifier.md`|ID Verifier allows your iPhone application to read mobile IDs in person without…|
 |`imessage-apps-and-stickers`|`imessage-apps-and-stickers.md`|iMessage applications enable users to share content, collaborate, and play…|
-|`in-app-purchase`|`in-app-purchase/` ×7|When implementing in-app purchases, you have four content models available:|
-|`live-activities`|`live-activities/` ×13|For instance, a Live Activity could display the estimated arrival time for a…|
+|`in-app-purchase`|`in-app-purchase/`|When implementing in-app purchases, you have four content models available:|
+|`live-activities`|`live-activities/`|For instance, a Live Activity could display the estimated arrival time for a…|
 |`live-photos`|`live-photos.md`|Live Photos transforms cherished moments into a dynamic, interactive experience…|
 |`live-viewing-apps`|`live-viewing-apps.md`|When developing a live-viewing application, the content must be elevated and…|
-|`machine-learning`|`machine-learning/` ×12|For related guidance on utilizing machine learning models to facilitate…|
-|`managing-accounts`|`managing-accounts/` ×2|Explain the benefits of creating an account and how to sign up|
+|`machine-learning`|`machine-learning/`|For related guidance on utilizing machine learning models to facilitate…|
+|`managing-accounts`|`managing-accounts/`|Explain the benefits of creating an account and how to sign up|
 |`managing-notifications`|`managing-notifications.md`|People value being informed about matters important to them, but they may not…|
-|`maps`|`maps/` ×5|In general, ensure your map is interactive|
-|`nearby-interactions`|`nearby-interactions/` ×2|Nearby interactions enable on-device experiences that incorporate the presence…|
+|`maps`|`maps/`|In general, ensure your map is interactive|
+|`nearby-interactions`|`nearby-interactions/`|Nearby interactions enable on-device experiences that incorporate the presence…|
 |`nfc`|`nfc.md`|Near-field communication (NFC) enables devices located within a few centimeters…|
-|`notifications`|`notifications/` ×6|Notifications may utilize different styles depending on the platform, including:|
+|`notifications`|`notifications/`|Notifications may utilize different styles depending on the platform, including:|
 |`photo-editing`|`photo-editing.md`|Photo-editing extensions enable users to modify photos and videos within the…|
 |`ratings-and-reviews`|`ratings-and-reviews.md`|Potential users frequently consult ratings and reviews before downloading an…|
 |`researchkit`|`researchkit.md`|When a user launches a research application for the first time, they encounter…|
-|`shareplay`|`shareplay/` ×6|When content is being shared during a FaceTime call, the system prompts each…|
+|`shareplay`|`shareplay/`|When content is being shared during a FaceTime call, the system prompts each…|
 |`shazamkit`|`shazamkit.md`|ShazamKit enables audio recognition by comparing an audio sample against either…|
-|`sign-in-with-apple`|`sign-in-with-apple/` ×6|You are able to implement Sign in with Apple across any version of your website…|
-|`siri`|`siri/` ×18|Ask Siri to execute a system-defined task that your application supports, such…|
-|`tap-to-pay-on-iphone`|`tap-to-pay-on-iphone/` ×6|To integrate Tap to Pay on iPhone into your iOS application, you must…|
-|`wallet`|`wallet/` ×14|When you integrate Apple Wallet into your application, you can generate custom…|
-|`widgets`|`widgets/` ×17|On the Home Screen and Lock Screen of their iPhone and iPad|
+|`sign-in-with-apple`|`sign-in-with-apple/`|You are able to implement Sign in with Apple across any version of your website…|
+|`siri`|`siri/`|Ask Siri to execute a system-defined task that your application supports, such…|
+|`tap-to-pay-on-iphone`|`tap-to-pay-on-iphone/`|To integrate Tap to Pay on iPhone into your iOS application, you must…|
+|`wallet`|`wallet/`|When you integrate Apple Wallet into your application, you can generate custom…|
+|`widgets`|`widgets/`|On the Home Screen and Lock Screen of their iPhone and iPad|

--- a/plugins/apple-design/skills/tvos/SKILL.md
+++ b/plugins/apple-design/skills/tvos/SKILL.md
@@ -9,7 +9,7 @@ Platform-specific HIG for tvOS. Components, controls, navigation patterns, and c
 
 ## How to use
 1. **Match the user's UI element to a topic** — most map directly to component or pattern names.
-2. **Read only the matched references**. Multi-file topics (`×N`) live in `references/<topic>/`.
+2. **Read only the matched references**. Directory topics live in `references/<topic>/`.
 3. **Pull in `foundations`** for shared principles (color, typography, layout, accessibility, shared UI like rating indicators).
 4. **Pull in `services`** when integrating Apple frameworks (Pay, HealthKit, Siri, sensors, media playback).
 5. **Stay on tvOS.** For another Apple platform, point to the matching skill.
@@ -21,7 +21,7 @@ Platform-specific HIG for tvOS. Components, controls, navigation patterns, and c
 |`buttons`|`buttons.md`|Style|
 |`context-menus`|`context-menus.md`|context menu grants access to item-specific functionality without adding visual…|
 |`designing-for-tvos`|`designing-for-tvos.md`|tvOS provides vibrant content, deeply immersive experiences, and streamlined…|
-|`drag-and-drop`|`drag-and-drop/` ×4|Depending on different factors, the drag and drop action may *move* the…|
+|`drag-and-drop`|`drag-and-drop/`|Depending on different factors, the drag and drop action may *move* the…|
 |`focus-and-selection`|`focus-and-selection.md`|Focus assists users in visually confirming the element they intend to interact…|
 |`image-views`|`image-views.md`|image view presents either a static image or an animated sequence against a…|
 |`images`|`images.md`|Different devices render visuals at varying resolutions|
@@ -31,7 +31,7 @@ Platform-specific HIG for tvOS. Components, controls, navigation patterns, and c
 |`pickers`|`pickers.md`|picker presents one or more scrollable lists containing unique values from…|
 |`playing-audio`|`playing-audio.md`|Silence|
 |`playing-haptics`|`playing-haptics.md`|Haptic feedback can involve users' sense of touch, allowing you to integrate a…|
-|`playing-video`|`playing-video/` ×3|system-provided video players support different aspect ratio playback modes…|
+|`playing-video`|`playing-video/`|system-provided video players support different aspect ratio playback modes…|
 |`progress-indicators`|`progress-indicators.md`|Progress indicators inform users that your application is actively working,…|
 |`remotes`|`remotes.md`|Use standard gestures for common actions|
 |`scroll-views`|`scroll-views.md`|scroll view enables users to examine content that exceeds the display…|
@@ -44,6 +44,6 @@ Platform-specific HIG for tvOS. Components, controls, navigation patterns, and c
 |`tab-bars`|`tab-bars.md`|tab bar enables users to navigate between the application's highest-level…|
 |`text-fields`|`text-fields.md`|text field is a rectangular region where users input or modify brief, specific…|
 |`text-views`|`text-views.md`|TextView presents multi-line, styled text content that may or may not be…|
-|`toolbars`|`toolbars/` ×6|Toolbars perform actions on content within the view, facilitate movement…|
-|`top-shelf`|`top-shelf/` ×3|Top Shelf presents a unique chance to highlight new, featured, or recommended…|
+|`toolbars`|`toolbars/`|Toolbars perform actions on content within the view, facilitate movement…|
+|`top-shelf`|`top-shelf/`|Top Shelf presents a unique chance to highlight new, featured, or recommended…|
 |`windows`|`windows.md`|window displays the user interface views and components within your application…|

--- a/plugins/apple-design/skills/visionos/SKILL.md
+++ b/plugins/apple-design/skills/visionos/SKILL.md
@@ -9,7 +9,7 @@ Platform-specific HIG for visionOS. Components, controls, navigation patterns, a
 
 ## How to use
 1. **Match the user's UI element to a topic** — most map directly to component or pattern names.
-2. **Read only the matched references**. Multi-file topics (`×N`) live in `references/<topic>/`.
+2. **Read only the matched references**. Directory topics live in `references/<topic>/`.
 3. **Pull in `foundations`** for shared principles (color, typography, layout, accessibility, shared UI like rating indicators).
 4. **Pull in `services`** when integrating Apple frameworks (Pay, HealthKit, Siri, sensors, media playback).
 5. **Stay on visionOS.** For another Apple platform, point to the matching skill.
@@ -18,35 +18,35 @@ Platform-specific HIG for visionOS. Components, controls, navigation patterns, a
 |Topic|Reference|Summary|
 |---|---|---|
 |`alerts`|`alerts.md`|Use alerts sparingly|
-|`augmented-reality`|`augmented-reality/` ×12|Only offer AR features on devices that support them|
-|`buttons`|`buttons/` ×5|Style|
+|`augmented-reality`|`augmented-reality/`|Only offer AR features on devices that support them|
+|`buttons`|`buttons/`|Style|
 |`collaboration-and-sharing`|`collaboration-and-sharing.md`|Effective collaboration and sharing experiences are straightforward and highly…|
 |`context-menus`|`context-menus.md`|context menu grants access to item-specific functionality without adding visual…|
 |`designing-for-visionos`|`designing-for-visionos.md`|Space|
-|`drag-and-drop`|`drag-and-drop/` ×4|Depending on different factors, the drag and drop action may *move* the…|
-|`game-controls`|`game-controls/` ×4|Although physical game controllers are supported on all platforms except…|
+|`drag-and-drop`|`drag-and-drop/`|Depending on different factors, the drag and drop action may *move* the…|
+|`game-controls`|`game-controls/`|Although physical game controllers are supported on all platforms except…|
 |`image-views`|`image-views.md`|image view presents either a static image or an animated sequence against a…|
 |`images`|`images.md`|Different devices render visuals at varying resolutions|
-|`immersive-experiences`|`immersive-experiences/` ×6|Provide users with multiple ways to interact with your application or game|
+|`immersive-experiences`|`immersive-experiences/`|Provide users with multiple ways to interact with your application or game|
 |`lists-and-tables`|`lists-and-tables.md`|Tables and lists display information arranged across one or more columns of rows|
-|`menus`|`menus/` ×8||
+|`menus`|`menus/`||
 |`multitasking`|`multitasking.md`|Multitasking enables users to rapidly transition between applications and…|
 |`ornaments`|`ornaments.md`|In visionOS, an ornament displays controls and information pertaining to a…|
 |`page-controls`|`page-controls.md`|page control presents a horizontal row of indicator images, with each image…|
 |`pickers`|`pickers.md`|picker presents one or more scrollable lists containing unique values from…|
-|`playing-audio`|`playing-audio/` ×3|Silence|
+|`playing-audio`|`playing-audio/`|Silence|
 |`playing-haptics`|`playing-haptics.md`|Haptic feedback can involve users' sense of touch, allowing you to integrate a…|
-|`playing-video`|`playing-video/` ×3|system-provided video players support different aspect ratio playback modes…|
+|`playing-video`|`playing-video/`|system-provided video players support different aspect ratio playback modes…|
 |`progress-indicators`|`progress-indicators.md`|Progress indicators inform users that your application is actively working,…|
-|`scroll-views`|`scroll-views/` ×2|Support default scrolling gestures and keyboard shortcuts|
+|`scroll-views`|`scroll-views/`|Support default scrolling gestures and keyboard shortcuts|
 |`search-fields`|`search-fields.md`|search field allows users to locate specific content within a collection using…|
 |`segmented-controls`|`segmented-controls.md`|segmented control presents as a linear arrangement of two or more segments,…|
 |`sheets`|`sheets.md`|sheet enables users to execute a focused task that is contextually linked to…|
 |`sidebars`|`sidebars.md`|sidebar is a view element that appears on the leading edge of a screen,…|
 |`sliders`|`sliders.md`|slider consists of a horizontal track and a control, known as the thumb, which…|
-|`spatial-layout`|`spatial-layout/` ×4|person’s *field of view* refers to the visual area they perceive without…|
+|`spatial-layout`|`spatial-layout/`|person’s *field of view* refers to the visual area they perceive without…|
 |`split-views`|`split-views.md`|split view manages the simultaneous presentation of multiple adjacent content…|
 |`tab-bars`|`tab-bars.md`|tab bar enables users to navigate between the application's highest-level…|
 |`text-fields`|`text-fields.md`|text field is a rectangular region where users input or modify brief, specific…|
-|`toolbars`|`toolbars/` ×7|Toolbars perform actions on content within the view, facilitate movement…|
-|`windows`|`windows/` ×4|Conceptually, applications utilize two kinds of windows to display content:|
+|`toolbars`|`toolbars/`|Toolbars perform actions on content within the view, facilitate movement…|
+|`windows`|`windows/`|Conceptually, applications utilize two kinds of windows to display content:|

--- a/plugins/apple-design/skills/watchos/SKILL.md
+++ b/plugins/apple-design/skills/watchos/SKILL.md
@@ -9,7 +9,7 @@ Platform-specific HIG for watchOS. Components, controls, navigation patterns, an
 
 ## How to use
 1. **Match the user's UI element to a topic** — most map directly to component or pattern names.
-2. **Read only the matched references**. Multi-file topics (`×N`) live in `references/<topic>/`.
+2. **Read only the matched references**. Directory topics live in `references/<topic>/`.
 3. **Pull in `foundations`** for shared principles (color, typography, layout, accessibility, shared UI like rating indicators).
 4. **Pull in `services`** when integrating Apple frameworks (Pay, HealthKit, Siri, sensors, media playback).
 5. **Stay on watchOS.** For another Apple platform, point to the matching skill.
@@ -24,11 +24,11 @@ Platform-specific HIG for watchOS. Components, controls, navigation patterns, an
 |`always-on`|`always-on.md`|On devices equipped with Always On display, the system can keep an app's…|
 |`buttons`|`buttons.md`|Style|
 |`collaboration-and-sharing`|`collaboration-and-sharing.md`|Effective collaboration and sharing experiences are straightforward and highly…|
-|`complications`|`complications/` ×8|While most watch faces can accommodate at least one complication, some support…|
+|`complications`|`complications/`|While most watch faces can accommodate at least one complication, some support…|
 |`context-menus`|`context-menus.md`|context menu grants access to item-specific functionality without adding visual…|
 |`designing-for-watchos`|`designing-for-watchos.md`|When a user glances at their Apple Watch, they understand it provides quick…|
 |`digital-crown`|`digital-crown.md`|Digital Crown functions as a crucial hardware input mechanism for Apple Vision…|
-|`drag-and-drop`|`drag-and-drop/` ×4|Depending on different factors, the drag and drop action may *move* the…|
+|`drag-and-drop`|`drag-and-drop/`|Depending on different factors, the drag and drop action may *move* the…|
 |`image-views`|`image-views.md`|image view presents either a static image or an animated sequence against a…|
 |`images`|`images.md`|To ensure optimal visual quality across all supported devices, familiarize…|
 |`labels`|`labels.md`|label is static text that users can read and often copy, but they cannot modify|
@@ -36,9 +36,9 @@ Platform-specific HIG for watchOS. Components, controls, navigation patterns, an
 |`multitasking`|`multitasking.md`|Multitasking enables users to rapidly transition between applications and…|
 |`page-controls`|`page-controls.md`|page control presents a horizontal row of indicator images, with each image…|
 |`pickers`|`pickers.md`|picker presents one or more scrollable lists containing unique values from…|
-|`playing-audio`|`playing-audio/` ×3|Silence|
+|`playing-audio`|`playing-audio/`|Silence|
 |`playing-haptics`|`playing-haptics.md`|Beyond inherent haptic capabilities, certain external input devices can also…|
-|`playing-video`|`playing-video/` ×3|system-provided video players support different aspect ratio playback modes…|
+|`playing-video`|`playing-video/`|system-provided video players support different aspect ratio playback modes…|
 |`progress-indicators`|`progress-indicators.md`|Progress indicators inform users that your application is actively working,…|
 |`scroll-views`|`scroll-views.md`|Support default scrolling gestures and keyboard shortcuts|
 |`search-fields`|`search-fields.md`|search field allows users to locate specific content within a collection using…|
@@ -51,7 +51,7 @@ Platform-specific HIG for watchOS. Components, controls, navigation patterns, an
 |`tab-bars`|`tab-bars.md`|tab bar enables users to navigate between the application's highest-level…|
 |`tab-views`|`tab-views.md`|tab view displays several distinct content areas within a single frame,…|
 |`text-fields`|`text-fields.md`|text field is a rectangular region where users input or modify brief, specific…|
-|`toolbars`|`toolbars/` ×6|Toolbars perform actions on content within the view, facilitate movement…|
+|`toolbars`|`toolbars/`|Toolbars perform actions on content within the view, facilitate movement…|
 |`watch-faces`|`watch-faces.md`|watch face serves as the primary view selected by users within watchOS|
 |`windows`|`windows.md`|window displays the user interface views and components within your application…|
 |`workouts`|`workouts.md`|high-quality fitness or workout experience motivates users to engage with their…|


### PR DESCRIPTION
## Summary
- update Apple Design plugin metadata to avoid platform-count phrasing
- remove Apple glossary `×N` reference-file counts while keeping directory references intact
- regenerate plugin and marketplace metadata from source

## Validation
- `bun run ci`
- `git diff --check`