### PR TITLE
feat: add repository docs plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -117,6 +117,22 @@
 			}
 		},
 		{
+			"name": "repository-docs",
+			"source": {
+				"source": "local",
+				"path": "./plugins/repository-docs"
+			},
+			"policy": {
+				"installation": "AVAILABLE",
+				"authentication": "ON_INSTALL"
+			},
+			"category": "Documentation",
+			"interface": {
+				"displayName": "Repository Docs",
+				"shortDescription": "README and contributor docs"
+			}
+		},
+		{
 			"name": "skill-creation",
 			"source": {
 				"source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -137,6 +137,24 @@
 			]
 		},
 		{
+			"name": "repository-docs",
+			"source": "./plugins/repository-docs",
+			"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
+			"version": "1.1.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Documentation",
+			"keywords": [
+				"readme",
+				"contributing",
+				"documentation",
+				"open-source",
+				"internal-docs"
+			]
+		},
+		{
 			"name": "skill-creation",
 			"source": "./plugins/skill-creation",
 			"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -47,6 +47,11 @@
 			"description": "Project setup and context management skills for requirements and shared agent context."
 		},
 		{
+			"name": "repository-docs",
+			"source": "repository-docs",
+			"description": "Repository documentation maintenance for public open-source projects and private internal project hubs."
+		},
+		{
 			"name": "skill-creation",
 			"source": "skill-creation",
 			"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills."

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -39,6 +39,19 @@
 			}
 		},
 		{
+			"name": "repository-docs",
+			"displayName": "Repository Docs",
+			"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
+			"shortDescription": "README and contributor docs",
+			"category": "Documentation",
+			"keywords": ["readme", "contributing", "documentation", "open-source", "internal-docs"],
+			"skills": ["closed-source-docs", "open-source-docs"],
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			}
+		},
+		{
 			"name": "frontend",
 			"displayName": "Frontend",
 			"description": "Frontend design exploration toolkit for interactive HTML design options.",

--- a/plugins/repository-docs/.claude-plugin/plugin.json
+++ b/plugins/repository-docs/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+	"name": "repository-docs",
+	"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
+	"version": "1.1.0",
+	"skills": [
+		"./skills/closed-source-docs",
+		"./skills/open-source-docs"
+	],
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"readme",
+		"contributing",
+		"documentation",
+		"open-source",
+		"internal-docs"
+	]
+}

--- a/plugins/repository-docs/.codex-plugin/plugin.json
+++ b/plugins/repository-docs/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+	"name": "repository-docs",
+	"version": "1.1.0",
+	"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"readme",
+		"contributing",
+		"documentation",
+		"open-source",
+		"internal-docs"
+	],
+	"skills": "./skills/",
+	"interface": {
+		"displayName": "Repository Docs",
+		"shortDescription": "README and contributor docs",
+		"longDescription": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
+		"developerName": "Luca Silverentand",
+		"category": "Documentation",
+		"capabilities": [
+			"Read",
+			"Write"
+		],
+		"websiteURL": "https://github.com/lucasilverentand/skills",
+		"defaultPrompt": [
+			"Use Repository Docs when the task matches one of its bundled skills."
+		]
+	}
+}

--- a/plugins/repository-docs/.cursor-plugin/plugin.json
+++ b/plugins/repository-docs/.cursor-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+	"name": "repository-docs",
+	"displayName": "Repository Docs",
+	"version": "1.1.0",
+	"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"license": "MIT",
+	"keywords": [
+		"readme",
+		"contributing",
+		"documentation",
+		"open-source",
+		"internal-docs"
+	]
+}

