### PR TITLE
Add project intent interview skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
 		"url": "https://github.com/lucasilverentand"
 	},
 	"description": "Reusable agent skills by Luca Silverentand.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"metadata": {
-		"version": "1.1.0",
+		"version": "1.2.0",
 		"homepage": "https://github.com/lucasilverentand/skills",
 		"repository": "https://github.com/lucasilverentand/skills",
 		"license": "MIT"
@@ -18,7 +18,7 @@
 			"name": "apple-design",
 			"source": "./plugins/apple-design",
 			"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "luca.silverentand@gmail.com"
@@ -37,7 +37,7 @@
 			"name": "documentation",
 			"source": "./plugins/documentation",
 			"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -54,7 +54,7 @@
 			"name": "frontend",
 			"source": "./plugins/frontend",
 			"description": "Frontend design exploration toolkit for interactive HTML design options.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -71,7 +71,7 @@
 			"name": "git",
 			"source": "./plugins/git",
 			"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -88,7 +88,7 @@
 			"name": "github",
 			"source": "./plugins/github",
 			"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -105,7 +105,7 @@
 			"name": "linear-planner",
 			"source": "./plugins/linear-planner",
 			"description": "Linear planning workflows and project document templates for turning product ideas into traceable plans, specs, decisions, and release checks.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -115,6 +115,7 @@
 				"linear",
 				"planning",
 				"projects",
+				"intent",
 				"issues",
 				"project-docs",
 				"templates"
@@ -124,7 +125,7 @@
 			"name": "project",
 			"source": "./plugins/project",
 			"description": "Project setup and context management skills for requirements and shared agent context.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -140,7 +141,7 @@
 			"name": "repository-docs",
 			"source": "./plugins/repository-docs",
 			"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -158,7 +159,7 @@
 			"name": "skill-creation",
 			"source": "./plugins/skill-creation",
 			"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"
@@ -175,7 +176,7 @@
 			"name": "systems-design",
 			"source": "./plugins/systems-design",
 			"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
-			"version": "1.1.0",
+			"version": "1.2.0",
 			"author": {
 				"name": "Luca Silverentand",
 				"email": "dev@lucasilverentand.com"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -7,7 +7,7 @@
 	},
 	"metadata": {
 		"description": "Reusable agent skills by Luca Silverentand.",
-		"version": "1.1.0",
+		"version": "1.2.0",
 		"pluginRoot": "plugins"
 	},
 	"plugins": [

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/lucasilverentand"
 	},
 	"metadata": {
-		"version": "1.1.0",
+		"version": "1.2.0",
 		"homepage": "https://github.com/lucasilverentand/skills",
 		"repository": "https://github.com/lucasilverentand/skills",
 		"license": "MIT"
@@ -111,7 +111,7 @@
 			"description": "Linear planning workflows and project document templates for turning product ideas into traceable plans, specs, decisions, and release checks.",
 			"shortDescription": "Linear planning and project docs",
 			"category": "Productivity",
-			"keywords": ["linear", "planning", "projects", "issues", "project-docs", "templates"],
+			"keywords": ["linear", "planning", "projects", "intent", "issues", "project-docs", "templates"],
 			"readmeBody": "README.body.txt",
 			"skills": [
 				"create-doc-template",
@@ -119,6 +119,7 @@
 				"estimate-issue-complexity",
 				"linear-issues",
 				"pickup-work",
+				"project-intent",
 				"project-docs",
 				"tidy-linear-project"
 			],

--- a/plugins/apple-design/.claude-plugin/plugin.json
+++ b/plugins/apple-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "apple-design",
 	"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/foundations",
 		"./skills/ios",

--- a/plugins/apple-design/.codex-plugin/plugin.json
+++ b/plugins/apple-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "apple-design",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/apple-design/.cursor-plugin/plugin.json
+++ b/plugins/apple-design/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "apple-design",
 	"displayName": "Apple Design",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Apple Human Interface Guidelines as a single plugin: foundations, platform guidance, and services.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/documentation/.claude-plugin/plugin.json
+++ b/plugins/documentation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "documentation",
 	"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/c4-diagrams",
 		"./skills/decision-trees",

--- a/plugins/documentation/.codex-plugin/plugin.json
+++ b/plugins/documentation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "documentation",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/documentation/.cursor-plugin/plugin.json
+++ b/plugins/documentation/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "documentation",
 	"displayName": "Documentation",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Documentation authoring and structured knowledge capture for design docs, ADRs, C4 diagrams, and decision trees.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/frontend/.claude-plugin/plugin.json
+++ b/plugins/frontend/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"description": "Frontend design exploration toolkit for interactive HTML design options.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/design-options"
 	],

