### PR TITLE
docs(skill-creation): prefer scripts for skill helpers

### DIFF
--- a/plugins/skill-creation/skills/authoring/SKILL.md
+++ b/plugins/skill-creation/skills/authoring/SKILL.md
@@ -47,7 +47,7 @@ For workflow or agent-tier skills with multiple references or unfamiliar domains
 2. Write `SKILL.md` with portable YAML frontmatter — include `name` and `description` first, then add client-specific fields only when the target client supports them (see `references/skill-format.md`)
 3. Write the decision tree — use the **decision-trees** skill for this
 4. Write conventions — the rules the agent must follow every time
-5. Optionally add executable helpers if the skill has automatable tasks — use the `tooling` skill for this. Many skills work fine without any helpers.
+5. Optionally add executable helpers in `scripts/` if the skill has automatable tasks — use the `tooling` skill for this. Many skills work fine without any scripts. Existing skills in this repo may still use `tools/`; keep those paths stable unless the task is an explicit migration.
 6. Add references in `references/` for any detailed content over ~10 lines
 
 Follow the writing principles in `references/writing-philosophy.md` — explain reasoning over rigid rules, keep the prompt lean, generalize rather than overfit to test cases.
@@ -81,7 +81,7 @@ Read SKILL.md to get the skill's responsibilities, then ensure each one has a de
 ## Validating
 1. Run `tools/skill-validate.ts <path>` — checks files, frontmatter, naming, line count
 2. Run `tools/token-estimate.ts <path>/SKILL.md` — must be under 5000 tokens
-3. Run `tools/coverage-gap.ts <path>` — compares responsibilities against content and tools
+3. Run `tools/coverage-gap.ts <path>` — compares responsibilities against content and bundled scripts/tools
 
 ## Key references
 |File|What it covers|

--- a/plugins/skill-creation/skills/authoring/references/skill-structure.md
+++ b/plugins/skill-creation/skills/authoring/references/skill-structure.md
@@ -14,7 +14,7 @@ skill-name/
     └── openai.yaml         # optional Codex app metadata and dependencies
 ```
 
-Only `SKILL.md` is required. Add supporting folders when they reduce repeated work or keep `SKILL.md` lean. The open spec allows additional folders, but standard names travel best across clients.
+Only `SKILL.md` is required. Add supporting folders when they reduce repeated work or keep `SKILL.md` lean. New portable skills should use `scripts/` for executable helper code. The open spec allows additional folders, but standard names travel best across clients. Some older skills in this repo still use `tools/`; treat those as legacy paths and keep them stable unless you are doing a deliberate migration.
 
 ## Repository layout
 This repository uses `plugins/<plugin-name>/skills/<skill-name>/` as the authoring tree. Each skill has one owning plugin. `plugin-groups.json` records plugin metadata and skill ownership, and `bun run marketplace:write` regenerates manifests, READMEs, and marketplace catalogs.
@@ -62,8 +62,8 @@ Rules:
 ## Progressive disclosure
 Codex, Claude Code, and other Agent Skills clients load skills progressively:
 
-1. Metadata - `name`, `description`, and sometimes path. This is how the agent decides which skill to activate.
-2. Instructions - full `SKILL.md` body when the skill is activated.
-3. Resources - supporting files such as `references/`, `scripts/`, and `assets/` only when the skill points the agent to them.
+1. **Metadata** (~100 tokens) — `name` and `description` from frontmatter. Loaded at startup for all visible skills. This is how the agent decides which skill to activate.
+2. **Instructions** (<5000 tokens) — full SKILL.md body. Loaded when the skill is activated.
+3. **Resources** (as needed) — files in `references/`, `scripts/`, `assets/`, or legacy `tools/`. Loaded only when the SKILL.md tells the agent to read them.
 
 Codex caps the initial skills list at roughly 2% of the context window, or 8,000 characters when the context window is unknown. Front-load descriptions so shortening still preserves the trigger. Claude Code also keeps skill content in context after invocation and preserves the first 5,000 tokens per skill during compaction, so every line still has a recurring cost.

--- a/plugins/skill-creation/skills/authoring/references/writing-philosophy.md
+++ b/plugins/skill-creation/skills/authoring/references/writing-philosophy.md
@@ -10,7 +10,7 @@ Every line should earn its place. If test runs show the skill sending the model 
 When improving a skill from test feedback, don't put in fiddly changes that only fix the case at hand. Skills get used across many different prompts — potentially millions of times. Try different framings and metaphors rather than adding constrictive rules. If something is stubbornly wrong, try branching out with a completely different approach rather than tightening the screws.
 
 ## Look for repeated work
-If every test run independently wrote similar helper scripts, that's a signal to bundle that script in `tools/` and reference it from the skill. This saves every future invocation from reinventing the wheel.
+If every test run independently wrote similar helper scripts, that's a signal to bundle that script in `scripts/` and reference it from the skill. This saves every future invocation from reinventing the wheel.
 
 ## Calibrate communication to the audience
 Pay attention to context cues about the user's technical level. Some users are experienced developers; others are non-technical people exploring what agents can do. In the default case, terms like "evaluation" and "benchmark" are fine, but explain "JSON" or "assertion" if there's no signal the user knows them. A brief inline definition when in doubt costs nothing.

--- a/plugins/skill-creation/skills/tooling/SKILL.md
+++ b/plugins/skill-creation/skills/tooling/SKILL.md
@@ -24,7 +24,7 @@ allowed-tools: Read Grep Glob Bash Write Edit
 Before writing any code, confirm the tool passes at least one bar from `references/when-to-create-tools.md`. If it doesn't, put the command inline in SKILL.md instead.
 
 ### 2. Write the tool
-Create `tools/<tool-name>.ts` following the conventions in `references/tool-conventions.md`. The structural patterns there reflect how tools in this repo are built — follow them for consistency.
+Create `scripts/<tool-name>.ts` following the conventions in `references/tool-conventions.md`. Agent Skills, Codex, and Claude Code all treat `scripts/` as the portable executable-code directory. If you are improving an existing repo skill that already has `tools/`, keep that path stable unless the task is explicitly to migrate it.
 
 Key principles:
 

--- a/plugins/skill-creation/skills/tooling/references/tool-conventions.md
+++ b/plugins/skill-creation/skills/tooling/references/tool-conventions.md
@@ -8,6 +8,9 @@ How tools are built in this repo. These conventions aren't arbitrary — they ex
 
 **Dynamic imports for node stdlib.** Use `await import("node:fs")` inside `main()` rather than top-level imports. This keeps the arg-parsing and help-text path fast and dependency-free.
 
+## Location
+Put new executable helper code under `scripts/`. That is the portable Agent Skills convention used by Codex and Claude Code. Existing skills in this repository may still have `tools/` directories; improve those files in place unless the requested change is a mechanical migration.
+
 ## Interface contract
 Every tool supports these flags:
 


### PR DESCRIPTION
## Summary

- Update authoring and tooling guidance to use `scripts/` for new executable skill helpers.
- Keep existing `tools/` paths documented as legacy repo-local paths so current validators and tools are not renamed in this docs PR.
- Align the portable guidance with the current Agent Skills, Codex, and Claude Code directory convention.

## Validation

- `bun run check --strict`
- `git diff --check`
- `bun run plugins/skill-creation/skills/authoring/tools/skill-validate.ts plugins/skill-creation/skills/tooling`
- `bun run plugins/skill-creation/skills/authoring/tools/skill-validate.ts plugins/skill-creation/skills/authoring`
- `bun run ci`