### PR TITLE
docs(skill-creation): flatten hook example

### DIFF
--- a/plugins/skill-creation/skills/authoring/references/advanced-features.md
+++ b/plugins/skill-creation/skills/authoring/references/advanced-features.md
@@ -57,6 +57,16 @@ Do not add `skills` to a normal portable `SKILL.md` unless the target client doc
 ## Claude Code hooks in skills
 Claude Code supports hooks scoped to a skill's lifecycle. Hooks can enforce deterministic checks or guardrails around tool use.
 
+```yaml
+---
+name: secure-ops
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks: [{ type: command, command: "${CLAUDE_SKILL_DIR}/scripts/security-check.sh" }]
+---
+```
+
 Hooks are powerful and product-specific. Keep them out of portable skills unless the skill is explicitly Claude Code-only, document what they run, and check the current Claude Code hook schema before writing them.
 
 ## Claude Code built-in and legacy behavior


### PR DESCRIPTION
## Summary

- Flatten the Claude Code hook example in the advanced-features reference.
- Preserve the same hook behavior while avoiding a deeply nested YAML list that is harder for agents to parse.
- Clear the skill-creation-specific deep nesting checker warning.

## Validation

- `bun run check --strict`
- `git diff --check`
- `bun run ci`