### PR TITLE
feat(design): add design system skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -21,6 +21,22 @@
 			}
 		},
 		{
+			"name": "design",
+			"source": {
+				"source": "local",
+				"path": "./plugins/design"
+			},
+			"policy": {
+				"installation": "AVAILABLE",
+				"authentication": "ON_INSTALL"
+			},
+			"category": "Design",
+			"interface": {
+				"displayName": "Design",
+				"shortDescription": "Design system synthesis"
+			}
+		},
+		{
 			"name": "documentation",
 			"source": {
 				"source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,6 +34,27 @@
 			]
 		},
 		{
+			"name": "design",
+			"source": "./plugins/design",
+			"description": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.",
+			"version": "1.2.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Design",
+			"keywords": [
+				"design",
+				"design-system",
+				"moodboard",
+				"screenshots",
+				"video",
+				"ui",
+				"ux",
+				"DESIGN.md"
+			]
+		},
+		{
 			"name": "documentation",
 			"source": "./plugins/documentation",
 			"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -17,6 +17,11 @@
 			"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services."
 		},
 		{
+			"name": "design",
+			"source": "design",
+			"description": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references."
+		},
+		{
 			"name": "documentation",
 			"source": "documentation",
 			"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees."

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -39,6 +39,19 @@
 			}
 		},
 		{
+			"name": "design",
+			"displayName": "Design",
+			"description": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.",
+			"shortDescription": "Design system synthesis",
+			"category": "Design",
+			"keywords": ["design", "design-system", "moodboard", "screenshots", "video", "ui", "ux", "DESIGN.md"],
+			"skills": ["design-system"],
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			}
+		},
+		{
 			"name": "repository-docs",
 			"displayName": "Repository Docs",
 			"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",

--- a/plugins/design/.claude-plugin/plugin.json
+++ b/plugins/design/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+	"name": "design",
+	"description": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.",
+	"version": "1.2.0",
+	"skills": [
+		"./skills/design-system"
+	],
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"design",
+		"design-system",
+		"moodboard",
+		"screenshots",
+		"video",
+		"ui",
+		"ux",
+		"DESIGN.md"
+	]
+}

--- a/plugins/design/.codex-plugin/plugin.json
+++ b/plugins/design/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+	"name": "design",
+	"version": "1.2.0",
+	"description": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"design",
+		"design-system",
+		"moodboard",
+		"screenshots",
+		"video",
+		"ui",
+		"ux",
+		"DESIGN.md"
+	],
+	"skills": "./skills/",
+	"interface": {
+		"displayName": "Design",
+		"shortDescription": "Design system synthesis",
+		"longDescription": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.",
+		"developerName": "Luca Silverentand",
+		"category": "Design",
+		"capabilities": [
+			"Read",
+			"Write"
+		],
+		"websiteURL": "https://github.com/lucasilverentand/skills",
+		"defaultPrompt": [
+			"Use Design when the task matches one of its bundled skills."
+		]
+	}
+}

--- a/plugins/design/.cursor-plugin/plugin.json
+++ b/plugins/design/.cursor-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+	"name": "design",
+	"displayName": "Design",
+	"version": "1.2.0",
+	"description": "Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"license": "MIT",
+	"keywords": [
+		"design",
+		"design-system",
+		"moodboard",
+		"screenshots",
+		"video",
+		"ui",
+		"ux",
+		"DESIGN.md"
+	]
+}

