### PR TITLE
docs(skill-creation): clarify skill compatibility

### DIFF
--- a/plugins/skill-creation/skills/authoring/SKILL.md
+++ b/plugins/skill-creation/skills/authoring/SKILL.md
@@ -92,7 +92,7 @@ Read SKILL.md to get the skill's responsibilities, then ensure each one has a de
 |`references/writing-philosophy.md`|Explain the why, keep prompts lean, generalize, description writing|
 |`references/best-practices.md`|Anti-patterns, keeping SKILL.md lean|
 |`references/agent-workflow.md`|Optional research-write-validate agent pipeline for complex skills|
-|`references/advanced-features.md`|Claude Code-only advanced features: dynamic context, invocation control, forked execution, hooks, permissions|
+|`references/advanced-features.md`|Agent-specific advanced features: Codex metadata, Claude Code dynamic context, invocation control, forked execution, hooks, permissions|
 
 ## Official spec vs. repo conventions
 The skill format and structure references separate the portable Agent Skills baseline from Codex and Claude Code extensions. Check `references/skill-format.md` before adding client-specific frontmatter. The following are conventions specific to this repository — useful for organizing a skill library, but not required by the spec:

--- a/plugins/skill-creation/skills/authoring/SKILL.md
+++ b/plugins/skill-creation/skills/authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring
-description: Creates and improves agent skills — scaffolds skill directories, writes SKILL.md with frontmatter and decision trees, adds references, validates structure and token budgets. Use when creating a new skill from scratch, improving an existing skill's instructions or decision tree, adding a reference to a skill, validating a skill, or refactoring a bloated skill into smaller pieces. For adding tools to a skill, use the tooling skill.
+description: Use when the user asks to create, update, review, or refactor an agent skill, including requests like "turn this workflow into a skill", "fix this SKILL.md", "add references to this skill", "make this skill work in Codex and Claude", or "split this bloated skill". Creates skill directories, writes portable SKILL.md frontmatter and workflows, adds references, validates structure and token budgets. For adding executable helpers, use the tooling skill.
 allowed-tools: Read Grep Glob Bash Write Edit Agent
 ---
 
@@ -15,7 +15,7 @@ allowed-tools: Read Grep Glob Bash Write Edit Agent
     - **Skill instructions are too rigid or verbose** -> see `references/writing-philosophy.md` and rewrite: explain the why, drop heavy-handed MUSTs, remove lines that aren't pulling their weight
     - **Automatable tasks would benefit from a tool** -> use the `tooling` skill
     - **Missing references for detailed content** -> follow "Adding a reference" below
-    - **Frontmatter is wrong or incomplete** -> see `references/skill-format.md` for all fields and fix
+    - **Frontmatter is wrong or incomplete** -> see `references/skill-format.md` for portable fields and product-specific extensions, then fix
     - **Description is vague or undertriggering** -> rewrite per `references/writing-philosophy.md` "Description writing"
     - **Not sure what's wrong** -> run `tools/coverage-gap.ts <path>` and `tools/skill-validate.ts <path>`, fix reported issues
   - **Adding a tool to a skill** -> use the `tooling` skill
@@ -36,7 +36,7 @@ Start by understanding what the skill should do. If the conversation already con
 1. What should this skill enable an agent to do?
 2. When should this skill trigger? (what user phrases/contexts)
 3. What's the expected output format?
-4. What tier is this skill? See `references/skill-taxonomy.md` — atomic (does one thing), workflow (chains atomics in a known sequence), or agent (goal-driven, decides its own path). The tier shapes the decision tree, allowed-tools, and composition strategy.
+4. What tier is this skill? See `references/skill-taxonomy.md` — atomic (does one thing), workflow (chains atomics in a known sequence), or agent (goal-driven, decides its own path). The tier shapes the decision tree, supporting resources, validation, and composition strategy.
 Proactively ask about edge cases, example files, success criteria, and dependencies. Check available MCPs for research and the codebase for similar existing skills to avoid overlap. Come prepared with context.
 
 ### Agent workflow (optional)
@@ -44,10 +44,10 @@ For workflow or agent-tier skills with multiple references or unfamiliar domains
 
 ### 2. Write the skill
 1. Pick the owning plugin and create the directory: `plugins/<plugin>/skills/<skill-name>/`
-2. Write `SKILL.md` with YAML frontmatter — `description` is recommended for discovery (see `references/skill-format.md`)
+2. Write `SKILL.md` with portable YAML frontmatter — include `name` and `description` first, then add client-specific fields only when the target client supports them (see `references/skill-format.md`)
 3. Write the decision tree — use the **decision-trees** skill for this
 4. Write conventions — the rules the agent must follow every time
