### PR TITLE
docs(skill-creation): sharpen skill trigger descriptions

### DIFF
--- a/plugins/skill-creation/skills/authoring/SKILL.md
+++ b/plugins/skill-creation/skills/authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring
-description: Use when the user asks to create, update, review, or refactor an agent skill, including requests like "turn this workflow into a skill", "fix this SKILL.md", "add references to this skill", "make this skill work in Codex and Claude", or "split this bloated skill". Creates skill directories, writes portable SKILL.md frontmatter and workflows, adds references, validates structure and token budgets. For adding executable helpers, use the tooling skill.
+description: Use when the user asks to create, update, review, or refactor an agent skill, including requests like "turn this workflow into a skill", "make a skill for this", "fix this SKILL.md", "add references to this skill", "make this skill work in Codex and Claude", or "split this bloated skill". Creates skill directories, writes portable SKILL.md frontmatter and workflows, adds references, validates structure and token budgets. For adding executable helpers, use the tooling skill.
 allowed-tools: Read Grep Glob Bash Write Edit Agent
 ---
 

--- a/plugins/skill-creation/skills/publishing/SKILL.md
+++ b/plugins/skill-creation/skills/publishing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publishing
-description: Manages Codex, Claude Code, and Cursor skill marketplaces — publishes plugin-owned skills, updates plugin groups, removes entries, packages skills for distribution, regenerates plugin manifests, and validates catalog integrity. Use when publishing a skill to the marketplace, bumping a version, removing a skill from the catalog, packaging a skill as a .skill file, regenerating marketplace files, moving a skill between plugins, or fixing marketplace validation errors.
+description: Manages Codex, Claude Code, and Cursor skill/plugin marketplaces — publishes plugin-owned skills, updates plugin groups, removes entries, packages skills for distribution, regenerates plugin manifests, and validates catalog integrity. Use when publishing a skill to the marketplace, bumping a version, removing a skill from the catalog, packaging a skill as a .skill file, regenerating marketplace files, moving a skill between plugins, fixing marketplace validation errors, or when the user says "publish this skill", "regenerate the marketplace", "move this skill to another plugin", or "package this skill".
 allowed-tools: Read Grep Glob Bash Write Edit
 ---
 

--- a/plugins/skill-creation/skills/retrospecting/SKILL.md
+++ b/plugins/skill-creation/skills/retrospecting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retrospecting
-description: Mines recent agent conversations and git history for struggles, repeated corrections, rework patterns, and taste signals — then turns findings into new skills or updates to existing ones. Use when you want to retrospect on recent coding sessions to extract learnings, identify skill gaps, improve existing skills based on real usage patterns, or codify preferences that keep coming up in conversations.
+description: Mines recent Codex or Claude agent conversations and git history for struggles, repeated corrections, rework patterns, and taste signals — then turns findings into new skills or updates to existing ones. Use when retrospecting on recent coding sessions, extracting learnings, identifying skill gaps, improving skills from real usage patterns, codifying recurring preferences, or when the user says "retro this repo", "mine recent conversations", "what should become a skill", or "find repeated agent mistakes".
 allowed-tools: Read Grep Glob Bash Write Edit Agent
 ---
 

--- a/plugins/skill-creation/skills/tooling/SKILL.md
+++ b/plugins/skill-creation/skills/tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tooling
-description: Creates and improves bun-based tools for skills — decides when a tool earns its place, scaffolds zero-dependency scripts with dual output, validates tool quality, and wires tools into SKILL.md decision trees. Use when adding a tool to a skill, improving an existing tool, deciding whether something should be a tool or inline instructions, or reviewing tool quality.
+description: Creates and improves Bun-based tools for skills — decides when a tool earns its place, scaffolds zero-dependency scripts with dual output, validates tool quality, and wires tools into SKILL.md decision trees. Use when adding a tool to a skill, improving an existing tool, deciding whether something should be a tool or inline instructions, reviewing tool quality, or when the user says "add a tool to this skill", "write a validator for this skill", "make this repeatable", or "check this tool".
 allowed-tools: Read Grep Glob Bash Write Edit
 ---
 


### PR DESCRIPTION
## Summary

- Add concrete user-language trigger examples to the authoring, publishing, retrospecting, and tooling descriptions.
- Make the descriptions clearer about Codex, Claude Code, Cursor, and portable agent-skill use cases.
- Clear the skill-creation-specific `no user language examples` checker warnings without changing skill behavior.

## Validation

- `bun run check --strict`
- `git diff --check`
- `bun run ci`