--- a/plugins/frontend/.codex-plugin/plugin.json
+++ b/plugins/frontend/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "frontend",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Frontend design exploration toolkit for interactive HTML design options.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/frontend/.cursor-plugin/plugin.json
+++ b/plugins/frontend/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"displayName": "Frontend",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Frontend design exploration toolkit for interactive HTML design options.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "git",
 	"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/cleaning-repos",
 		"./skills/creating-commits",

--- a/plugins/git/.codex-plugin/plugin.json
+++ b/plugins/git/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "git",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/git/.cursor-plugin/plugin.json
+++ b/plugins/git/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "git",
 	"displayName": "Git",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Git workflow toolkit for commits, conflict resolution, rebases, and repository cleanup.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "github",
 	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/creating-prs",
 		"./skills/fix-pr",

--- a/plugins/github/.codex-plugin/plugin.json
+++ b/plugins/github/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "github",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/github/.cursor-plugin/plugin.json
+++ b/plugins/github/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "github",
 	"displayName": "GitHub",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "GitHub workflow toolkit for creating pull requests, monitoring CI, and getting PRs ready to merge.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/linear-planner/.claude-plugin/plugin.json
+++ b/plugins/linear-planner/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "linear-planner",
 	"description": "Linear planning workflows and project document templates for turning product ideas into traceable plans, specs, decisions, and release checks.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/create-doc-template",
 		"./skills/create-planner-project",
@@ -9,6 +9,7 @@
 		"./skills/linear-issues",
 		"./skills/pickup-work",
 		"./skills/project-docs",