-5. Optionally add tools in `tools/` if the skill has automatable tasks — use the `tooling` skill for this. Many skills work fine without any tools.
+5. Optionally add executable helpers if the skill has automatable tasks — use the `tooling` skill for this. Many skills work fine without any helpers.
 6. Add references in `references/` for any detailed content over ~10 lines
 
 Follow the writing principles in `references/writing-philosophy.md` — explain reasoning over rigid rules, keep the prompt lean, generalize rather than overfit to test cases.
@@ -88,14 +88,14 @@ Read SKILL.md to get the skill's responsibilities, then ensure each one has a de
 |---|---|
 |`references/skill-taxonomy.md`|Skill tiers (atomic, workflow, agent), choosing a tier, extracting skills downward|
 |`references/skill-structure.md`|Directory layout, SKILL.md structure, progressive disclosure|
-|`references/skill-format.md`|Frontmatter fields, naming rules, Claude Code extensions, string substitutions|
+|`references/skill-format.md`|Portable frontmatter, Codex metadata, Claude Code extensions, naming rules, string substitutions|
 |`references/writing-philosophy.md`|Explain the why, keep prompts lean, generalize, description writing|
 |`references/best-practices.md`|Anti-patterns, keeping SKILL.md lean|
 |`references/agent-workflow.md`|Optional research-write-validate agent pipeline for complex skills|
-|`references/advanced-features.md`|Extended thinking, legacy commands, bundled skills, subagent preloading, hooks, permission control|
+|`references/advanced-features.md`|Claude Code-only advanced features: dynamic context, invocation control, forked execution, hooks, permissions|
 
 ## Official spec vs. repo conventions