--- a/plugins/design/README.md
+++ b/plugins/design/README.md
@@ -1,0 +1,34 @@
+# Design
+Design system synthesis from screenshots, moodboards, videos, URLs, chat briefs, and mixed visual references.
+
+## Skills
+- `design:design-system`
+
+## Install
+Codex:
+
+```bash
+codex plugin marketplace add lucasilverentand/skills
+```
+
+Claude Code:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install design@skills-of-luca
+```
+
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `design` (Required or Optional)
+
+Cursor (IDE slash commands):
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install design@skills-of-luca
+```
+
+This plugin owns its skill source under `plugins/design/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/design/skills/design-system/SKILL.md
+++ b/plugins/design/skills/design-system/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: design-system
+description: Synthesizes build-ready design systems and DESIGN.md files from chat briefs, screenshots, moodboards, videos, URLs, live pages, or local image folders while preserving the target product identity. Use when the user asks to "make a design system from these screenshots", "turn this moodboard into DESIGN.md", "extract the design language from this video", "define the UX vibe and rules from these references", or create cohesive UI rules from visual inspiration.
+---
+
+# Design System
+Use this skill to turn mixed inspiration into a target-product design system that another agent or engineer can build from.
+
+The job is not to copy reference apps. Extract the underlying mechanics, then translate them through the product being designed.
+
+## Decision tree
+- What input did the user provide?
+  - **Chat-only brief** -> extract product anchor, desired feel, constraints, and missing context from the conversation.
+  - **Images, screenshots, or moodboard** -> read `references/ingestion-workflow.md`, inspect each image, and classify observed details as transferable, adaptable, or rejected.
+  - **Video or animation capture** -> read `references/ingestion-workflow.md`, sample representative frames, and capture temporal behavior separately from static visual rules.
+  - **URL or live page** -> inspect the page as supporting evidence; preserve screenshots or provided artifacts as the primary inspiration source when both exist.
+  - **Local folder** -> inventory image and video files first, then sample enough artifacts to understand the repeated design grammar.
+  - **Existing DESIGN.md** -> update it in place, preserve useful product-specific rules, and replace vague or copied-inspiration rules with target-aware system rules.
+
+## Workflow
+1. Establish the target-product anchor before synthesis:
+   - App purpose and audience.
+   - Core workflows and primary objects.
+   - Existing UI, repo context, or platform conventions.
+   - What must stay recognizable after the redesign.
+2. Ingest the inputs using `references/ingestion-workflow.md`.
+3. Separate reference observations into:
+   - **Transferable**: spacing logic, material treatment, hierarchy, affordance style, state behavior, motion pacing, and tone.
+   - **Adaptable**: component ideas that need reshaping around the target app's own objects and workflows.
+   - **Rejected**: domain-specific layouts, metaphors, navigation, data models, branding, or content patterns that would pull the product into the inspiration app's identity.
+4. Synthesize the core system:
+   - Write the few governing principles first.
+   - Derive visual grammar, layout rhythm, interaction rules, motion, content tone, and component behavior from those principles.
+   - Include small details only when they reinforce the whole: corner logic, stroke weight, hover timing, focus treatment, shadow behavior, icon density, empty states, copy cadence, and transitions.
+5. Write or update `DESIGN.md`.
+   - Use the repo root unless the project already has an obvious design-doc convention.
+   - Use `references/design-md-template.md` as the target structure.
+6. Check each rule against the product-identity guardrail:
+   - Does this make the original app feel more coherent?
+   - Or does it pull the app toward the reference product's domain?
+
+## Product-identity guardrail
+Translate inspiration through the target app's job. A contacts app can inspire rhythm, hierarchy, density, list treatment, or tactile detail for a photo editor, but it must not make the photo editor behave like a contacts app.
+
+If the target-product anchor is missing, inspect the repo or ask for the app's purpose before writing final design rules. Never finalize a `DESIGN.md` from references alone.
+
+## Writing rules
+- Prefer system language over mood language: "primary actions earn contrast through placement and weight before color" beats "clean and premium."
+- Tie every detail back to a principle or workflow.
+- Name what not to borrow from each reference.
+- Make implementation constraints concrete enough for code review: token ranges, component states, responsive behavior, accessibility checks, and examples of acceptable variation.
+- Preserve platform conventions unless the user explicitly wants a custom interaction model.
+- Do not claim to imitate a specific designer. Capture design discipline and system logic instead.
+
+## Output checklist
+- [ ] `DESIGN.md` names the target product and what must stay recognizable.
+- [ ] Inspiration is classified into transferable, adaptable, and rejected details.
+- [ ] The design thesis can guide future screens without re-opening the moodboard.
+- [ ] Component and interaction rules are product-specific, not copied from reference domains.
+- [ ] Tiny details are connected to the whole system.
+- [ ] Accessibility and responsive behavior are explicit.
+- [ ] Open questions are clearly marked instead of hidden behind invented certainty.
+
+## References
+|Reference|Use|
+|---|---|
+|`references/ingestion-workflow.md`|How to analyze chat, images, folders, URLs, videos, and mixed inputs.|
+|`references/design-md-template.md`|The structure to use when writing or updating `DESIGN.md`.|

--- a/plugins/design/skills/design-system/references/design-md-template.md
+++ b/plugins/design/skills/design-system/references/design-md-template.md
@@ -1,0 +1,138 @@
+# DESIGN.md Template
+Use this shape when creating or refreshing `DESIGN.md`. Keep sections concise, but do not collapse away decisions another agent needs to implement the system.
+
+## Target product anchor
+- **Product**:
+- **Audience**:
+- **Primary workflows**:
+- **Core objects**:
+- **Must stay recognizable**:
+- **Must not become**:
+
+## Source inventory
+|Source|Type|Role|What it contributes|
+|---|---|---|---|
+|...|...|target, inspiration, constraint, anti-reference|...|
+
+## Inspiration analysis
+Summarize what the references share. Focus on mechanics rather than taste adjectives.
+
+### Transferable principles
+- ...
+
+### Adaptable ideas
+- ...
+
+### Rejected borrowings
+- ...
+
+## Design thesis
+One paragraph describing the system the product should follow. This should explain how many small rules create one coherent product feel.
+
+## Core principles
+List 3-6 principles. Each principle needs a rationale and a practical implication.
+
+|Principle|Rationale|Practical implication|
+|---|---|---|
+|...|...|...|
+
+## Visual grammar
+Define the recurring forms of the interface:
+
+- Shape language:
+- Surface model:
+- Depth and separation:
+- Icon and symbol style:
+- Image or media treatment:
+- Density:
+
+## Layout rhythm
+- Grid and alignment:
+- Spacing scale:
+- Page structure:
+- Navigation structure:
+- Panel and sidebar behavior:
+- Empty and loading layouts:
+
+## Color and material system
+- Base surfaces:
+- Text colors:
+- Accent behavior:
+- Borders and dividers:
+- Elevation or shadow:
+- Selection and focus:
+- Error, warning, success:
+
+Use ranges or token names when exact values are unknown. Avoid decorative color unless it carries hierarchy, state, or meaning.
+
+## Typography
+- Font family:
+- Type scale:
+- Heading behavior:
+- Body and metadata behavior:
+- Numeric or tabular text:
+- Line length and wrapping:
+
+## Components
+Define components as system rules, not a full component library unless the app needs one.
+
+|Component|Purpose|Rules|States|
+|---|---|---|---|
+|Primary action|...|...|default, hover, pressed, disabled, loading|
+|...|...|...|...|
+
+## Interaction states
+- Hover:
+- Pressed:
+- Selected:
+- Focus:
+- Disabled:
+- Loading:
+- Empty:
+- Error:
+- Success:
+
+## Motion
+- Motion purpose:
+- Duration ranges:
+- Easing:
+- Choreography:
+- What should not animate:
+
+## Content voice
+- Labels:
+- Empty states:
+- Error messages:
+- Confirmation copy:
+- Tone boundaries:
+
+## Responsive and accessibility rules
+- Keyboard behavior:
+- Touch targets:
+- Contrast:
+- Reduced motion:
+- Screen reader naming:
+- Small-screen layout:
+- Large-screen layout:
+
+## Implementation guardrails
+- Reuse existing product concepts and navigation unless explicitly changed.
+- Keep inspiration domain-specific metaphors out of the target app.
+- Introduce tokens before one-off styles.
+- Keep repeated controls visually stable across screens.
+- Prefer native platform behavior where it helps the product feel expected.
+
+## Detail checklist
+Use this before implementing or reviewing UI:
+
+- [ ] Do the tiny details reinforce the same system?
+- [ ] Are primary actions clear without relying only on color?
+- [ ] Are spacing and density consistent across repeated structures?
+- [ ] Do empty, loading, and error states use the same voice and visual grammar?
+- [ ] Does motion clarify continuity instead of decorating the interface?
+- [ ] Does each borrowed idea still serve the target app's job?
+
+## Open questions
+|Question|Why it matters|Owner|
+|---|---|---|
+|...|...|...|

--- a/plugins/design/skills/design-system/references/ingestion-workflow.md
+++ b/plugins/design/skills/design-system/references/ingestion-workflow.md
@@ -1,0 +1,70 @@
+# Ingestion Workflow
+Use this workflow to turn raw inspiration into target-aware design-system evidence.
+
+## Source inventory
+Start with a compact inventory:
+
+|Source|Type|Role|Confidence|Notes|
+|---|---|---|---|---|
+|`path`, URL, or attachment label|chat, image, video, URL, folder|target product, inspiration, constraint, anti-reference|high, medium, low|What it contributes|
+
+Mark which inputs describe the target product and which are only inspiration. If no source describes the target product, inspect the repo or ask for the app purpose before final synthesis.
+
+## Chat briefs
+- Extract the user's stated product, audience, workflow, tone, constraints, and disliked directions.
+- Preserve strong phrases from the user as intent anchors, but turn them into implementable rules.
+- Flag vague words such as "premium", "playful", or "simple" until they are backed by concrete visual or interaction behavior.
+
+## Images and screenshots
+Inspect each image for reusable mechanics:
+
+- Composition: density, alignment, grouping, whitespace, focal areas.
+- Hierarchy: what earns size, contrast, placement, or persistent visibility.
+- Material: surface depth, borders, shadows, translucency, texture, separation.
+- Components: controls, cards, lists, toolbars, panels, modals, empty states.
+- State: selected, hover, pressed, disabled, loading, error, success.
+- Content: copy length, labels, metadata, icon/text balance.
+- Platform conventions: native controls, navigation, pointer or touch affordances.
+
+Then classify each observation:
+
+|Class|Meaning|Example|
+|---|---|---|
+|Transferable|Can apply directly as design-system logic.|Quiet hierarchy where metadata recedes before actions.|
+|Adaptable|Useful idea, but the component or domain needs reshaping.|A contacts list rhythm becomes a photo asset browser rhythm.|
+|Rejected|Would distort the target product identity.|Contacts-first navigation in a photo editor.|
+
+Do not let a reference app donate its data model, core navigation, or product metaphor unless the target app actually shares that job.
+
+## Local folders
+- List the files first so the analysis has a clear source trail.
+- Group visually similar images instead of analyzing every duplicate at full depth.
+- Sample enough examples to catch repeated rules and exceptions.
+- Note outliers separately; do not let one striking image override the system.
+
+## URLs and live pages
+- Use URLs to inspect interaction, responsive behavior, and details missing from still screenshots.
+- Treat live pages as supporting evidence when the user supplied screenshots or a moodboard.
+- Avoid copying site content, brand assets, or information architecture unless the user says the URL is the target app.
+- Capture source-specific constraints, such as responsive breakpoints, hover behavior, or motion, as observations before translating them.
+
+## Videos
+- Sample representative frames: opening state, main action, transition midpoint, completed state, edge or error state if visible.
+- Capture temporal behavior separately from static style:
+  - Pacing and duration.
+  - Easing and choreography.
+  - Object continuity between states.
+  - Gesture or pointer relationship.
+  - What changes instantly versus what animates.
+- Translate motion into rules, not one-off animation notes. For example: "Panels settle with short deceleration after content appears" is better than "use a nice slide animation."
+
+## Mixed inputs
+When sources conflict, prioritize in this order:
+
+1. Target app purpose and core workflows.
+2. Existing product constraints and platform conventions.
+3. User-stated direction.
+4. Repeated patterns across inspiration sources.
+5. Single-source details.
+
+Record rejected conflicts in `DESIGN.md` so future agents do not reintroduce them.


### PR DESCRIPTION
## Summary
- add a new `design` plugin
- add `design:design-system` for turning chat, images, moodboards, videos, URLs, and folders into build-ready `DESIGN.md` guidance
- include ingestion and `DESIGN.md` template references that keep inspiration anchored to the target app's product identity

## Details
- Classifies inspiration details as transferable, adaptable, or rejected so a reference app does not overwrite the target product's domain.
- Requires a target-product anchor before final synthesis: purpose, audience, workflows, core objects, existing UI or platform context, and what must stay recognizable.
- Regenerates Codex, Claude, and Cursor plugin manifests plus marketplace entries.

## Validation
- `bun run marketplace:write`
- `bun run marketplace`
- `bun run validate:cursor`
- `bun run check --strict`
- `bun scripts/validate-json.ts`
- `python3 /Users/luca/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/design/skills/design-system`
- `git diff --check`
- `bun run ci`

## Local install refresh
- `bun run install:codex-skills -- --symlink --force design:design-system`
- `bun run install:claude-skills -- --symlink --force design:design-system`