### PR TITLE
fix(skill-creation): support Codex retrospection sources

### DIFF
--- a/plugins/skill-creation/skills/retrospecting/SKILL.md
+++ b/plugins/skill-creation/skills/retrospecting/SKILL.md
@@ -7,14 +7,10 @@ allowed-tools: Read Grep Glob Bash Write Edit Agent
 # Retro
 Retrospective analysis of recent agent sessions and code changes to continuously improve the skill library.
 
-## Current context
-- Branch: !`git branch --show-current`
-- Project: !`basename $(git rev-parse --show-toplevel)`
-
 ## Decision tree
 - What do you want to do?
   - **Full retro** (conversations + git) -> follow "Running a full retro" below
-  - **Just mine conversations** -> run `tools/conversation-miner.ts --project $(git rev-parse --show-toplevel)` and review findings
+  - **Just mine conversations** -> run `tools/conversation-miner.ts --project $(git rev-parse --show-toplevel) --source auto` and review findings
   - **Just check git rework** -> run `tools/rework-detector.ts` and review findings
   - **Create skills from findings** -> follow "Acting on findings" below
 
@@ -22,16 +18,22 @@ Retrospective analysis of recent agent sessions and code changes to continuously
 A full retro has two phases: gathering data and cross-referencing existing skills. For larger skill libraries or longer time ranges, offer to use agents — a Miner to gather and cluster, and a Cross-Referrer to classify findings against existing skills. For smaller retros, single-agent is fine. Let the user decide.
 
 ### Single-agent flow
+Start by identifying the current project root and, if useful for the report, the branch:
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+```
 
 #### 1. Gather data
 Run both tools in parallel to collect findings:
 
 ```bash
-tools/conversation-miner.ts --project $(git rev-parse --show-toplevel) --days 7 --json
+tools/conversation-miner.ts --project $(git rev-parse --show-toplevel) --source auto --days 7 --json
 tools/rework-detector.ts --days 7 --json
 ```
 
-Adjust `--days` based on how far back the user wants to look (default: 7 days).
+Adjust `--days` based on how far back the user wants to look (default: 7 days). Use `--source codex` or `--source claude` when the user wants a specific agent's transcript store. Use `--transcripts <path>` for exported JSONL sessions or custom transcript archives.
 
 #### 2. Review and cluster
 Read the JSON output from both tools. Look for clusters — multiple findings that point to the same underlying issue or preference. Group them by theme:
@@ -60,13 +62,13 @@ Classify each cluster as:
 
 - **New skill needed** — no existing skill covers this area
 - **Existing skill update** — a skill exists but misses this pattern
-- **AGENTS.md / CLAUDE.md addition** — too small for a skill, better as a project instruction
+- **Project instruction addition** — too small for a skill, better in AGENTS.md, CLAUDE.md, or another repo instruction file
 - **Memory entry** — a personal preference that should be saved to memory
 
 ### Agent flow (optional)
 When the skill library is large or the retro covers many days, agents keep context focused:
 
-**Miner** (general-purpose agent) — runs both tools, clusters raw findings by theme, produces a structured findings document with clusters, evidence, and frequency counts.
+**Miner** (general-purpose agent) — runs both tools, uses `--source auto` unless the user asks for a specific transcript source, clusters raw findings by theme, produces a structured findings document with clusters, evidence, and frequency counts.
 
 **Cross-Referrer** (Explore agent, read-only) — receives the Miner's clusters, reads all existing skills in the repo (Glob for `plugins/*/skills/*/SKILL.md`), searches for overlap, and classifies each cluster as new skill / skill update / project-instructions addition / memory entry. Returns an annotated report.
 
@@ -105,7 +107,7 @@ For each approved finding:
 
 - **New skill** -> use the authoring skill to create it. Pass the finding's evidence as context for intent capture — the struggle patterns become the skill's decision tree branches, the taste signals become its conventions.
 - **Skill update** -> read the existing SKILL.md, identify where the new pattern fits, and edit it in. Add new decision tree branches, conventions, or tool behaviors as needed.
-- **AGENTS.md / CLAUDE.md addition** -> append the preference or rule to the project's agent instruction file.
+- **Project instruction addition** -> append the preference or rule to the repo's agent instruction file, such as AGENTS.md or CLAUDE.md.
 - **Memory entry** -> save to memory using the appropriate memory type (feedback for corrections, user for preferences).
 
 ## Key references

--- a/plugins/skill-creation/skills/retrospecting/references/pattern-catalog.md
+++ b/plugins/skill-creation/skills/retrospecting/references/pattern-catalog.md
@@ -104,5 +104,5 @@ When a pattern is confirmed, follow this decision process:
 1. **Is it project-specific?** → Add to project instructions, not a skill
 2. **Is it personal preference?** → Save as a memory (feedback or user type)
 3. **Is it a single rule?** → Add as a convention to an existing skill
-4. **Is it a repeatable workflow?** → Create a new skill with the lifecycle skill
+4. **Is it a repeatable workflow?** → Create a new skill with the authoring skill
 5. **Is it a validation need?** → Add a tool to an existing or new skill

--- a/plugins/skill-creation/skills/retrospecting/tools/conversation-miner.ts
+++ b/plugins/skill-creation/skills/retrospecting/tools/conversation-miner.ts
@@ -1,26 +1,30 @@
 const args = Bun.argv.slice(2);
 
 const HELP = `