+		"./skills/project-intent",
 		"./skills/tidy-linear-project"
 	],
 	"author": {
@@ -22,6 +23,7 @@
 		"linear",
 		"planning",
 		"projects",
+		"intent",
 		"issues",
 		"project-docs",
 		"templates"

--- a/plugins/linear-planner/.codex-plugin/plugin.json
+++ b/plugins/linear-planner/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "linear-planner",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Linear planning workflows and project document templates for turning product ideas into traceable plans, specs, decisions, and release checks.",
 	"author": {
 		"name": "Luca Silverentand",
@@ -13,6 +13,7 @@
 		"linear",
 		"planning",
 		"projects",
+		"intent",
 		"issues",
 		"project-docs",
 		"templates"

--- a/plugins/linear-planner/.cursor-plugin/plugin.json
+++ b/plugins/linear-planner/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "linear-planner",
 	"displayName": "Linear Planner",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Linear planning workflows and project document templates for turning product ideas into traceable plans, specs, decisions, and release checks.",
 	"author": {
 		"name": "Luca Silverentand",
@@ -12,6 +12,7 @@
 		"linear",
 		"planning",
 		"projects",
+		"intent",
 		"issues",
 		"project-docs",
 		"templates"

--- a/plugins/linear-planner/README.body.txt
+++ b/plugins/linear-planner/README.body.txt
@@ -5,6 +5,8 @@ The detailed operational structure lives in [skills/create-planner-project/refer
 
 The shared Linear issue workflow lives in [skills/linear-issues/SKILL.md](skills/linear-issues/SKILL.md). It owns issue creation, issue refinement, field and relationship rules, complexity scoring, and tidy-up issue hygiene.
 
+The project intent workflow lives in [skills/project-intent/SKILL.md](skills/project-intent/SKILL.md). Use it before docs, projects, or issues when an idea needs structured interviews, A/B/C narrowing, portfolio triage, or an LLM alignment packet.
+
 The compatibility entrypoints [skills/estimate-issue-complexity/SKILL.md](skills/estimate-issue-complexity/SKILL.md) and [skills/tidy-linear-project/SKILL.md](skills/tidy-linear-project/SKILL.md) route old triggers to `linear-issues`.
 
 ## Template library

--- a/plugins/linear-planner/README.md
+++ b/plugins/linear-planner/README.md
@@ -8,6 +8,7 @@ Linear planning workflows and project document templates for turning product ide
 - `linear-planner:linear-issues`
 - `linear-planner:pickup-work`
 - `linear-planner:project-docs`
+- `linear-planner:project-intent`
 - `linear-planner:tidy-linear-project`
 
 Codex and Claude Code also expose command shims for this plugin: `/linear-planner:pickup-work`, `/linear-planner:tidy-linear-project`. Prefer the portable skills above for automatic loading.
@@ -47,6 +48,8 @@ The project source of truth for this plugin is [documents/project-brief.md](docu
 The detailed operational structure lives in [skills/create-planner-project/references/planner-project-structure.md](skills/create-planner-project/references/planner-project-structure.md).
 
 The shared Linear issue workflow lives in [skills/linear-issues/SKILL.md](skills/linear-issues/SKILL.md). It owns issue creation, issue refinement, field and relationship rules, complexity scoring, and tidy-up issue hygiene.
+
+The project intent workflow lives in [skills/project-intent/SKILL.md](skills/project-intent/SKILL.md). Use it before docs, projects, or issues when an idea needs structured interviews, A/B/C narrowing, portfolio triage, or an LLM alignment packet.
 
 The compatibility entrypoints [skills/estimate-issue-complexity/SKILL.md](skills/estimate-issue-complexity/SKILL.md) and [skills/tidy-linear-project/SKILL.md](skills/tidy-linear-project/SKILL.md) route old triggers to `linear-issues`.
 

--- a/plugins/linear-planner/skills/project-intent/SKILL.md
+++ b/plugins/linear-planner/skills/project-intent/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: project-intent
+description: Facilitates structured project-intent interviews and A/B/C option narrowing before planning work. Use when the user asks to refine an app, product, repo, automation, or project idea, feels lost across many projects, wants Codex to interview them, wants A/B/C choices, needs an LLM alignment packet, wants to decide whether to build, pause, merge, or kill a project, or wants to prepare a Linear planning project before creating docs, issues, or implementation work.
+---
+
+# Project Intent
+Use this skill before `project-docs`, `create-planner-project`, or `linear-issues` when the project direction is still fuzzy. It turns scattered ideas into a concise intent packet that future agents can ingest.
+
+## Core posture
+- Interview first. Do not jump to implementation, Linear project creation, or issue creation while purpose, audience, scope, and current lane are unclear.
+- Keep Linear and GitHub as execution sources of truth. This skill owns intent shaping and LLM alignment, not backlog management.
+- Prefer one short round at a time. When the user is lost, offer A/B/C options with trade-offs instead of asking broad open-ended questions.
+- Keep decisions, assumptions, open questions, and evidence separate.
+- Treat `build`, `pause`, `merge into another project`, and `kill` as equally valid outcomes.
+
+## Workflow
+1. Scope the session: one new idea, one existing project, or a portfolio triage across many projects.
+2. For an existing project, inspect available repo, Linear, GitHub, and prior-context evidence before interviewing. Do not rely only on the user's memory if live state is cheap to check.
+3. Read `references/interview-playbook.md` for the matching interview mode.
+4. Run one interview round at a time. Ask at most three questions, or present one A/B/C choice set.
+5. After each answer, reflect the working interpretation in two to five bullets and name the uncertainty that remains.
+6. Use A/B/C option narrowing whenever the user hesitates, gives multiple directions, or asks what you would do.
+7. Stop interviewing when the packet can state: why this should exist, who it serves, current lane, next proof, non-goals, and agent behavior rules.
+8. Draft the project intent packet using `references/project-intent-packet-template.md`.
+9. Ask the user to approve, correct, or choose between remaining options before creating durable Linear docs, Linear issues, repo files, or implementation tasks.
+
+## A/B/C option rules
+- Default to exactly three options: a focused/small path, a balanced/practical path, and an ambitious/high-variance path.
+- Give every option a concrete consequence, not just a label.
+- Mark one option as recommended only when evidence supports it. Otherwise say what evidence would decide.
+- Let the user pick, mix, reject all three, or answer freeform. Do not trap them in the options.
+- When the user rejects the options, extract the hidden criterion and make a better option set.
+
+## Output contract
+The final packet should include:
+- One-line intent
+- Project type and current status
+- Audience or user
+- Problem, job, or desire
+- Chosen strategy and rejected alternatives
+- Scope, non-goals, and taste/principles
+- Linear/GitHub/repo source-of-truth links when known
+- Next proof or decision gate
+- Agent alignment packet: what future LLM sessions should do, avoid, verify, and ask before changing direction
+- Open questions and follow-up handoffs
+
+## Handoffs
+- Use `project-docs` to turn an approved intent packet into a project brief, customer profile, research brief, decision record, or testing strategy.
+- Use `create-planner-project` only after the intent is committed enough to justify a real Linear planning project.
+- Use `linear-issues` only after the work can be phrased as executable issues.
+- Use repository docs skills when a repo exists and the intent packet needs to become public README flow or private repo hub documentation.

--- a/plugins/linear-planner/skills/project-intent/references/interview-playbook.md
+++ b/plugins/linear-planner/skills/project-intent/references/interview-playbook.md
@@ -1,0 +1,86 @@
+# Project intent interview playbook
+Use this reference to choose the smallest interview that will clarify intent. Keep the conversation moving; a good interview feels like structured thinking, not a form.
+
+## Mode 1: One new idea
+Start with one A/B/C choice if the user is unsure:
+
+|Option|Use when|Consequence|
+|---|---|---|
+|A. Small utility|The idea solves a recurring personal pain or workflow gap.|Optimize for quick proof, narrow scope, and a low-maintenance repo.|
+|B. Product bet|The idea could become a real app, business, or public product.|Optimize for audience clarity, differentiation, design, and validation.|
+|C. Platform piece|The idea coordinates other tools, agents, repos, automations, or infrastructure.|Optimize for source-of-truth boundaries, operations, and integration risk.|
+
+Then ask only the missing questions:
+- Who is this for, even if the first user is Luca?
+- What pain or desire makes it worth existing?
+- What would prove it is useful within the next small slice?
+- What should it explicitly not become?
+- What taste, design, or workflow principles should future agents preserve?
+
+## Mode 2: Existing project
+Inspect available evidence first:
+- Current branch, PRs, issues, and recent commits
+- Linear initiative, project, milestones, and open issues
+- Repo docs, README, project docs, and design docs
+- Prior context or memory when available
+
+Then interview against drift:
+- What was the original intent?
+- What does the current code or backlog imply the intent has become?
+- Is that drift good, bad, or unresolved?
+- Should the project be active, maintenance-only, paused, merged into another project, or killed?
+- What would a future agent likely misunderstand?
+
+## Mode 3: Many projects
+Batch projects into groups of five to seven. Avoid asking the user to rank everything at once.
+
+Use these status choices:
+
+|Status|Meaning|Default next action|
+|---|---|---|
+|Active|Worth pushing now.|Name the current lane and next proof.|
+|Maintained|Useful, but not a product push.|Keep small maintenance issues only.|
+|Incubating|Interesting, but intent needs more thinking.|Run a short idea interview.|
+|Paused|Keep context, do not spend active effort.|Record resume trigger.|
+|Merge candidate|Overlaps another project.|Decide what survives and where.|
+|Kill candidate|Not worth more attention.|Preserve any reusable learning, then close the loop.|
+
+For each project, capture:
+- What is it?
+- Why keep it?
+- What is the current lane?
+- What should Codex do next?
+- What should Codex avoid doing?
+
+## Option-narrowing patterns
+Use these option sets when the user is stuck:
+
+### Scope choice
+|Option|Shape|
+|---|---|
+|A. Narrow wedge|One workflow, one proof, one repo.|
+|B. Useful hub|Enough structure to coordinate related work without building a full platform.|
+|C. Full system|Integrations, automations, and durable project operations.|
+
+### Validation choice
+|Option|Shape|
+|---|---|
+|A. Personal proof|Luca uses it on real work for a week.|
+|B. Workflow proof|It produces better Linear/GitHub/repo output than the current process.|
+|C. External proof|Someone else can understand and use it without Luca explaining it live.|
+
+### Agent behavior choice
+|Option|Shape|
+|---|---|
+|A. Conservative agent|Ask before direction changes, prefer docs and issues.|
+|B. Execution agent|Pick the next clear lane and carry it through PR/validation.|
+|C. Strategy agent|Challenge project fit, propose kills/merges, and keep portfolio focus.|
+
+## Exit criteria
+Stop interviewing and draft the packet once these sentences can be completed:
+- This exists to ...
+- It is for ...
+- The current lane is ...
+- The next proof is ...
+- Future agents should ...
+- Future agents should not ...

--- a/plugins/linear-planner/skills/project-intent/references/project-intent-packet-template.md
+++ b/plugins/linear-planner/skills/project-intent/references/project-intent-packet-template.md
@@ -1,0 +1,81 @@
+# Project intent packet template
+Use this as the final output structure after the interview. Delete fields that genuinely do not apply, but keep the agent alignment section.
+
+```md
+# <Project name> intent
+
+## One-line intent
+<One sentence that states why this should exist.>
+
+## Current status
+|Field|Value|
+|---|---|
+|Type|<app, repo, automation, infrastructure, library, content, mixed>|
+|Status|<active, maintained, incubating, paused, merge candidate, kill candidate>|
+|Current lane|<what work is actually in motion>|
+|Source of truth|<Linear initiative/project, GitHub repo, repo docs, or none yet>|
+
+## User and problem
+- Primary user:
+- Pain, job, or desire:
+- Why now:
+- Existing alternatives:
+
+## Strategy choice
+Chosen direction:
+
+Rejected alternatives:
+- A:
+- B:
+- C:
+
+Decision reason:
+
+## Scope
+In scope:
+-
+
+Out of scope:
+-
+
+Non-goals:
+-
+
+## Product and workflow principles
+-
+
+## Validation
+Next proof:
+
+Evidence needed:
+-
+
+Kill, pause, or pivot trigger:
+
+## Agent alignment packet
+Future agents should:
+-
+
+Future agents should avoid:
+-
+
+Before changing direction, verify:
+-
+
+Ask Luca when:
+-
+
+## Open questions
+-
+
+## Handoff
+Recommended next step:
+
+Possible follow-up artifacts:
+- Project brief:
+- Customer profile:
+- Research brief:
+- Decision record:
+- Linear planning project:
+- Linear issues:
+```

--- a/plugins/project/.claude-plugin/plugin.json
+++ b/plugins/project/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "project",
 	"description": "Project setup and context management skills for requirements and shared agent context.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/project-context",
 		"./skills/requirements",

--- a/plugins/project/.codex-plugin/plugin.json
+++ b/plugins/project/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "project",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Project setup and context management skills for requirements and shared agent context.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/project/.cursor-plugin/plugin.json
+++ b/plugins/project/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "project",
 	"displayName": "Project",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Project setup and context management skills for requirements and shared agent context.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/repository-docs/.claude-plugin/plugin.json
+++ b/plugins/repository-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "repository-docs",
 	"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/closed-source-docs",
 		"./skills/open-source-docs"

--- a/plugins/repository-docs/.codex-plugin/plugin.json
+++ b/plugins/repository-docs/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "repository-docs",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/repository-docs/.cursor-plugin/plugin.json
+++ b/plugins/repository-docs/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "repository-docs",
 	"displayName": "Repository Docs",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Repository documentation maintenance for public open-source projects and private internal project hubs.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/skill-creation/.claude-plugin/plugin.json
+++ b/plugins/skill-creation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "skill-creation",
 	"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/authoring",
 		"./skills/publishing",

--- a/plugins/skill-creation/.codex-plugin/plugin.json
+++ b/plugins/skill-creation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "skill-creation",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/skill-creation/.cursor-plugin/plugin.json
+++ b/plugins/skill-creation/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "skill-creation",
 	"displayName": "Skill Creation",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "End-to-end toolkit for authoring, publishing, tooling, and improving reusable agent skills.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/systems-design/.claude-plugin/plugin.json
+++ b/plugins/systems-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "systems-design",
 	"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"skills": [
 		"./skills/api-design",
 		"./skills/architecture",

--- a/plugins/systems-design/.codex-plugin/plugin.json
+++ b/plugins/systems-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "systems-design",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
 	"author": {
 		"name": "Luca Silverentand",

--- a/plugins/systems-design/.cursor-plugin/plugin.json
+++ b/plugins/systems-design/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "systems-design",
 	"displayName": "Systems Design",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Opinionated system design toolkit for architecture, data modeling, API design, workflow sequencing, and design review.",
 	"author": {
 		"name": "Luca Silverentand",


### PR DESCRIPTION
## Summary

- Add `linear-planner:project-intent` for structured project idea interviews, A/B/C option narrowing, portfolio triage, and LLM alignment packets.
- Add a reusable interview playbook plus a project intent packet template.
- Publish the new skill through the generated plugin manifests and marketplaces with version `1.2.0`.

## Validation

- `bun run plugins/skill-creation/skills/publishing/scripts/quick-validate.ts plugins/linear-planner/skills/project-intent`
- `bun run marketplace`
- `bun run validate:cursor`
- `bun run check --strict`
- `bun scripts/validate-json.ts`
- `bun run ci`
- `git diff --check`

`validate:cursor` and `check --strict` still report the repo's existing warning-only notes about optional hooks/MCP files and older long skills; no new validation failures were introduced.