--- a/plugins/repository-docs/README.md
+++ b/plugins/repository-docs/README.md
@@ -1,0 +1,35 @@
+# Repository Docs
+Repository documentation maintenance for public open-source projects and private internal project hubs.
+
+## Skills
+- `repository-docs:closed-source-docs`
+- `repository-docs:open-source-docs`
+
+## Install
+Codex:
+
+```bash
+codex plugin marketplace add lucasilverentand/skills
+```
+
+Claude Code:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install repository-docs@skills-of-luca
+```
+
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `repository-docs` (Required or Optional)
+
+Cursor (IDE slash commands):
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install repository-docs@skills-of-luca
+```
+
+This plugin owns its skill source under `plugins/repository-docs/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/repository-docs/skills/closed-source-docs/SKILL.md
+++ b/plugins/repository-docs/skills/closed-source-docs/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: closed-source-docs
+description: Creates, audits, and updates private or closed-source project documentation, including internal README hubs, codebase navigation guides, ownership links, Linear initiative links, onboarding notes, runbooks, and contribution guidance for teams. Use when maintaining docs for private repositories, internal apps, services, infrastructure, or company projects, especially when the user says "make this README an internal hub", "document how to navigate this repo", "add Linear links to the docs", or "write private project documentation".
+---
+
+# Closed Source Docs
+Use this skill to make a private repository easy for teammates and agents to understand, operate, and change without turning the README into public marketing copy.
+
+## First pass
+1. Confirm the repo is private, internal, or otherwise not intended as a public open-source project. If unsure, inspect remotes, license, package metadata, GitHub visibility hints, and existing docs before assuming.
+2. Read existing docs and project context: `README*`, `CONTRIBUTING*`, `AGENTS.md`, `CLAUDE.md`, `.github/`, `docs/`, package manifests, deployment config, CI workflows, and local tooling files.
+3. Identify the real operating surface: app, service, package, infrastructure repo, automation, data pipeline, plugin, or monorepo.
+4. Find authoritative links where possible: Linear initiative or project, GitHub project, deployment dashboard, observability, runbooks, design docs, ADRs, incidents, and support channel.
+5. Preserve sensitive details carefully. Internal docs can link to private systems, but avoid copying secrets, credentials, customer data, private tokens, or unnecessary personal information.
+
+## README as hub
+Closed-source READMEs should help maintainers move fast. Prefer this structure:
+
+1. **Project identity**: name, one-sentence purpose, owner/team, and current status.
+2. **Primary links**: Linear initiative, GitHub repo or project, production/staging URLs, dashboards, runbooks, design docs, and support channel.
+3. **What lives here**: short explanation of the codebase boundaries and what belongs elsewhere.
+4. **Quick local start**: prerequisites, install command, environment setup, run command, and test command.
+5. **Codebase map**: important directories, packages, services, entrypoints, generated files, and ownership notes.
+6. **Common workflows**: develop, test, typecheck, lint, generate, migrate, deploy, release, and rollback.
+7. **Operational notes**: environments, scheduled jobs, queues, data stores, observability, alerts, and known failure modes.
+8. **How to change it**: branch or issue conventions, PR expectations, validation gates, code owners, and documentation update rules.
+9. **Open questions or known gaps**: only if the repo already tracks them here; otherwise file issues instead of turning the README into a backlog.
+
+## Contribution guidance
+- Use `CONTRIBUTING.md` for recurring team workflow: local setup, branch naming, commit and PR expectations, review policy, generated artifacts, validation commands, release steps, and rollback notes.
+- Keep repo-specific agent instructions in `AGENTS.md`, `CLAUDE.md`, or equivalent files when the project already uses them.
+- Link to Linear rather than duplicating planning detail. Prefer the initiative for long-lived context and issues for specific implementation tasks.
+- If docs reveal follow-up work, file it in the project tracker instead of expanding the current documentation change.
+
+## Writing rules
+- Write for the next teammate or agent who has repository access but no meeting context.
+- Make authoritative links visible near the top. A private README is often a control panel, not a sales page.
+- State ownership and boundaries plainly. Readers should know who owns the system and what this repo should not be used for.
+- Prefer exact commands over prose. Match package scripts, task runners, Makefiles, and CI names.
+- Mark access requirements: required accounts, secrets source, VPN, local services, cloud permissions, hardware, or staging data.
+- Keep sensitive values out of docs. Say where to obtain them, not what they are.
+- Avoid public-open-source boilerplate unless the repo is actually meant to accept outside users or contributors.
+
+## Update workflow
+1. Inventory the docs and remove conflicts between README, CONTRIBUTING, runbooks, and agent instructions.
+2. Verify commands against the repo's real scripts before documenting them.
+3. Check whether links are durable enough for a README. Prefer stable Linear initiative, dashboard, and runbook links over one-off comments.
+4. Keep planning, implementation detail, operations, and contribution policy in their owning files; cross-link instead of copying.
+5. Add missing docs only when they have a clear owner and recurring reader.
+6. Run available Markdown, formatting, and repo validation checks.
+
+## Done checklist
+- [ ] The README is a practical internal hub with owner, status, links, setup, and codebase map.
+- [ ] Linear or project-tracker links point to durable initiative or project context when available.
+- [ ] Local setup and validation commands match the repo.
+- [ ] Contribution guidance lives in `CONTRIBUTING.md` or an existing equivalent.
+- [ ] Sensitive data is referenced by source or process, not copied into docs.
+- [ ] Follow-up work is tracked outside the README.

--- a/plugins/repository-docs/skills/open-source-docs/SKILL.md
+++ b/plugins/repository-docs/skills/open-source-docs/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: open-source-docs
+description: Creates, audits, and updates public open-source repository documentation, including README files, CONTRIBUTING guides, SECURITY and SUPPORT docs, project badges, quickstarts, usage guidance, community links, and contributor onboarding. Use when maintaining docs for public GitHub projects, libraries, CLIs, apps, or reusable packages, especially when the user says "update this README", "write CONTRIBUTING.md", "make these docs open-source ready", or "improve the public project docs".
+---
+
+# Open Source Docs
+Use this skill to make public repository documentation useful to first-time users, evaluators, contributors, and maintainers.
+
+## First pass
+1. Inspect the repository before writing: `README*`, `CONTRIBUTING*`, `SECURITY*`, `SUPPORT*`, `CODE_OF_CONDUCT*`, `LICENSE*`, `.github/`, package manifests, examples, docs folders, CI workflows, and release files.
+2. Determine the project type from the code, not just the current README: app, library, CLI, template, infrastructure repo, plugin, or mixed workspace.
+3. Identify the public audience:
+   - **Evaluator**: deciding whether the project is active, trustworthy, and a fit.
+   - **User**: installing, configuring, and using it.
+   - **Contributor**: filing issues, running checks, and submitting changes.
+   - **Maintainer**: reviewing releases, support, and security process.
+4. Preserve accurate existing content. Remove stale claims, vague hype, and instructions that no longer match the repo.
+
+## README shape
+Prefer this flow unless the repo already has a stronger public convention:
+
+1. **Header**: project name, one-sentence purpose, compact status signals, and useful badges. Use a logo or banner only when the repo already has one or the user provides one.
+2. **Why it exists**: what problem it solves, who it is for, and what makes it different in concrete terms.
+3. **Install or setup**: shortest successful path from clean machine to usable project.
+4. **Quickstart**: one runnable example or workflow that proves the project works.
+5. **Usage**: common commands, configuration, API examples, screenshots, or integration notes as appropriate.
+6. **Project layout**: only include this when the repo is large enough that readers need orientation.
+7. **Development**: local prerequisites, install command, test/lint/typecheck commands, and any generated-file workflow.
+8. **Contributing**: link to `CONTRIBUTING.md`; keep detailed contribution rules there.
+9. **Support and security**: link to issue templates, discussions, `SUPPORT.md`, and `SECURITY.md` when present.
+10. **License**: state the license and link to `LICENSE`.
+
+## Supporting docs
+- Put contributor workflow, coding standards, branch naming, commit conventions, PR expectations, and local validation in `CONTRIBUTING.md`.
+- Put vulnerability reporting, supported versions, and disclosure expectations in `SECURITY.md`.
+- Put help channels, issue triage expectations, and commercial/community support boundaries in `SUPPORT.md`.
+- Put long examples in `docs/`, `examples/`, or package-specific files and link them from the README.
+- Keep `.github/ISSUE_TEMPLATE/*` and `.github/PULL_REQUEST_TEMPLATE*` aligned with the README and CONTRIBUTING guide.
+
+## Writing rules
+- Be concrete. Use actual commands, package names, paths, environment variables, ports, and artifact names.
+- Make the first successful path obvious. A new user should know exactly what to run.
+- Separate user docs from contributor docs. The README can point to contribution details, but it should not become a maintainer handbook.
+- Prefer public links and public context. Do not include private Linear links, internal Slack channels, private runner names, or company-only context unless the user explicitly asks and the repo is not public.
+- Avoid fake completeness. If setup depends on missing secrets, services, hardware, or access, say so directly.
+- Use GitHub Flavored Markdown tables only when comparison or scanning is better than prose.
+- Keep badges useful: CI, package version, license, docs, coverage, or security. Do not add vanity badges.
+
+## Update workflow
+1. Build an inventory of docs and note conflicts between files.
+2. Verify commands against package scripts or Makefiles before documenting them.
+3. Update the smallest set of docs that fixes the reader journey.
+4. Remove duplicated instructions when one canonical doc can own them.
+5. If you change generated docs or generated examples, run the repo's generator and commit generated output with the source.
+6. Validate Markdown formatting and links with available project checks.
+
+## Done checklist
+- [ ] The README tells a public reader what the project is, why it matters, and how to try it.
+- [ ] Install, quickstart, and validation commands match the repo.
+- [ ] CONTRIBUTING owns detailed contribution workflow.
+- [ ] SECURITY and SUPPORT exist or the README clearly points to the current public process.
+- [ ] Public docs do not leak private project-management, infrastructure, or company context.
+- [ ] Links, badges, and file references are current.


### PR DESCRIPTION
## Summary

Adds a new Repository Docs plugin for maintaining README and contributor documentation across public and private repositories.

- Adds `repository-docs:open-source-docs` for public project READMEs, contribution guides, support, and security docs.
- Adds `repository-docs:closed-source-docs` for private/internal README hubs with ownership, Linear links, codebase maps, and operational guidance.
- Registers the plugin in `plugin-groups.json` and refreshes generated manifests, plugin README, and marketplaces.

## Checklist

- [x] Edited `plugins/<plugin>/skills/...` and updated `plugin-groups.json` if membership or plugin metadata changed
- [x] Ran `bun run marketplace:write` when sources affect generated manifests, READMEs, or marketplaces
- [x] Ran `bun run ci` locally, or confirmed the **`validate`** CI check is green

## Validation

- `bun run marketplace:write`
- `bun run ci`
- `git diff --check`