-conversation-miner — Scan Claude Code conversation transcripts for struggle patterns and taste signals
+conversation-miner — Scan agent conversation transcripts for struggle patterns and taste signals
 
 Usage:
   bun run tools/conversation-miner.ts [options]
 
 Options:
   --project <path>   Project root to find conversations for (default: cwd)
+  --source <name>    Transcript source: auto, claude, or codex (default: auto)
+  --transcripts <path>  Scan JSONL transcripts under this directory instead of a known source
   --days <n>         How many days back to scan (default: 7)
   --min-confidence <n>  Minimum confidence threshold 0-1 (default: 0.3)
   --json             Output as JSON
   --help             Show this help message
 
-Scans ~/.claude/projects/<project-path>/ for conversation JSONL files and
-analyzes them for:
+Scans Claude Code transcripts, Codex session JSONL, or an explicit transcript
+directory and analyzes them for:
   - Struggle patterns: corrections, retries, long back-and-forths, tool failures
   - Taste signals: preferences, style guidance, technology choices
   - Skill gaps: repeated manual work that could be automated
 
 Examples:
   bun run tools/conversation-miner.ts --project /Users/me/myproject --days 14
+  bun run tools/conversation-miner.ts --source codex --days 14 --json
+  bun run tools/conversation-miner.ts --transcripts ~/exports/session-jsonl --json
   bun run tools/conversation-miner.ts --json
 `.trim();
 
@@ -38,9 +42,16 @@ function getFlag(name: string, fallback: string): string {
 }
 
 const projectPath = getFlag("--project", process.cwd());
+const source = getFlag("--source", "auto");
+const transcriptsPath = getFlag("--transcripts", "");
 const daysBack = parseInt(getFlag("--days", "7"), 10);
 const minConfidence = parseFloat(getFlag("--min-confidence", "0.3"));
 const jsonOutput = args.includes("--json");
+
+if (!["auto", "claude", "codex"].includes(source)) {
+  console.error("Error: --source must be one of: auto, claude, codex");
+  process.exit(1);
+}
 
 // ── Types ──
 
@@ -60,6 +71,30 @@ interface ConversationMessage {
   content: string;
   timestamp: string;
   isMeta?: boolean;
+  source: "claude" | "codex" | "custom";
+}
+
+interface TranscriptFile {
+  path: string;
+  source: "claude" | "codex" | "custom";
+}
+
+interface DirectoryEntryLike {
+  name: string;
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+}
+
+interface FindTranscriptFilesOptions {
+  homedir: string;
+  projectPath: string;
+  requestedSource: "auto" | "claude" | "codex";
+  transcriptsPath: string;
+  cutoff: number;
+  existsSync: (path: string) => boolean;
+  readdirSync: (path: string, options?: { withFileTypes?: boolean }) => Array<string | DirectoryEntryLike>;
+  statSync: (path: string) => { mtimeMs: number; isFile: () => boolean; isDirectory: () => boolean };
+  resolve: (...paths: string[]) => string;
 }
 
 // ── Struggle detection patterns ──
@@ -101,47 +136,120 @@ const TASTE_PATTERNS = [
 
 // ── Main ──
 
+function findTranscriptFiles(options: FindTranscriptFilesOptions): TranscriptFile[] {
+  const roots: TranscriptFile[] = [];
+
+  if (options.transcriptsPath) {
+    roots.push({
+      path: options.resolve(options.transcriptsPath),
+      source: "custom",
+    });
+  } else {
+    if (options.requestedSource === "auto" || options.requestedSource === "claude") {
+      const projectKey = options.projectPath.replace(/\//g, "-");
+      roots.push({
+        path: options.resolve(options.homedir, ".claude", "projects", projectKey),
+        source: "claude",
+      });
+    }
+
+    if (options.requestedSource === "auto" || options.requestedSource === "codex") {
+      roots.push({
+        path: options.resolve(options.homedir, ".codex", "sessions"),
+        source: "codex",
+      });
+      roots.push({
+        path: options.resolve(options.homedir, ".codex", "archived_sessions"),
+        source: "codex",
+      });
+    }
+  }
+
+  const files: TranscriptFile[] = [];
+  for (const root of roots) {
+    if (!options.existsSync(root.path)) continue;
+    files.push(...collectJsonlFiles(root.path, root.source, options));
+  }
+
+  const seen = new Set<string>();
+  return files
+    .filter((file) => {
+      if (seen.has(file.path)) return false;
+      seen.add(file.path);
+      return true;
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function collectJsonlFiles(
+  dir: string,
+  sourceName: TranscriptFile["source"],
+  options: FindTranscriptFilesOptions,
+): TranscriptFile[] {
+  const files: TranscriptFile[] = [];
+
+  let entries: Array<string | DirectoryEntryLike>;
+  try {
+    entries = options.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+
+  for (const entry of entries) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    const fullPath = options.resolve(dir, name);
+
+    if (typeof entry !== "string" && entry.isDirectory()) {
+      files.push(...collectJsonlFiles(fullPath, sourceName, options));
+      continue;
+    }
+
+    try {
+      const stat = options.statSync(fullPath);
+      const isFile = typeof entry === "string" ? stat.isFile() : entry.isFile();
+      if (isFile && name.endsWith(".jsonl") && stat.mtimeMs >= options.cutoff) {
+        files.push({ path: fullPath, source: sourceName });
+      }
+    } catch {
+      // Ignore files that disappear during scanning.
+    }
+  }
+
+  return files;
+}
+
+function summarizeSources(files: TranscriptFile[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const file of files) counts[file.source] = (counts[file.source] ?? 0) + 1;
+  return counts;
+}
+
+function formatSourceSummary(counts: Record<string, number>): string {
+  return Object.entries(counts)
+    .map(([name, count]) => `${name}=${count}`)
+    .join(", ");
+}
+
 async function main() {
-  const { readdirSync, readFileSync, statSync } = await import("node:fs");
-  const { resolve, basename } = await import("node:path");
+  const { existsSync, readdirSync, readFileSync, statSync } = await import("node:fs");
+  const { resolve } = await import("node:path");
   const { homedir } = await import("node:os");
 
-  // Find the conversation directory.
-  // Assumption: Claude Code stores conversation JSONL files at
-  // ~/.claude/projects/<project-path-with-slashes-replaced-by-dashes>/
-  // This convention may change in future Claude Code versions.
-  const projectKey = projectPath.replace(/\//g, "-");
-  const conversationsDir = resolve(homedir(), ".claude", "projects", projectKey);
-
-  const { existsSync } = await import("node:fs");
-  if (!existsSync(conversationsDir)) {
-    console.warn(`Warning: conversation directory not found at ${conversationsDir}`);
-    console.warn("Claude Code may store conversations differently on this system, or --project may not point to a valid project root.");
-    process.exit(0);
-  }
-
-  let files: string[];
-  try {
-    files = readdirSync(conversationsDir).filter((f) => f.endsWith(".jsonl"));
-  } catch {
-    console.warn(`Warning: could not read conversations at ${conversationsDir}`);
-    console.warn("Check that --project points to a valid project root.");
-    process.exit(0);
-  }
-
-  // Filter by date
   const cutoff = Date.now() - daysBack * 24 * 60 * 60 * 1000;
-  const recentFiles = files.filter((f) => {
-    try {
-      const stat = statSync(resolve(conversationsDir, f));
-      return stat.mtimeMs >= cutoff;
-    } catch {
-      return false;
-    }
+  const recentFiles = findTranscriptFiles({
+    homedir: homedir(),
+    projectPath,
+    requestedSource: source as "auto" | "claude" | "codex",
+    transcriptsPath,
+    cutoff,
+    existsSync,
+    readdirSync,
+    statSync,
+    resolve,
   });
 
   if (recentFiles.length === 0) {
-    console.error(`No conversations found in the last ${daysBack} days.`);
+    console.error(`No transcript files found in the last ${daysBack} days.`);
     process.exit(0);
   }
 
@@ -152,8 +260,7 @@ async function main() {
   const longExchanges: { file: string; turns: number; topic: string }[] = [];
 
   for (const file of recentFiles) {
-    const filePath = resolve(conversationsDir, file);
-    const messages = parseConversationFile(filePath, readFileSync);
+    const messages = parseConversationFile(file.path, file.source, readFileSync);
 
     // Filter to real user messages (not meta, not commands)
     const userMessages = messages.filter(
@@ -173,7 +280,7 @@ async function main() {
           const existing = correctionCounts.get(key) ?? { evidence: [], files: [] };
           const snippet = extractSnippet(content, match.index ?? 0);
           if (existing.evidence.length < 5) existing.evidence.push(snippet);
-          if (!existing.files.includes(file)) existing.files.push(file);
+          if (!existing.files.includes(file.path)) existing.files.push(file.path);
           correctionCounts.set(key, existing);
         }
       }
@@ -186,7 +293,7 @@ async function main() {
           const existing = correctionCounts.get(key) ?? { evidence: [], files: [] };
           const snippet = extractSnippet(content, match.index ?? 0);
           if (existing.evidence.length < 5) existing.evidence.push(snippet);
-          if (!existing.files.includes(file)) existing.files.push(file);
+          if (!existing.files.includes(file.path)) existing.files.push(file.path);
           correctionCounts.set(key, existing);
         }
       }
@@ -199,7 +306,7 @@ async function main() {
           const existing = tasteCounts.get(key) ?? { evidence: [], files: [], tasteType };
           const snippet = extractSnippet(content, match.index ?? 0);
           if (existing.evidence.length < 5) existing.evidence.push(snippet);
-          if (!existing.files.includes(file)) existing.files.push(file);
+          if (!existing.files.includes(file.path)) existing.files.push(file.path);
           tasteCounts.set(key, existing);
         }
       }
@@ -209,7 +316,7 @@ async function main() {
     if (userMessages.length >= 8) {
       const firstMsg = userMessages[0];
       const topic = extractTextContent(firstMsg.content)?.slice(0, 100) ?? "unknown";
-      longExchanges.push({ file, turns: userMessages.length, topic });
+      longExchanges.push({ file: file.path, turns: userMessages.length, topic });
     }
   }
 
@@ -269,6 +376,7 @@ async function main() {
       JSON.stringify(
         {
           scanned: recentFiles.length,
+          sources: summarizeSources(recentFiles),
           daysBack,
           findings: allFindings,
           summary: {
@@ -282,7 +390,8 @@ async function main() {
       ),
     );
   } else {
-    console.log(`Scanned ${recentFiles.length} conversations from the last ${daysBack} days.\n`);
+    console.log(`Scanned ${recentFiles.length} transcript file(s) from the last ${daysBack} days.`);
+    console.log(`Sources: ${formatSourceSummary(summarizeSources(recentFiles))}\n`);
 
     const struggles = allFindings.filter((f) => f.type === "struggle");
     const tastes = allFindings.filter((f) => f.type === "taste");
@@ -331,6 +440,7 @@ async function main() {
 
 function parseConversationFile(
   filePath: string,
+  sourceName: ConversationMessage["source"],
   readFileSync: (path: string, enc: string) => string,
 ): ConversationMessage[] {
   const messages: ConversationMessage[] = [];
@@ -340,27 +450,76 @@ function parseConversationFile(
     if (!line.trim()) continue;
     try {
       const parsed = JSON.parse(line);
-      const type = parsed.type;
-      if (type !== "user" && type !== "assistant") continue;
-
-      const message = parsed.message ?? {};
-      const content = message.content ?? "";
-      const timestamp = parsed.timestamp ?? "";
-      const isMeta = parsed.isMeta ?? false;
-
-      messages.push({
-        type,
-        role: message.role,
-        content: typeof content === "string" ? content : JSON.stringify(content),
-        timestamp,
-        isMeta,
-      });
+      const message = normalizeTranscriptRecord(parsed, sourceName);
+      if (message) messages.push(message);
     } catch {
       // Skip malformed lines
     }
   }
 
   return messages;
+}
+
+function normalizeTranscriptRecord(
+  parsed: Record<string, unknown>,
+  sourceName: ConversationMessage["source"],
+): ConversationMessage | null {
+  const nested = parsed.item ?? parsed.message ?? parsed.payload;
+  const record = isRecord(nested) ? nested : parsed;
+  const role = stringValue(record.role) ?? stringValue(parsed.role);
+  const rawType = stringValue(record.type) ?? stringValue(parsed.type);
+  const type = role === "user" || rawType === "user"
+    ? "user"
+    : role === "assistant" || rawType === "assistant"
+      ? "assistant"
+      : "";
+
+  if (type !== "user" && type !== "assistant") return null;
+
+  const content =
+    record.content ??
+    record.text ??
+    parsed.content ??
+    (isRecord(parsed.message) ? parsed.message.content : undefined) ??
+    "";
+
+  return {
+    type,
+    role,
+    content: normalizeContent(content),
+    timestamp: stringValue(record.timestamp) ?? stringValue(parsed.timestamp) ?? "",
+    isMeta: Boolean(parsed.isMeta ?? record.isMeta ?? false),
+    source: sourceName,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") return block;
+        if (!isRecord(block)) return "";
+        if (typeof block.text === "string") return block.text;
+        if (typeof block.content === "string") return block.content;
+        return "";
+      })
+      .filter(Boolean)
+      .join(" ");
+  }
+  if (isRecord(content)) {
+    if (typeof content.text === "string") return content.text;
+    if (typeof content.content === "string") return content.content;
+  }
+  return "";
 }
 
 function extractTextContent(content: string): string {
@@ -405,10 +564,10 @@ function suggestAction(type: string, key: string, evidence: string[]): string {
     if (key.includes("dissatisfaction")) {
       return "Repeated issues — investigate if a skill could catch or prevent these errors.";
     }
-    return "User corrections detected — consider a skill or CLAUDE.md rule to prevent this pattern.";
+    return "User corrections detected — consider a skill or project instruction rule to prevent this pattern.";
   }
   if (type === "taste") {
-    return "Consistent preference — codify in a skill's conventions or add to CLAUDE.md.";
+    return "Consistent preference — codify in a skill's conventions or add to project instructions.";
   }
   return "Review for skill opportunity.";
 }


### PR DESCRIPTION
## Summary

- Teach the retrospection transcript miner to scan Codex session JSONL, Claude Code project transcripts, or explicit exported JSONL archives.
- Normalize Claude-style and Codex-style message records before extracting struggle and taste signals.
- Update the retro skill workflow to use explicit project commands, source selection, and portable project-instruction wording.

## Validation

- `bun run plugins/skill-creation/skills/retrospecting/tools/conversation-miner.ts --help`
- `bun run plugins/skill-creation/skills/retrospecting/tools/conversation-miner.ts --source codex --days 1 --json`
- Custom JSONL `--transcripts` smoke test covering Claude-style and Codex-style records
- `bun run plugins/skill-creation/skills/authoring/tools/skill-validate.ts plugins/skill-creation/skills/retrospecting`
- `git diff --check`
- `bun run ci`