-The skill format, structure, locations, and advanced features documented in the references above reflect the open [Agent Skills specification](https://agentskills.io), with Codex and Claude Code extensions called out when they are product-specific. The following are conventions specific to this repository — useful for organizing a skill library, but not required by the spec:
+The skill format and structure references separate the portable Agent Skills baseline from Codex and Claude Code extensions. Check `references/skill-format.md` before adding client-specific frontmatter. The following are conventions specific to this repository — useful for organizing a skill library, but not required by the spec:
 
 - **Skill taxonomy** (`references/skill-taxonomy.md`) — atomic/workflow/agent tiers
 - **Decision trees** (via the **decision-trees** skill) — prescribed SKILL.md structure

--- a/plugins/skill-creation/skills/authoring/references/advanced-features.md
+++ b/plugins/skill-creation/skills/authoring/references/advanced-features.md
@@ -1,51 +1,60 @@
-# Advanced Features
-Official Claude Code skill features beyond the core format and structure.
+# Claude Code Advanced Features
+These features are useful when a skill intentionally targets Claude Code. Do not treat them as portable Agent Skills features unless another client documents support.
+
+## Dynamic context injection
+Claude Code can run shell commands before the skill content reaches the model:
+
+```markdown
+## Current changes
+
+!`git diff HEAD`
+```
+
+Use dynamic context injection when the skill needs a small, fresh snapshot such as current branch, diff, or dependency metadata. Avoid commands that are slow, destructive, or leak sensitive data. The `shell` frontmatter field controls which shell runs injected commands.
+
+## Invocation control
+Claude Code supports two frontmatter fields for visibility and invocation:
+
+|Field|Effect|
+|---|---|
+|`disable-model-invocation: true`|The user can invoke the skill directly, but Claude will not auto-load it. Use for side-effectful tasks like deploys.|
+|`user-invocable: false`|The skill is hidden from the `/` menu but can still be auto-loaded by Claude. Use for background context.|
+
+Use permission rules or `skillOverrides` for user-level visibility decisions you do not want to encode in shared skill source.
+
+## Tool permission fields
+`allowed-tools` pre-approves the listed tools while the skill is active; it does not restrict every other tool. `disallowed-tools` removes tools from Claude's available pool while the skill is active.
+
+Keep tool permissions narrow and concrete. For project skills, remember that users must trust the workspace before skill tool grants take effect.
 
 ## Extended thinking
-Include the word "ultrathink" anywhere in your SKILL.md content to enable extended thinking mode when the skill is active. This is a trigger word recognized by Claude Code, not a frontmatter field.
+Include the word `ultrathink` in the skill content to request deeper reasoning when the skill runs. Use this sparingly for work that genuinely needs more deliberation, such as complex architecture analysis or multi-file safety review. Do not add it to routine formatting or small edit skills.
 
-## Legacy command compatibility
-`.claude/commands/*.md` files are treated as skills. Both `.claude/commands/deploy.md` and `.claude/skills/deploy/SKILL.md` create the `/deploy` command and work identically. Existing command files keep working. If a skill and a legacy command share the same name, the skill takes precedence.
-
-## Bundled skills
-Claude Code ships with built-in skills that are always available:
-
-|Skill|Purpose|
-|---|---|
-|`/batch <instruction>`|Orchestrate large-scale parallel changes across a codebase using git worktrees|
-|`/claude-api`|Load Claude API reference material for your project's language|
-|`/debug [description]`|Troubleshoot your current Claude Code session|
-|`/loop [interval] <prompt>`|Run a prompt repeatedly on an interval|
-|`/simplify [focus]`|Review recently changed files for code reuse, quality, and efficiency|
-
-## Preloading skills into subagents
-Subagents can preload skills via the `skills` field in their frontmatter. The full skill content is injected into the subagent's context at startup — not just made available for invocation.
+## Forked execution
+Add `context: fork` when the skill should run in an isolated subagent context:
 
 ```yaml
 ---
-name: api-developer
-description: Implement API endpoints following team conventions
-skills:
-  - api-conventions
-  - error-handling-patterns
+name: deep-research
+description: Research a topic thoroughly.
+context: fork
+agent: Explore
 ---
 ```
 
-Subagents don't inherit skills from the parent conversation. Only explicitly listed skills are available.
+The skill content becomes the subagent task. Forked skills need explicit action instructions; a reference-only skill usually has no useful task to execute in isolation. `agent` can name a built-in agent such as `Explore`, `Plan`, `general-purpose`, or a custom subagent.
+
+## Subagents with preloaded skills
+Subagents can preload skills via the subagent's `skills` frontmatter field. This is the inverse of `context: fork`: the subagent receives the user's delegated task, plus the full content of the listed skills as reference material.
+
+Do not add `skills` to a normal portable `SKILL.md` unless the target client documents that behavior.
 
 ## Hooks in skills
-The `hooks` frontmatter field scopes hooks to a skill's lifecycle. Hooks are registered when the skill becomes active and automatically cleaned up when it finishes. All hook events are supported with the same format as settings-based hooks.
+Claude Code supports hooks scoped to a skill's lifecycle. Hooks can enforce deterministic checks or guardrails around tool use.
 
-```yaml
----
-name: secure-ops
-hooks:
-  PreToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "${CLAUDE_SKILL_DIR}/scripts/security-check.sh"
----
-```
+Hooks are powerful and product-specific. Keep them out of portable skills unless the skill is explicitly Claude Code-only, document what they run, and check the current Claude Code hook schema before writing them.
 
-Four handler types: `command`, `http`, `prompt`, `agent`. Paths can use `$CLAUDE_PROJECT_DIR` and `${CLAUDE_SKILL_DIR}`.
+## Built-in and legacy behavior
+Claude Code includes bundled skills and built-in commands that may change by version. Reference current Claude Code docs instead of hardcoding a long built-in list in a reusable skill.
+
+Legacy `.claude/commands/*.md` files still work and support similar frontmatter. Prefer skills for new portable workflows because skills can include supporting files and can be packaged in plugins.

--- a/plugins/skill-creation/skills/authoring/references/advanced-features.md
+++ b/plugins/skill-creation/skills/authoring/references/advanced-features.md
@@ -1,7 +1,12 @@
-# Claude Code Advanced Features
-These features are useful when a skill intentionally targets Claude Code. Do not treat them as portable Agent Skills features unless another client documents support.
+# Agent-Specific Advanced Features
+Start from the portable Agent Skills baseline: `name`, `description`, Markdown instructions, and supporting files such as `references/`, `scripts/`, and `assets/`. Add the features below only when the target agent client documents support for them, and label product-specific behavior clearly so shared skills stay usable in Codex, Claude Code, Cursor, and future Agent Skills clients.
 
-## Dynamic context injection
+## Codex app metadata
+Codex-specific UI metadata, invocation policy, and MCP dependencies live in `agents/openai.yaml`, not in `SKILL.md` frontmatter. Use it when the skill needs install-surface display copy, a default prompt, implicit-invocation policy, or an app/tool dependency declaration.
+
+Keep `agents/openai.yaml` in sync with the skill's `description`, but do not move portable trigger guidance out of `SKILL.md`; other clients will not read Codex app metadata.
+
+## Claude Code dynamic context injection
 Claude Code can run shell commands before the skill content reaches the model:
 
 ```markdown
@@ -12,7 +17,7 @@ Claude Code can run shell commands before the skill content reaches the model:
 
 Use dynamic context injection when the skill needs a small, fresh snapshot such as current branch, diff, or dependency metadata. Avoid commands that are slow, destructive, or leak sensitive data. The `shell` frontmatter field controls which shell runs injected commands.
 
-## Invocation control
+## Claude Code invocation control
 Claude Code supports two frontmatter fields for visibility and invocation:
 
 |Field|Effect|
@@ -22,15 +27,15 @@ Claude Code supports two frontmatter fields for visibility and invocation:
 
 Use permission rules or `skillOverrides` for user-level visibility decisions you do not want to encode in shared skill source.
 
-## Tool permission fields
+## Claude Code tool permission fields
 `allowed-tools` pre-approves the listed tools while the skill is active; it does not restrict every other tool. `disallowed-tools` removes tools from Claude's available pool while the skill is active.
 
 Keep tool permissions narrow and concrete. For project skills, remember that users must trust the workspace before skill tool grants take effect.
 
-## Extended thinking
+## Claude Code extended thinking
 Include the word `ultrathink` in the skill content to request deeper reasoning when the skill runs. Use this sparingly for work that genuinely needs more deliberation, such as complex architecture analysis or multi-file safety review. Do not add it to routine formatting or small edit skills.
 
-## Forked execution
+## Claude Code forked execution
 Add `context: fork` when the skill should run in an isolated subagent context:
 
 ```yaml
@@ -44,17 +49,17 @@ agent: Explore
 
 The skill content becomes the subagent task. Forked skills need explicit action instructions; a reference-only skill usually has no useful task to execute in isolation. `agent` can name a built-in agent such as `Explore`, `Plan`, `general-purpose`, or a custom subagent.
 
-## Subagents with preloaded skills
+## Claude Code subagents with preloaded skills
 Subagents can preload skills via the subagent's `skills` frontmatter field. This is the inverse of `context: fork`: the subagent receives the user's delegated task, plus the full content of the listed skills as reference material.
 
 Do not add `skills` to a normal portable `SKILL.md` unless the target client documents that behavior.
 
-## Hooks in skills
+## Claude Code hooks in skills
 Claude Code supports hooks scoped to a skill's lifecycle. Hooks can enforce deterministic checks or guardrails around tool use.
 
 Hooks are powerful and product-specific. Keep them out of portable skills unless the skill is explicitly Claude Code-only, document what they run, and check the current Claude Code hook schema before writing them.
 
-## Built-in and legacy behavior
+## Claude Code built-in and legacy behavior
 Claude Code includes bundled skills and built-in commands that may change by version. Reference current Claude Code docs instead of hardcoding a long built-in list in a reusable skill.
 
 Legacy `.claude/commands/*.md` files still work and support similar frontmatter. Prefer skills for new portable workflows because skills can include supporting files and can be packaged in plugins.

--- a/plugins/skill-creation/skills/authoring/references/skill-format.md
+++ b/plugins/skill-creation/skills/authoring/references/skill-format.md
@@ -1,46 +1,82 @@
 # SKILL.md Format
 
 ## Frontmatter
-SKILL.md uses YAML frontmatter between `---` fences. Most skills only need `description`.
+`SKILL.md` uses YAML frontmatter between `---` fences. For skills that should work across Codex, Claude Code, and other Agent Skills clients, write the portable fields first and add product-specific fields only when the target client supports them.
 
-### Standard fields (Agent Skills spec)
+## Compatibility matrix
+|Surface|Minimum to author|Notes|
+|---|---|---|
+|Open Agent Skills spec|`name`, `description`, Markdown body|This is the portable baseline. Use it unless you are intentionally targeting one client.|
+|Codex|`name`, `description`, Markdown body|Codex uses `name`, `description`, and path in the initial skill list. UI metadata and dependencies live in `agents/openai.yaml`, not SKILL.md frontmatter.|
+|Claude Code|`description` is recommended; `name` can default from the directory|Keep `name` and `description` anyway for portability. Claude Code adds extra frontmatter fields listed below.|
+
+### Portable fields
 |Field|Required|Description|
 |---|---|---|
-|`name`|No|Lowercase letters, numbers, hyphens only. 1-64 chars. Must match parent directory name. No leading/trailing/consecutive hyphens. Defaults to parent directory name if omitted.|
-|`description`|Recommended|What the skill does AND when to use it. Max 1024 chars. Written in third person. Falls back to the first paragraph of the markdown body if omitted.|
-|`license`|No|License name or path to bundled license file.|
-|`compatibility`|No|Environment requirements. Max 500 chars.|
-|`metadata`|No|Arbitrary key-value pairs.|
-|`allowed-tools`|No|Space-delimited list of pre-approved tools.|
+|`name`|Yes|Lowercase letters, numbers, hyphens only. 1-64 chars. Must match the parent directory name for portable skills. No leading, trailing, or consecutive hyphens.|
+|`description`|Yes|What the skill does and when to use it. Max 1024 chars. Put the trigger intent first because clients may truncate long skill lists.|
+|`license`|No|License name or path to a bundled license file.|
+|`compatibility`|No|Environment requirements. Max 500 chars. Use for things like intended client, required CLIs, network needs, or OS expectations.|
+|`metadata`|No|Arbitrary key-value mapping. Clients may ignore it.|
+|`allowed-tools`|No|Experimental in the open spec. Support and semantics vary by client, so do not rely on it as the only safety boundary.|
 
-### Product extensions
-These fields are valid in Claude Code. Other Agent Skills clients may ignore them unless they explicitly document support.
+### Claude Code fields
+These fields are Claude Code-specific. Other clients may ignore them or fail strict validation.
 
 |Field|Default|Description|
 |---|---|---|
-|`argument-hint`|—|Hint shown in autocomplete. Example: `[issue-number]`|
-|`disable-model-invocation`|`false`|Set `true` to prevent Claude Code from auto-loading. User-only via `/name`.|
-|`user-invocable`|`true`|Set `false` to hide from `/` menu. Background knowledge only.|
-|`model`|—|Override model when skill is active.|
-|`effort`|—|Thinking effort level: `low`, `medium`, `high`, or `max`. Opus 4.6 only. Overrides session effort level.|
-|`context`|—|Set to `fork` to run in a forked subagent context.|
-|`agent`|—|Subagent type when `context: fork` is set (`Explore`, `Plan`, `general-purpose`, or custom).|
-|`skills`|—|List of skill names to preload into subagent context at startup (when `context: fork`). Full skill content is injected, not just made available for invocation.|
-|`hooks`|—|Hooks scoped to this skill's lifecycle.|
+|`when_to_use`|None|Additional trigger guidance appended to `description` in Claude Code's skill listing.|
+|`argument-hint`|None|Hint shown in autocomplete. Example: `[issue-number]`.|
+|`arguments`|None|Named positional arguments for `$name` substitution. Accepts a space-separated string or YAML list.|
+|`disable-model-invocation`|`false`|Prevents Claude from automatically loading the skill. Users can still invoke it directly.|
+|`user-invocable`|`true`|Hides the skill from the `/` menu when `false`; it does not block model invocation by itself.|
+|`allowed-tools`|None|Pre-approves listed tools while the skill is active. In Claude Code this grants permission; it does not restrict every other tool.|
+|`disallowed-tools`|None|Removes listed tools from Claude's available pool while the skill is active.|
+|`model`|Inherit session|Model override for the current turn, or `inherit`.|
+|`effort`|Inherit session|Reasoning effort. Values include `low`, `medium`, `high`, `xhigh`, and `max`; availability depends on the model.|
+|`context`|Inline|Set to `fork` to run the skill in a forked subagent context.|
+|`agent`|`general-purpose`|Subagent type when `context: fork` is set.|
+|`hooks`|None|Hooks scoped to the skill lifecycle.|
+|`paths`|None|Glob patterns that limit automatic activation to matching files.|
+|`shell`|`bash`|Shell used for Claude Code dynamic context injection.|
 
-### Invocation control
-|Configuration|User can invoke|Agent can invoke|
-|---|---|---|
-|(default)|Yes|Yes|
-|`disable-model-invocation: true`|Yes|No|
-|`user-invocable: false`|No|Yes|
+`skills` is a subagent frontmatter field, not a normal `SKILL.md` field. Use it when defining a custom subagent that preloads skills; do not add it to a portable skill unless the target client documents support.
 
-### Example frontmatter
+### Codex metadata
+Codex app UI metadata and dependency declarations live in `agents/openai.yaml`:
+
+```yaml
+interface:
+  display_name: "Short human name"
+  short_description: "Human-facing summary"
+  default_prompt: "Optional prompt to start with this skill"
+policy:
+  allow_implicit_invocation: false
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "openaiDeveloperDocs"
+      description: "OpenAI Docs MCP server"
+```
+
+Only add `agents/openai.yaml` when the skill benefits from UI metadata, explicit invocation policy, or tool dependencies. Keep it in sync with `SKILL.md` whenever the skill's purpose changes.
+
+### Example portable frontmatter
 ```yaml
 ---
-name: my-skill
-description: Processes data exports and generates summary reports. Use when the user asks to analyze CSV files, generate reports, or summarize data.
-allowed-tools: Read Grep Glob Bash
+name: data-reports
+description: Use this skill when the user needs to analyze tabular exports, summarize metrics, or generate a report from CSV, TSV, or spreadsheet-like data.
+---
+```
+
+### Example Claude Code task frontmatter
+```yaml
+---
+name: deploy
+description: Deploy the application after tests pass.
+disable-model-invocation: true
+context: fork
+allowed-tools: Bash(npm test *) Bash(npm run build *) Bash(git status *)
 ---
 ```
 
@@ -48,11 +84,11 @@ allowed-tools: Read Grep Glob Bash
 - Lowercase alphanumeric + hyphens only
 - 1-64 characters
 - No leading, trailing, or consecutive hyphens
-- Directory name must match the `name` field (when specified)
-- Avoid: vague names (`helper`, `utils`, `api`), reserved prefixes (`anthropic-*`, `claude-*`)
+- Directory name must match the `name` field for portable skills
+- Avoid vague names (`helper`, `utils`, `api`) and reserved prefixes (`anthropic-*`, `claude-*`)
 
 ### Naming convention
-Names are **short and direct** — the category provides context, so the skill name should not repeat it.
+Names are short and direct. The owning plugin or folder provides context, so the skill name should not repeat it.
 
 |Pattern|When to use|Examples|
 |---|---|---|
@@ -60,36 +96,28 @@ Names are **short and direct** — the category provides context, so the skill n
 |`<noun>`|Domain or concern|`conflicts`, `errors`, `performance`, `database`|
 |`<platform>`|Platform/tool-specific skills|`cloudflare`, `docker`, `discord`|
 
-**Rules:**
+Rules:
 
-- Drop redundancy with the parent category: `security/audit`, not `security/auditing-security`
-- Be specific: `scaffolding`, not `parts`; `knowledge`, not `info`
-- Use gerunds only when the skill is truly an activity (`debugging`, `testing`), not when the category already implies the verb
+- Drop redundancy with the parent category: `security/audit`, not `security/auditing-security`.
+- Be specific: `scaffolding`, not `parts`; `knowledge`, not `info`.
+- Use gerunds only when the skill is truly an activity (`debugging`, `testing`), not when the category already implies the verb.
 
-## String substitutions
+## Invocation and substitutions
 |Variable|Description|
 |---|---|
-|`$ARGUMENTS`|All arguments passed when invoking.|
-|`$ARGUMENTS[N]` or `$N`|Specific argument by 0-based index.|
+|`$ARGUMENTS`|All arguments passed when invoking. Claude Code supports this in skills.|
+|`$ARGUMENTS[N]` or `$N`|Specific argument by 0-based index in Claude Code.|
 |`${CLAUDE_SESSION_ID}`|Claude Code session ID. Claude-specific.|
 |`${CLAUDE_SKILL_DIR}`|Directory containing the SKILL.md file in Claude Code. Claude-specific.|
 
-## Dynamic context injection
-In Claude Code, the `` !`command` `` syntax runs shell commands and injects output before the skill content reaches the model:
-
-```markdown
-## Current context
-
-- Branch: !`git branch --show-current`
-- Status: !`git status --short`
-```
+Claude Code also supports dynamic context injection with `` !`command` `` and ````!` fenced blocks. Treat that as Claude-specific preprocessing: Codex and the open spec do not use it as portable syntax.
 
 ## Permission control
-Three ways to restrict skill access:
+Permission controls are client-specific:
 
-|Method|Effect|
+|Client|Control surface|
 |---|---|
-|Deny `Skill` tool in `/permissions`|Blocks all skill loading|
-|`Skill(commit)`|Allow/deny a specific skill by exact name|
-|`Skill(deploy *)`|Allow/deny skills by prefix match|
-|`disable-model-invocation: true`|Per-skill opt-out from auto-loading (user can still invoke via `/name`)|
+|Codex|Codex configuration, plugin policy, host approvals, and optional `agents/openai.yaml` invocation policy.|
+|Claude Code|`allowed-tools`, `disallowed-tools`, `disable-model-invocation`, `user-invocable`, permission rules, and skill overrides.|
+
+Do not describe `allowed-tools` as a universal sandbox. In Claude Code it grants pre-approval for listed tools while the skill is active; permission settings still govern other tools.

--- a/plugins/skill-creation/skills/authoring/references/skill-structure.md
+++ b/plugins/skill-creation/skills/authoring/references/skill-structure.md
@@ -1,55 +1,69 @@
 # Skill Structure
 
 ## Directory layout
+Use the open Agent Skills layout unless the target client or this repository has a specific reason to diverge:
+
 ```text
-plugins/<plugin-name>/skills/<skill-name>/
-├── SKILL.md                # how: lean instructions, frontmatter, short decision trees
-├── tools/                  # (optional) bun scripts the agent can run
-│   └── *.ts
-├── references/             # (optional) detailed docs, long decision trees, domain knowledge
-│   └── *.md
-└── examples/               # (optional) example outputs showing expected format
-    └── *
+skill-name/
+├── SKILL.md                # required: frontmatter + instructions
+├── scripts/                # optional: executable code the agent can run
+├── references/             # optional: detailed docs and domain knowledge
+├── assets/                 # optional: templates, images, fonts, starter files
+├── examples/               # optional: expected inputs/outputs or test prompts
+└── agents/
+    └── openai.yaml         # optional Codex app metadata and dependencies
 ```
 
-Only `SKILL.md` is required. Add `tools/`, `references/`, or `examples/` when the skill needs them.
+Only `SKILL.md` is required. Add supporting folders when they reduce repeated work or keep `SKILL.md` lean. The open spec allows additional folders, but standard names travel best across clients.
 
 ## Repository layout
-This repository uses `plugins/<plugin-name>/skills/<skill-name>/` as the authoring tree. Each skill has one owning plugin. `plugin-groups.json` records the plugin metadata and skill ownership, and `bun run marketplace:write` regenerates manifests, READMEs, and marketplace catalogs.
+This repository uses `plugins/<plugin-name>/skills/<skill-name>/` as the authoring tree. Each skill has one owning plugin. `plugin-groups.json` records plugin metadata and skill ownership, and `bun run marketplace:write` regenerates manifests, READMEs, and marketplace catalogs.
+
+This repo also has historical `tools/` folders inside some skills. Treat those as repo conventions for Bun-based helper utilities. For new portable skills, prefer `scripts/` for executable code unless you are intentionally following an existing repo-local pattern.
 
 ## Skill locations
 |Consumer|Path|Scope|
 |---|---|---|
-|Open Agent Skills / Codex personal|`~/.agents/skills/<skill-name>/SKILL.md`|All projects for that user|
+|Codex personal|`~/.agents/skills/<skill-name>/SKILL.md`|All projects for that user|
 |Codex project|`.agents/skills/<skill-name>/SKILL.md`|Project or folder-specific skills|
 |Claude Code personal|`~/.claude/skills/<skill-name>/SKILL.md`|All Claude Code projects for that user|
 |Claude Code project|`.claude/skills/<skill-name>/SKILL.md`|Project or folder-specific skills|
 |Plugin package|`plugins/<plugin-name>/skills/<skill-name>/SKILL.md`|Where the plugin is enabled|
 
-Plugin skills use `plugin-name:skill-name` namespacing in both Codex and Claude Code, preventing collisions with direct personal or project skills.
+Codex scans `.agents/skills` from the current working directory up to the repository root, plus user/admin/system locations. Claude Code scans `.claude/skills` at personal, project, plugin, and parent/nested project scopes. Plugin skills use `plugin-name:skill-name` namespacing in both Codex and Claude Code, preventing collisions with direct personal or project skills.
 
 ## SKILL.md
 Rules:
 
-- Must have YAML frontmatter. `description` is recommended for skill discovery; `name` defaults to the directory name if omitted.
-- Keep under 5000 tokens (roughly 300-500 lines depending on density — tokens are the real constraint, lines are a rough proxy)
-- Lead with the workflow — what does the agent do, in what order?
-- Link to references/ for anything needing more than a few lines
+- Include YAML frontmatter and a Markdown body.
+- For portable and Codex skills, include both `name` and `description`. Claude Code can infer `name`, but keeping both fields avoids cross-client drift.
+- Keep the body focused. The 5000-token guideline is a practical target, not a license to fill the file.
+- Lead with the workflow: what does the agent do, in what order?
+- Link to supporting files for anything that needs more than a few lines.
 
-## references/
-Detailed documentation loaded on demand. Agents read these when the SKILL.md points to them.
+## scripts/
+Executable code loaded or run only when needed.
 
 Rules:
 
-- SKILL.md must explicitly reference these files: "See `references/foo.md`"
-- Keep each file focused on one topic
-- One level deep from SKILL.md — don't reference files from within references
+- Use scripts for deterministic checks, conversion, packaging, or other logic the agent would otherwise rewrite repeatedly.
+- Prefer small scripts with clear CLI help and no hidden side effects.
+- Test scripts by running them on representative inputs before finishing the skill.
+
+## references/
+Detailed documentation loaded on demand. Agents read these when `SKILL.md` points to them.
+
+Rules:
+
+- `SKILL.md` must explicitly reference these files: "See `references/foo.md`".
+- Keep each file focused on one topic.
+- Keep references one level deep from `SKILL.md`; avoid reference-to-reference chains.
 
 ## Progressive disclosure
 Codex, Claude Code, and other Agent Skills clients load skills progressively:
 
-1. **Metadata** (~100 tokens) — `name` and `description` from frontmatter. Loaded at startup for all visible skills. This is how the agent decides which skill to activate.
-2. **Instructions** (<5000 tokens) — full SKILL.md body. Loaded when the skill is activated.
-3. **Resources** (as needed) — files in references/ and tools/. Loaded only when the SKILL.md tells the agent to read them.
+1. Metadata - `name`, `description`, and sometimes path. This is how the agent decides which skill to activate.
+2. Instructions - full `SKILL.md` body when the skill is activated.
+3. Resources - supporting files such as `references/`, `scripts/`, and `assets/` only when the skill points the agent to them.
 
-Token budget for skill descriptions: ~2% of context window (~16,000 characters across all skills). Keep individual descriptions concise so they don't crowd out other skills.
+Codex caps the initial skills list at roughly 2% of the context window, or 8,000 characters when the context window is unknown. Front-load descriptions so shortening still preserves the trigger. Claude Code also keeps skill content in context after invocation and preserves the first 5,000 tokens per skill during compaction, so every line still has a recurring cost.

--- a/plugins/skill-creation/skills/authoring/references/writing-philosophy.md
+++ b/plugins/skill-creation/skills/authoring/references/writing-philosophy.md
@@ -18,17 +18,17 @@ Pay attention to context cues about the user's technical level. Some users are e
 ## Description writing
 The `description` field determines whether agents activate the skill. It is the single most important line you write — a perfect skill with a bad description never fires. Descriptions tend to undertrigger, so lean slightly pushy.
 
-- Third person: "Generates migration files from schema changes"
-- Include BOTH what and when: "... Use when the user modifies Drizzle schema files or asks to create a migration."
+- Prefer trigger phrasing: "Use this skill when..." or "Use when..." tells the agent when to act.
+- Include BOTH what and when: "Use this skill when the user modifies Drizzle schema files or asks to create a migration."
 - Include edge cases: "even if they don't explicitly ask for a 'migration'"
 - Max 1024 characters
 
 ### Before/after examples
 |Problem|Before|After|
 |---|---|---|
-|Too vague — matches everything, triggers on noise|"Helps with database tasks"|"Generates and applies Drizzle ORM migration files. Use when the user changes a schema file, asks to migrate, or says 'update the database'."|
-|Too narrow — misses common phrasings|"Creates a PR when the user says 'open a pull request'"|"Opens a pull request for the current branch — rebases, writes a description from commits, and creates via gh CLI. Use when the user says 'open a PR', 'submit for review', 'send this upstream', or finishes a feature branch."|
-|Overlapping — competes with another skill|"Writes and runs tests for code" (collides with a general testing skill)|"Writes Playwright end-to-end tests for browser flows. Use when the user asks for E2E tests, browser tests, or integration tests that need a real browser."|
+|Too vague — matches everything, triggers on noise|"Helps with database tasks"|"Use this skill when the user changes Drizzle schema files, asks to create a migration, or says 'update the database'. Generates and applies Drizzle ORM migrations."|
+|Too narrow — misses common phrasings|"Creates a PR when the user says 'open a pull request'"|"Use this skill when the user says 'open a PR', 'submit for review', 'send this upstream', or finishes a feature branch. Opens a pull request from the current branch."|
+|Overlapping — competes with another skill|"Writes and runs tests for code" (collides with a general testing skill)|"Use this skill when the user asks for Playwright E2E tests, browser tests, or integration tests that need a real browser. Avoid for unit tests."|
 
 ### Common failure modes
 - **Too short / abstract** — agents can't distinguish it from other skills. Add the "Use when..." clause.


### PR DESCRIPTION
## Summary
- separate portable Agent Skills/Codex requirements from Claude Code-only extensions in the authoring references
- refresh skill structure guidance around standard `scripts/`, `references/`, `assets`, and optional Codex `agents/openai.yaml`
- update description-writing guidance to prefer trigger-oriented phrasing and add concrete trigger examples to `skill-creation:authoring`

## Source checks
- [Codex Agent Skills](https://developers.openai.com/codex/skills)
- [Agent Skills specification](https://agentskills.io/specification)
- [Claude Code skills](https://code.claude.com/docs/en/skills)
- [Agent Skills description optimization](https://agentskills.io/skill-creation/optimizing-descriptions)

## Validation
- [x] `bun run ci`
- [x] `git diff --check`
- [x] `bun run plugins/skill-creation/skills/authoring/tools/skill-validate.ts plugins/skill-creation/skills/authoring`