### PR TITLE
feat(design): add interactive system design skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,7 +55,7 @@
 		{
 			"name": "design",
 			"source": "./plugins/design",
-			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.",
 			"version": "2.0.0",
 			"author": {
 				"name": "Luca Silverentand",
@@ -65,6 +65,9 @@
 			"keywords": [
 				"design",
 				"architecture",
+				"diagram",
+				"interactive",
+				"html",
 				"api",
 				"database",
 				"apple",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -24,7 +24,7 @@
 		{
 			"name": "design",
 			"source": "design",
-			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews."
+			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews."
 		},
 		{
 			"name": "development",

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -42,10 +42,10 @@
 		{
 			"name": "design",
 			"displayName": "Design",
-			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.",
 			"shortDescription": "Product and system design",
 			"category": "Design",
-			"keywords": ["design", "architecture", "api", "database", "apple", "hig", "ui", "ux", "adr", "c4"],
+			"keywords": ["design", "architecture", "diagram", "interactive", "html", "api", "database", "apple", "hig", "ui", "ux", "adr", "c4"],
 			"skills": [
 				"api-design",
 				"architecture",
@@ -56,6 +56,7 @@
 				"design-system",
 				"design-workflow",
 				"foundations",
+				"interactive-system-design",
 				"platforms",
 				"services",
 				"write-adr",

--- a/plugins/design/.claude-plugin/plugin.json
+++ b/plugins/design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "design",
-	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.",
 	"version": "2.0.0",
 	"skills": [
 		"./skills/api-design",
@@ -12,6 +12,7 @@
 		"./skills/design-system",
 		"./skills/design-workflow",
 		"./skills/foundations",
+		"./skills/interactive-system-design",
 		"./skills/platforms",
 		"./skills/services",
 		"./skills/write-adr",
@@ -27,6 +28,9 @@
 	"keywords": [
 		"design",
 		"architecture",
+		"diagram",
+		"interactive",
+		"html",
 		"api",
 		"database",
 		"apple",

--- a/plugins/design/.codex-plugin/plugin.json
+++ b/plugins/design/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "design",
 	"version": "2.0.0",
-	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
@@ -12,6 +12,9 @@
 	"keywords": [
 		"design",
 		"architecture",
+		"diagram",
+		"interactive",
+		"html",
 		"api",
 		"database",
 		"apple",
@@ -25,7 +28,7 @@
 	"interface": {
 		"displayName": "Design",
 		"shortDescription": "Product and system design",
-		"longDescription": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+		"longDescription": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.",
 		"developerName": "Luca Silverentand",
 		"category": "Design",
 		"capabilities": [

--- a/plugins/design/.cursor-plugin/plugin.json
+++ b/plugins/design/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"name": "design",
 	"displayName": "Design",
 	"version": "2.0.0",
-	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
@@ -11,6 +11,9 @@
 	"keywords": [
 		"design",
 		"architecture",
+		"diagram",
+		"interactive",
+		"html",
 		"api",
 		"database",
 		"apple",

--- a/plugins/design/README.md
+++ b/plugins/design/README.md
@@ -1,5 +1,5 @@
 # Design
-Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.
+Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, interactive HTML system diagrams, and design reviews.
 
 ## Skills
 - `design:api-design`
@@ -11,6 +11,7 @@ Design and architecture skills for product UI, Apple platforms, system architect
 - `design:design-system`
 - `design:design-workflow`
 - `design:foundations`
+- `design:interactive-system-design`
 - `design:platforms`
 - `design:services`
 - `design:write-adr`

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -22,6 +22,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
    - Swimlanes for ownership, trust boundaries, platforms, or runtime tiers.
    - Radial or clustered layouts only when the relationships are genuinely hub-like.
 3. Create the HTML artifact by copying `assets/system-map-template.html`. Replace the placeholder `map` object with the system content: title, search placeholder, plane size, lanes, cards, and connections. Avoid editing shell CSS, rendering, zoom, or transform-based canvas panning unless the user specifically asks to change the shell.
+   - Keep card `x` and `y` coordinates on the template's 22px grid so cards, lanes, and orthogonal routes line up cleanly.
 4. Use Bun to preview the artifact from its directory. Prefer a temporary `Bun.serve` command or an existing project Bun script; do not add dependencies or commit server files just to view one HTML file.
 5. Use the Browser plugin when available. Open the Bun-served local URL in the in-app browser, interact with it, check console errors, test a small viewport, and adjust the file until it is readable and usable.
 6. Share the file path, local preview URL if the server is still running, and the main design questions the artifact now exposes. For co-creation, ask for the next decision in concrete terms, such as which component to expand, which flow to trace, or which trade-off to compare.

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -21,7 +21,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
    - Top-to-bottom for pipeline, lifecycle, or command flow.
    - Swimlanes for ownership, trust boundaries, platforms, or runtime tiers.
    - Radial or clustered layouts only when the relationships are genuinely hub-like.
-3. Create the HTML artifact by copying `assets/system-map-template.html`. Replace the placeholder `map` object with the system content: title, search placeholder, plane size, lanes, cards, and connections. Avoid editing shell CSS, rendering, zoom, scrolling, or canvas panning unless the user specifically asks to change the shell.
+3. Create the HTML artifact by copying `assets/system-map-template.html`. Replace the placeholder `map` object with the system content: title, search placeholder, plane size, lanes, cards, and connections. Avoid editing shell CSS, rendering, zoom, or transform-based canvas panning unless the user specifically asks to change the shell.
 4. Use Bun to preview the artifact from its directory. Prefer a temporary `Bun.serve` command or an existing project Bun script; do not add dependencies or commit server files just to view one HTML file.
 5. Use the Browser plugin when available. Open the Bun-served local URL in the in-app browser, interact with it, check console errors, test a small viewport, and adjust the file until it is readable and usable.
 6. Share the file path, local preview URL if the server is still running, and the main design questions the artifact now exposes. For co-creation, ask for the next decision in concrete terms, such as which component to expand, which flow to trace, or which trade-off to compare.
@@ -29,7 +29,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
 ## Drawing structure
 Use three layers:
 
-1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, scrollable map, free canvas dragging, and Space-hold map-only dragging that disables card and edge interactions. This comes from the template and should usually stay unchanged.
+1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, clipped viewport, transform-based wheel/trackpad panning, free canvas dragging, and Space-hold map-only dragging that disables card and edge interactions. This comes from the template and should usually stay unchanged.
 2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind them.
 3. **Detail surface**: centered hero overlay content for responsibilities, contracts, data owned, failure modes, and open questions.
 
@@ -37,7 +37,7 @@ The template already includes:
 - Search parts and edge labels.
 - Focus mode on click: highlight connected edges and dim unrelated parts.
 - Edge selection: clicking a connector or its label should focus both endpoints and expose the relationship detail.
-- Reset, fit-to-view, zoom in/out, scroll-wheel map movement, free canvas dragging, and Space-hold map-only dragging.
+- Reset, fit-to-view, zoom in/out, wheel/trackpad map panning, free canvas dragging, and Space-hold map-only dragging.
 
 ## Orthogonal connectors
 Draw every relationship as right-angle SVG paths.
@@ -72,7 +72,7 @@ Use the template's accessible button-to-dialog interaction: clicking a compact c
 - Make primary flow arrows visually stronger than secondary relationships.
 - Keep card radii modest, spacing consistent, and labels short enough to scan.
 - Include real domain language from the system. Generic boxes like "Service", "Handler", or "Processor" are weak unless the source material uses those names.
-- Treat mobile as a review surface: it can scroll and inspect, but it still needs readable cards and usable controls.
+- Treat mobile as a review surface: it can pan and inspect, but it still needs readable cards and usable controls.
 
 ## Browser verification
 Before finishing:

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: interactive-system-design
+description: Creates browser-tested, single-file interactive HTML system design drawings with orthogonal connected arrows, labeled parts, foldout detail cards, pan/zoom, filtering, and polished visual hierarchy. Use when the user asks to co-create an interactive system design, elaborate architecture drawing, explorable service map, ortho-connected diagram, foldout-card diagram, or a beautiful single-HTML system visualization.
+---
+
+# Interactive System Design
+Create an explorable system drawing as one self-contained HTML file. The artifact should feel like a working design surface: orthogonal arrows connect concrete parts, cards fold open to explain responsibilities and trade-offs, and the in-app browser is used to inspect and iterate on the result.
+
+## Output contract
+- Write one `.html` file. Default to `.context/architecture/interactive/<slug>.html` unless the user names a path.
+- Keep it self-contained: inline CSS, inline SVG, inline JavaScript, no CDN dependencies, no external fonts, no build step.
+- Use real HTML and SVG for the main drawing. Do not make the core diagram a raster image, canvas-only surface, or Mermaid embed.
+- Include enough structure for later edits: a `nodes` array, an `edges` array, stable ids, and clear sections for layout, rendering, interactions, and content.
+- If a source design doc or architecture artifact exists, preserve its terminology. If it does not, create a first draft from the conversation and mark uncertain assumptions in the foldout cards.
+
+## Workflow
+1. Gather the minimum useful context. Ask only for information that would materially change the drawing: the system boundary, 5-15 primary parts, the key flows, and the audience. If the user asked for co-creation but left gaps, produce a first pass and make the gaps visible in the artifact.
+2. Pick the layout before coding:
+   - Left-to-right for request/data flow.
+   - Top-to-bottom for pipeline, lifecycle, or command flow.
+   - Swimlanes for ownership, trust boundaries, platforms, or runtime tiers.
+   - Radial or clustered layouts only when the relationships are genuinely hub-like.
+3. Create the HTML artifact. Model the system in JavaScript first, then render from that model so nodes, edges, cards, filters, and inspector state stay consistent.
+4. Use Bun to preview the artifact from its directory. Prefer a temporary `Bun.serve` command or an existing project Bun script; do not add dependencies or commit server files just to view one HTML file.
+5. Use the Browser plugin when available. Open the Bun-served local URL in the in-app browser, interact with it, check console errors, test a small viewport, and adjust the file until it is readable and usable.
+6. Share the file path, local preview URL if the server is still running, and the main design questions the artifact now exposes. For co-creation, ask for the next decision in concrete terms, such as which component to expand, which flow to trace, or which trade-off to compare.
+
+## Drawing structure
+Use three layers:
+
+1. **Canvas shell**: toolbar, search, view toggles, zoom controls, and an optional minimap.
+2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind or above them.
+3. **Detail surface**: foldout cards, side inspector, or inline accordions for responsibilities, contracts, data owned, failure modes, and open questions.
+
+Good default controls:
+- Search parts and edge labels.
+- Toggle by layer, ownership lane, runtime tier, sync vs async, or happy path vs failure path.
+- Focus mode on click: highlight connected edges and dim unrelated parts.
+- Edge selection: clicking a connector or its label should focus both endpoints and expose the relationship detail.
+- Reset, fit-to-view, zoom in/out, and copy/share metadata when useful.
+
+## Orthogonal connectors
+Draw every relationship as right-angle SVG paths.
+
+- Use explicit anchor points on node sides: `left`, `right`, `top`, `bottom`.
+- Prefer `M x y H midX V y2 H x2` for horizontal flow and `M x y V midY H x2 V y2` for vertical flow.
+- Add arrow markers, small labels, and relationship type classes such as `sync`, `async`, `event`, `read`, `write`, `control`, and `external`.
+- Route edges around lanes and dense clusters. If crossings become confusing, change the layout or split the view instead of accepting line clutter.
+- Keep labels close to the segment they describe. A user should be able to answer what crosses a boundary without opening the card.
+
+## Foldout cards
+Every important part should have a compact visible card and a richer expanded state.
+
+Compact card:
+- Name, type, owner or boundary, and one responsibility.
+- Health or status indicators only when the data is meaningful.
+- Small badges for runtime, storage, protocol, or sensitivity.
+
+Expanded card:
+- Responsibilities.
+- Inputs and outputs.
+- Data owned.
+- Key dependencies.
+- Failure modes and degradation behavior.
+- Open questions or disputed assumptions.
+
+Use details/summary, accessible buttons, or a side inspector. Animate height and opacity gently, but keep content measurable and selectable. Expanded content must not push the whole diagram into chaos; prefer an inspector or overlay when many cards can open.
+
+## Visual quality
+- Use a restrained but varied palette. Avoid making the whole drawing one hue.
+- Give lanes and boundaries quiet background treatments, not heavy boxes around everything.
+- Make primary flow arrows visually stronger than secondary relationships.
+- Keep card radii modest, spacing consistent, and labels short enough to scan.
+- Include real domain language from the system. Generic boxes like "Service", "Handler", or "Processor" are weak unless the source material uses those names.
+- Treat mobile as a review surface: it can scroll and inspect, but it still needs readable cards and usable controls.
+
+## Browser verification
+Before finishing:
+- Serve the artifact with Bun. From the artifact directory, a dependency-free preview can use `bun -e 'const root=process.cwd(); const mime={".html":"text/html; charset=utf-8",".css":"text/css",".js":"text/javascript",".svg":"image/svg+xml"}; Bun.serve({port:4173, async fetch(req){const url=new URL(req.url); const pathname=url.pathname==="/" ? "/index.html" : decodeURIComponent(url.pathname); const file=Bun.file(root+pathname); if(!(await file.exists())) return new Response("Not found",{status:404}); const ext=pathname.match(/\.[^.]+$/)?.[0] ?? ""; return new Response(file,{headers:{"Content-Type":mime[ext] ?? "application/octet-stream"}})}}); console.log("http://localhost:4173"); await new Promise(()=>{});'`.
+- Open the Bun-served local URL with the in-app Browser.
+- Click at least three nodes, two edges, search once, toggle at least one view, and open/close foldout content.
+- Resize or test a narrow viewport. Check that labels do not overlap controls, cards remain readable, and connectors still meet their nodes.
+- Check the browser console. Fix JavaScript errors and missing asset warnings.
+- Inspect the HTML for accidental external dependencies with a quick search for `http://`, `https://`, `cdn`, `import`, and `@import`.
+
+## Cross-skill handoffs
+- Use `architecture` first when the component model is not clear.
+- Use `c4-diagrams` when the user wants a static Mermaid C4 diagram or a docs-friendly architecture diagram.
+- Use this skill when the deliverable is an interactive HTML artifact that people can explore, edit, and co-create around.

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -35,8 +35,8 @@ Use three layers:
 
 The template already includes:
 - Search parts and edge labels.
-- Focus mode on click: highlight connected edges and dim unrelated parts.
-- Edge selection: clicking a connector or its label should focus both endpoints and expose the relationship detail.
+- Card details: clicking a compact card opens the centered hero detail view without changing map focus or dimming neighboring cards.
+- Relationship focus mode: clicking a connector highlights the connected endpoints and dims unrelated parts.
 - Reset, fit-to-view, zoom in/out, cursor-centered wheel zoom, free canvas dragging, and Space-hold map-only dragging.
 
 ## Orthogonal connectors

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: interactive-system-design
-description: Creates browser-tested, single-file interactive HTML system design drawings with orthogonal connected arrows, labeled parts, foldout detail cards, pan/zoom, filtering, and polished visual hierarchy. Use when the user asks to co-create an interactive system design, elaborate architecture drawing, explorable service map, ortho-connected diagram, foldout-card diagram, or a beautiful single-HTML system visualization.
+description: Creates browser-tested, single-file interactive HTML system design drawings with orthogonal connected arrows, labeled parts, centered hero detail cards, pan/zoom, filtering, and polished visual hierarchy. Use when the user asks to co-create an interactive system design, elaborate architecture drawing, explorable service map, ortho-connected diagram, foldout-card or hero-card diagram, or a beautiful single-HTML system visualization.
 ---
 
 # Interactive System Design
-Create an explorable system drawing as one self-contained HTML file. The artifact should feel like a working design surface: orthogonal arrows connect concrete parts, cards fold open to explain responsibilities and trade-offs, and the in-app browser is used to inspect and iterate on the result.
+Create an explorable system drawing as one self-contained HTML file. The artifact should feel like a working design surface: orthogonal arrows connect concrete parts, cards open into centered hero detail views that explain responsibilities and trade-offs, and the in-app browser is used to inspect and iterate on the result.
 
 ## Output contract
 - Write one `.html` file. Default to `.context/architecture/interactive/<slug>.html` unless the user names a path.
@@ -12,7 +12,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
 - Use real HTML and SVG for the main drawing. Do not make the core diagram a raster image, canvas-only surface, or Mermaid embed.
 - Start from `assets/system-map-template.html` unless the user asks for a different interaction model. Copy it to the output path, then edit only the `map` object in the `CONTENT ONLY` block for the first pass.
 - Keep structure for later edits: the `map.nodes` cards, `map.edges` connections, stable ids, lane positions, and plane dimensions must be the only normal content-editing surface.
-- If a source design doc or architecture artifact exists, preserve its terminology. If it does not, create a first draft from the conversation and mark uncertain assumptions in the foldout cards.
+- If a source design doc or architecture artifact exists, preserve its terminology. If it does not, create a first draft from the conversation and mark uncertain assumptions in the hero detail cards.
 
 ## Workflow
 1. Gather the minimum useful context. Ask only for information that would materially change the drawing: the system boundary, 5-15 primary parts, the key flows, and the audience. If the user asked for co-creation but left gaps, produce a first pass and make the gaps visible in the artifact.
@@ -31,7 +31,7 @@ Use three layers:
 
 1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, scrollable map, and Space-hold dragging. This comes from the template and should usually stay unchanged.
 2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind them.
-3. **Detail surface**: foldout card content for responsibilities, contracts, data owned, failure modes, and open questions.
+3. **Detail surface**: centered hero overlay content for responsibilities, contracts, data owned, failure modes, and open questions.
 
 The template already includes:
 - Search parts and edge labels.
@@ -48,15 +48,15 @@ Draw every relationship as right-angle SVG paths.
 - Route edges around lanes and dense clusters. If crossings become confusing, change the layout or split the view instead of accepting line clutter.
 - Keep labels close to the segment they describe. A user should be able to answer what crosses a boundary without opening the card.
 
-## Foldout cards
-Every important part should have a compact visible card and a richer expanded state.
+## Hero detail cards
+Every important part should have a compact visible card and a richer centered detail state.
 
 Compact card:
 - Name, type, owner or boundary, and one responsibility.
 - Health or status indicators only when the data is meaningful.
 - Small badges for runtime, storage, protocol, or sensitivity.
 
-Expanded card:
+Hero detail card:
 - Responsibilities.
 - Inputs and outputs.
 - Data owned.
@@ -64,7 +64,7 @@ Expanded card:
 - Failure modes and degradation behavior.
 - Open questions or disputed assumptions.
 
-Use details/summary, accessible buttons, or a side inspector. Animate height and opacity gently, but keep content measurable and selectable. Expanded content must not push the whole diagram into chaos; prefer an inspector or overlay when many cards can open.
+Use the template's accessible button-to-dialog interaction: clicking a compact card opens a blurred backdrop and animates the card into a centered detail panel. Keep content measurable and selectable. Do not expand cards in place unless the user explicitly asks for that interaction.
 
 ## Visual quality
 - Use a restrained but varied palette. Avoid making the whole drawing one hue.
@@ -78,7 +78,7 @@ Use details/summary, accessible buttons, or a side inspector. Animate height and
 Before finishing:
 - Serve the artifact with Bun. From the artifact directory, a dependency-free preview can use `bun -e 'const root=process.cwd(); const mime={".html":"text/html; charset=utf-8",".css":"text/css",".js":"text/javascript",".svg":"image/svg+xml"}; Bun.serve({port:4173, async fetch(req){const url=new URL(req.url); const pathname=url.pathname==="/" ? "/index.html" : decodeURIComponent(url.pathname); const file=Bun.file(root+pathname); if(!(await file.exists())) return new Response("Not found",{status:404}); const ext=pathname.match(/\.[^.]+$/)?.[0] ?? ""; return new Response(file,{headers:{"Content-Type":mime[ext] ?? "application/octet-stream"}})}}); console.log("http://localhost:4173"); await new Promise(()=>{});'`.
 - Open the Bun-served local URL with the in-app Browser.
-- Click at least three nodes, two edges, search once, toggle at least one view, and open/close foldout content.
+- Click at least three nodes, two edges, search once, and open/close the hero detail overlay.
 - Resize or test a narrow viewport. Check that labels do not overlap controls, cards remain readable, and connectors still meet their nodes.
 - Check the browser console. Fix JavaScript errors and missing asset warnings.
 - Inspect the HTML for accidental external dependencies with a quick search for `http://`, `https://`, `cdn`, `import`, and `@import`.

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -21,7 +21,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
    - Top-to-bottom for pipeline, lifecycle, or command flow.
    - Swimlanes for ownership, trust boundaries, platforms, or runtime tiers.
    - Radial or clustered layouts only when the relationships are genuinely hub-like.
-3. Create the HTML artifact by copying `assets/system-map-template.html`. Replace the placeholder `map` object with the system content: title, search placeholder, plane size, lanes, cards, and connections. Avoid editing shell CSS, rendering, zoom, scrolling, or Space-drag panning unless the user specifically asks to change the shell.
+3. Create the HTML artifact by copying `assets/system-map-template.html`. Replace the placeholder `map` object with the system content: title, search placeholder, plane size, lanes, cards, and connections. Avoid editing shell CSS, rendering, zoom, scrolling, or canvas panning unless the user specifically asks to change the shell.
 4. Use Bun to preview the artifact from its directory. Prefer a temporary `Bun.serve` command or an existing project Bun script; do not add dependencies or commit server files just to view one HTML file.
 5. Use the Browser plugin when available. Open the Bun-served local URL in the in-app browser, interact with it, check console errors, test a small viewport, and adjust the file until it is readable and usable.
 6. Share the file path, local preview URL if the server is still running, and the main design questions the artifact now exposes. For co-creation, ask for the next decision in concrete terms, such as which component to expand, which flow to trace, or which trade-off to compare.
@@ -29,7 +29,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
 ## Drawing structure
 Use three layers:
 
-1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, scrollable map, and Space-hold dragging. This comes from the template and should usually stay unchanged.
+1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, scrollable map, free canvas dragging, and Space-hold map-only dragging that disables card and edge interactions. This comes from the template and should usually stay unchanged.
 2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind them.
 3. **Detail surface**: centered hero overlay content for responsibilities, contracts, data owned, failure modes, and open questions.
 
@@ -37,7 +37,7 @@ The template already includes:
 - Search parts and edge labels.
 - Focus mode on click: highlight connected edges and dim unrelated parts.
 - Edge selection: clicking a connector or its label should focus both endpoints and expose the relationship detail.
-- Reset, fit-to-view, zoom in/out, scroll-wheel map movement, and Space-hold drag panning.
+- Reset, fit-to-view, zoom in/out, scroll-wheel map movement, free canvas dragging, and Space-hold map-only dragging.
 
 ## Orthogonal connectors
 Draw every relationship as right-angle SVG paths.

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -29,7 +29,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
 ## Drawing structure
 Use three layers:
 
-1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, clipped viewport, transform-based wheel/trackpad panning, free canvas dragging, and Space-hold map-only dragging that disables card and edge interactions. This comes from the template and should usually stay unchanged.
+1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, clipped viewport, cursor-centered wheel zoom, free canvas dragging, and Space-hold map-only dragging that disables card and edge interactions. This comes from the template and should usually stay unchanged.
 2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind them.
 3. **Detail surface**: centered hero overlay content for responsibilities, contracts, data owned, failure modes, and open questions.
 
@@ -37,7 +37,7 @@ The template already includes:
 - Search parts and edge labels.
 - Focus mode on click: highlight connected edges and dim unrelated parts.
 - Edge selection: clicking a connector or its label should focus both endpoints and expose the relationship detail.
-- Reset, fit-to-view, zoom in/out, wheel/trackpad map panning, free canvas dragging, and Space-hold map-only dragging.
+- Reset, fit-to-view, zoom in/out, cursor-centered wheel zoom, free canvas dragging, and Space-hold map-only dragging.
 
 ## Orthogonal connectors
 Draw every relationship as right-angle SVG paths.

--- a/plugins/design/skills/interactive-system-design/SKILL.md
+++ b/plugins/design/skills/interactive-system-design/SKILL.md
@@ -10,7 +10,8 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
 - Write one `.html` file. Default to `.context/architecture/interactive/<slug>.html` unless the user names a path.
 - Keep it self-contained: inline CSS, inline SVG, inline JavaScript, no CDN dependencies, no external fonts, no build step.
 - Use real HTML and SVG for the main drawing. Do not make the core diagram a raster image, canvas-only surface, or Mermaid embed.
-- Include enough structure for later edits: a `nodes` array, an `edges` array, stable ids, and clear sections for layout, rendering, interactions, and content.
+- Start from `assets/system-map-template.html` unless the user asks for a different interaction model. Copy it to the output path, then edit only the `map` object in the `CONTENT ONLY` block for the first pass.
+- Keep structure for later edits: the `map.nodes` cards, `map.edges` connections, stable ids, lane positions, and plane dimensions must be the only normal content-editing surface.
 - If a source design doc or architecture artifact exists, preserve its terminology. If it does not, create a first draft from the conversation and mark uncertain assumptions in the foldout cards.
 
 ## Workflow
@@ -20,7 +21,7 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
    - Top-to-bottom for pipeline, lifecycle, or command flow.
    - Swimlanes for ownership, trust boundaries, platforms, or runtime tiers.
    - Radial or clustered layouts only when the relationships are genuinely hub-like.
-3. Create the HTML artifact. Model the system in JavaScript first, then render from that model so nodes, edges, cards, filters, and inspector state stay consistent.
+3. Create the HTML artifact by copying `assets/system-map-template.html`. Replace the placeholder `map` object with the system content: title, search placeholder, plane size, lanes, cards, and connections. Avoid editing shell CSS, rendering, zoom, scrolling, or Space-drag panning unless the user specifically asks to change the shell.
 4. Use Bun to preview the artifact from its directory. Prefer a temporary `Bun.serve` command or an existing project Bun script; do not add dependencies or commit server files just to view one HTML file.
 5. Use the Browser plugin when available. Open the Bun-served local URL in the in-app browser, interact with it, check console errors, test a small viewport, and adjust the file until it is readable and usable.
 6. Share the file path, local preview URL if the server is still running, and the main design questions the artifact now exposes. For co-creation, ask for the next decision in concrete terms, such as which component to expand, which flow to trace, or which trade-off to compare.
@@ -28,16 +29,15 @@ Create an explorable system drawing as one self-contained HTML file. The artifac
 ## Drawing structure
 Use three layers:
 
-1. **Canvas shell**: toolbar, search, view toggles, zoom controls, and an optional minimap.
-2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind or above them.
-3. **Detail surface**: foldout cards, side inspector, or inline accordions for responsibilities, contracts, data owned, failure modes, and open questions.
+1. **Canvas shell**: fixed menu/search, bottom-right zoom controls, scrollable map, and Space-hold dragging. This comes from the template and should usually stay unchanged.
+2. **Diagram plane**: absolute-positioned node cards with an SVG connector layer behind them.
+3. **Detail surface**: foldout card content for responsibilities, contracts, data owned, failure modes, and open questions.
 
-Good default controls:
+The template already includes:
 - Search parts and edge labels.
-- Toggle by layer, ownership lane, runtime tier, sync vs async, or happy path vs failure path.
 - Focus mode on click: highlight connected edges and dim unrelated parts.
 - Edge selection: clicking a connector or its label should focus both endpoints and expose the relationship detail.
-- Reset, fit-to-view, zoom in/out, and copy/share metadata when useful.
+- Reset, fit-to-view, zoom in/out, scroll-wheel map movement, and Space-hold drag panning.
 
 ## Orthogonal connectors
 Draw every relationship as right-angle SVG paths.

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -142,22 +142,24 @@
 			overflow: auto;
 			padding: 68px 28px 28px;
 			overscroll-behavior: contain;
+			cursor: grab;
 			background-color: var(--canvas);
 			background-image: radial-gradient(circle, rgba(99, 110, 138, .16) 1px, transparent 1.2px);
 			background-size: 22px 22px;
 			background-position: 2px 2px;
 		}
 
-		.stage.space-pan {
-			cursor: grab;
-		}
-
-		.stage.space-pan.dragging {
+		.stage.dragging {
 			cursor: grabbing;
 		}
 
 		.stage.space-pan * {
 			cursor: inherit !important;
+		}
+
+		.stage.space-pan .node-layer,
+		.stage.space-pan .edge-hit {
+			pointer-events: none;
 		}
 
 		.stage:focus {
@@ -498,7 +500,7 @@
 		/*
 			CONTENT ONLY.
 			Replace the map object below for each new diagram. Leave the shell,
-			rendering code, styling, scrolling, zooming, and Space-drag panning alone.
+			rendering code, styling, scrolling, zooming, and canvas panning alone.
 
 			Coordinate model:
 			- plane.width / plane.height set the drawing surface.
@@ -915,7 +917,11 @@
 		document.querySelector("#reset").addEventListener("click", resetView);
 
 		function isTypingTarget(target) {
-			return target && ["INPUT", "TEXTAREA", "SELECT", "BUTTON"].includes(target.tagName);
+			return target && (["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName) || target.isContentEditable);
+		}
+
+		function isInteractiveMapTarget(target) {
+			return !!target.closest?.(".node-button, .edge-hit");
 		}
 
 		function setSpacePan(active) {
@@ -942,7 +948,8 @@
 		window.addEventListener("blur", () => setSpacePan(false));
 
 		stage.addEventListener("pointerdown", event => {
-			if (!spacePan || event.button !== 0) return;
+			if (event.button !== 0) return;
+			if (!spacePan && isInteractiveMapTarget(event.target)) return;
 			event.preventDefault();
 			stage.focus({ preventScroll: true });
 			if (stage.setPointerCapture) {

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -511,108 +511,539 @@
 			- edge busX or busY creates an orthogonal dogleg route.
 		*/
 		const map = {
-			title: "Interactive System Map",
-			subtitle: "Replace this content model with the system under design.",
-			searchPlaceholder: "Search nodes, flows, owners, risks",
-			plane: { width: 1220, height: 720, cardWidth: 220, cardHeight: 132 },
+			title: "Agentic Design System Map",
+			subtitle: "A richer starter diagram showing orchestration, evidence, quality gates, and delivery loops.",
+			searchPlaceholder: "Search nodes, flows, evidence, owners, risks",
+			plane: { width: 1840, height: 1040, cardWidth: 242, cardHeight: 138 },
 			lanes: [
-				{ title: "Entry", x: 0, width: 250 },
-				{ title: "Core", x: 294, width: 250 },
-				{ title: "Data", x: 590, width: 290 },
-				{ title: "Delivery", x: 924, width: 296 }
+				{ title: "Intake", x: 0, width: 286 },
+				{ title: "Reasoning", x: 326, width: 326 },
+				{ title: "Tools + Data", x: 710, width: 324 },
+				{ title: "Quality", x: 1090, width: 324 },
+				{ title: "Delivery", x: 1470, width: 324 }
 			],
 			nodes: [
 				{
-					id: "entry",
-					lane: "Entry",
-					x: 22,
-					y: 168,
-					title: "Entry point",
+					id: "requester",
+					lane: "Intake",
+					x: 34,
+					y: 134,
+					title: "Request surface",
 					type: "Interface",
-					badges: ["request", "user-facing"],
-					summary: "The first boundary where a user, agent, or external system enters.",
+					badges: ["prompt", "user-facing"],
+					summary: "Captures the user's goal, visible constraints, and current browser or workspace state.",
 					sections: [
-						{ title: "Responsibilities", items: ["Accept the initial intent.", "Normalize the request shape."] },
-						{ title: "Open Questions", items: ["Which inputs are trusted?", "What context is required?"] }
+						{ title: "Responsibilities", items: ["Accept natural language goals.", "Preserve exact wording and selected browser evidence.", "Expose the first meaningful action quickly."] },
+						{ title: "Contracts", items: ["Input: user request and visible surface.", "Output: normalized goal envelope."] }
 					],
-					risk: "Ambiguous entry contracts push complexity into every downstream part."
+					risk: "Vague entry state can make the rest of the workflow optimize for the wrong target."
 				},
 				{
-					id: "orchestrator",
-					lane: "Core",
-					x: 316,
-					y: 244,
-					title: "Coordinator",
-					type: "Service",
-					badges: ["routing", "policy"],
-					summary: "Chooses the workflow and coordinates the major system steps.",
+					id: "context-capture",
+					lane: "Intake",
+					x: 34,
+					y: 374,
+					title: "Context capture",
+					type: "Collector",
+					badges: ["browser", "workspace"],
+					summary: "Collects the live page, repo files, screenshots, and existing implementation patterns.",
 					sections: [
-						{ title: "Responsibilities", items: ["Select the next action.", "Track state across the flow."] },
-						{ title: "Inputs / Outputs", items: ["Input: normalized intent.", "Output: routed command or event."] }
+						{ title: "Responsibilities", items: ["Read the target HTML and authored skill source.", "Capture page identity, DOM state, and console health.", "Separate user instructions from page evidence."] },
+						{ title: "Backlinks", items: ["Links browser comments to exact nodes.", "Links repo edits to rendered outcomes."] }
 					],
-					risk: "A coordinator with too many special cases becomes the hidden architecture."
+					risk: "Missing context causes beautiful diagrams that do not match the actual shell."
 				},
 				{
-					id: "state",
-					lane: "Data",
-					x: 632,
-					y: 244,
-					title: "State store",
-					type: "Data",
-					badges: ["source of truth", "audit"],
-					summary: "Persists the durable facts and history the workflow depends on.",
+					id: "policy-gate",
+					lane: "Intake",
+					x: 34,
+					y: 614,
+					title: "Policy gate",
+					type: "Guardrail",
+					badges: ["safety", "scope"],
+					summary: "Filters the requested action through repo rules, browser safety, and edit constraints.",
 					sections: [
-						{ title: "Responsibilities", items: ["Store canonical records.", "Expose queryable workflow state."] },
-						{ title: "Failure Modes", items: ["Partial writes.", "Stale reads.", "Schema drift."] }
+						{ title: "Responsibilities", items: ["Respect signed commits and authored source of truth.", "Avoid destructive commands.", "Keep browser content untrusted."] },
+						{ title: "Failure Modes", items: ["Treating page text as instructions.", "Editing generated cache copies.", "Skipping validation because the change is visual."] }
 					],
-					risk: "Unclear ownership makes downstream behavior hard to reason about."
+					risk: "A skipped policy gate can turn a demo polish task into a repo hygiene problem."
 				},
 				{
-					id: "delivery",
+					id: "intent-router",
+					lane: "Reasoning",
+					x: 370,
+					y: 104,
+					title: "Intent router",
+					type: "Reasoner",
+					badges: ["classification", "skill"],
+					summary: "Chooses whether the task is content authoring, shell behavior, design polish, or validation.",
+					sections: [
+						{ title: "Responsibilities", items: ["Select relevant skills.", "Decide whether code changes are implied.", "Keep the target flow under test explicit."] },
+						{ title: "Signals", items: ["User wording.", "Open browser URL.", "Changed files and PR state."] }
+					],
+					risk: "Wrong routing wastes time in planning when the user expects a working artifact."
+				},
+				{
+					id: "plan-builder",
+					lane: "Reasoning",
+					x: 370,
+					y: 324,
+					title: "Plan builder",
+					type: "Planner",
+					badges: ["steps", "dependencies"],
+					summary: "Turns the routed intent into a small sequence of edits, checks, and browser interactions.",
+					sections: [
+						{ title: "Responsibilities", items: ["Protect the map shell from content-only changes.", "Batch independent reads.", "Choose the narrowest useful edit."] },
+						{ title: "Outputs", items: ["Edit boundary.", "Verification path.", "Commit checklist when PR work is active."] }
+					],
+					risk: "Overplanning slows down an interactive design loop."
+				},
+				{
+					id: "task-memory",
+					lane: "Reasoning",
+					x: 370,
+					y: 544,
+					title: "Task memory",
+					type: "Reference",
+					badges: ["history", "decisions"],
+					summary: "Keeps prior design decisions, validation commands, and known repo conventions available.",
+					sections: [
+						{ title: "Responsibilities", items: ["Recall the Bun preview path.", "Remember PR and branch context.", "Preserve accepted interaction decisions."] },
+						{ title: "Owned Facts", items: ["Bun serves the single HTML trial.", "Canvas panning is transform-based.", "Wheel zoom is cursor-centered."] }
+					],
+					risk: "Stale memory must be verified when the live page or branch may have moved."
+				},
+				{
+					id: "rollback-ledger",
+					lane: "Reasoning",
+					x: 370,
+					y: 764,
+					title: "Change ledger",
+					type: "Trace",
+					badges: ["diff", "ownership"],
+					summary: "Records what changed, why it changed, and what should not be reverted.",
+					sections: [
+						{ title: "Responsibilities", items: ["Track touched files.", "Separate user changes from agent edits.", "Support clean commit messages."] },
+						{ title: "Failure Modes", items: ["Losing context across restarts.", "Accidentally replacing unrelated work."] }
+					],
+					risk: "Without a ledger, iteration creates mystery diffs."
+				},
+				{
+					id: "browser-agent",
+					lane: "Tools + Data",
+					x: 750,
+					y: 104,
+					title: "Browser agent",
+					type: "Tool",
+					badges: ["in-app", "DOM"],
+					summary: "Loads the local preview, inspects rendered state, captures screenshots, and exercises interactions.",
+					sections: [
+						{ title: "Responsibilities", items: ["Verify page identity and nonblank content.", "Click cards and edges.", "Read console errors after each UI change."] },
+						{ title: "Data Produced", items: ["DOM snapshots.", "Screenshots.", "Interaction state checks."] }
+					],
+					risk: "Static inspection can miss broken layout, overlap, and interaction regressions."
+				},
+				{
+					id: "file-workspace",
+					lane: "Tools + Data",
+					x: 750,
+					y: 324,
+					title: "Workspace files",
+					type: "Source",
+					badges: ["HTML", "skill"],
+					summary: "Contains the authored skill instructions and the reusable single-file HTML template.",
+					sections: [
+						{ title: "Responsibilities", items: ["Keep the map shell stable.", "Store only reusable template behavior.", "Make content replacement obvious."] },
+						{ title: "Key Files", items: ["SKILL.md.", "assets/system-map-template.html.", "trial index.html copy for preview."] }
+					],
+					risk: "Mixing demo content with shell mechanics makes the template harder to reuse."
+				},
+				{
+					id: "execution-sandbox",
+					lane: "Tools + Data",
+					x: 750,
+					y: 544,
+					title: "Execution sandbox",
+					type: "Runtime",
+					badges: ["Bun", "checks"],
+					summary: "Runs the local server, validation commands, and focused repo checks.",
+					sections: [
+						{ title: "Responsibilities", items: ["Serve the single HTML preview.", "Run repo validation.", "Keep long-running processes visible."] },
+						{ title: "Outputs", items: ["HTTP status.", "Check logs.", "Listening process evidence."] }
+					],
+					risk: "If the server dies, the browser can look broken even when the file is fine."
+				},
+				{
+					id: "artifact-store",
+					lane: "Tools + Data",
+					x: 750,
+					y: 764,
+					title: "Artifact store",
+					type: "Evidence",
+					badges: ["screenshots", "diffs"],
+					summary: "Keeps rendered proof, validation output, and commit-ready source diffs together.",
+					sections: [
+						{ title: "Responsibilities", items: ["Tie screenshot evidence to changed files.", "Keep temporary assets out of the repo.", "Support concise final reporting."] },
+						{ title: "Backlinks", items: ["Screenshot to browser state.", "Diff to source file.", "Commit to PR validation."] }
+					],
+					risk: "Evidence without backlinks is hard to trust during review."
+				},
+				{
+					id: "design-review",
+					lane: "Quality",
+					x: 1130,
+					y: 144,
+					title: "Design review",
+					type: "Evaluator",
+					badges: ["layout", "modern"],
+					summary: "Checks whether the diagram reads like a modern product surface and not a messy debug canvas.",
+					sections: [
+						{ title: "Responsibilities", items: ["Look for overlap and cramped labels.", "Keep shadows restrained.", "Keep controls quiet and discoverable."] },
+						{ title: "Acceptance", items: ["Clear lanes.", "Scannable cards.", "Orthogonal edges that explain structure."] }
+					],
+					risk: "More nodes can make the map feel complex without feeling designed."
+				},
+				{
+					id: "validation-runner",
+					lane: "Quality",
+					x: 1130,
+					y: 384,
+					title: "Validation runner",
+					type: "Verifier",
+					badges: ["CI", "browser"],
+					summary: "Runs the project checks and confirms the rendered target flow still works.",
+					sections: [
+						{ title: "Responsibilities", items: ["Run bun run ci.", "Reload the preview.", "Exercise zoom, pan, card overlay, and search."] },
+						{ title: "Outputs", items: ["Pass/fail check state.", "Console health.", "Interaction proof."] }
+					],
+					risk: "A passing diff can still ship a broken browser interaction."
+				},
+				{
+					id: "risk-register",
+					lane: "Quality",
+					x: 1130,
+					y: 624,
+					title: "Risk register",
+					type: "Control",
+					badges: ["open issues", "tradeoffs"],
+					summary: "Collects unresolved risks, known compromises, and follow-up work without bloating the current change.",
+					sections: [
+						{ title: "Responsibilities", items: ["Flag scope creep.", "Record visual debt.", "Separate follow-up work from the active request."] },
+						{ title: "Failure Modes", items: ["Hiding unresolved risk in a success summary.", "Expanding the PR beyond the user-visible ask."] }
+					],
+					risk: "Untracked risks come back as confusing browser comments later."
+				},
+				{
+					id: "trace-backlinks",
+					lane: "Quality",
+					x: 1130,
+					y: 824,
+					title: "Backlink graph",
+					type: "Trace",
+					badges: ["nodes", "edges"],
+					summary: "Shows how selected cards, edges, source edits, and review evidence refer back to each other.",
+					sections: [
+						{ title: "Responsibilities", items: ["Represent reverse relationships explicitly.", "Keep labels readable on long routes.", "Make each card explain its connected evidence."] },
+						{ title: "User Value", items: ["Click a card to see related system parts.", "Search evidence terms and keep context visible."] }
+					],
+					risk: "Backlinks become noise if every relationship is treated as equally important."
+				},
+				{
+					id: "live-preview",
 					lane: "Delivery",
-					x: 970,
-					y: 244,
-					title: "Delivery surface",
-					type: "Output",
-					badges: ["result", "handoff"],
-					summary: "Presents the outcome or hands it to the next system boundary.",
+					x: 1510,
+					y: 144,
+					title: "Live preview",
+					type: "Surface",
+					badges: ["localhost", "interactive"],
+					summary: "Presents the map as the user sees it, with zoom, pan, search, edge focus, and hero details.",
 					sections: [
-						{ title: "Responsibilities", items: ["Render the final state.", "Expose actionable next steps."] },
-						{ title: "Open Questions", items: ["Who confirms success?", "What gets logged?"] }
+						{ title: "Responsibilities", items: ["Keep the canvas full-screen.", "Make controls feel native to the map.", "Expose complexity without surrounding chrome."] },
+						{ title: "Quality Bar", items: ["No browser scrollbars for panning.", "Dots move with the canvas.", "Wheel zoom works at the cursor."] }
 					],
-					risk: "Success can look complete while hidden handoff work is still pending."
+					risk: "The visible preview is the source of truth for whether the design feels usable."
+				},
+				{
+					id: "pr-handoff",
+					lane: "Delivery",
+					x: 1510,
+					y: 384,
+					title: "PR handoff",
+					type: "Delivery",
+					badges: ["signed commit", "CI"],
+					summary: "Packages the source change with a signed commit, validation output, and PR check state.",
+					sections: [
+						{ title: "Responsibilities", items: ["Stage only touched source files.", "Use a conventional signed commit.", "Watch GitHub validate."] },
+						{ title: "Outputs", items: ["Commit hash.", "Pushed branch.", "Passing PR check."] }
+					],
+					risk: "A good local demo still needs a clean reviewable PR."
+				},
+				{
+					id: "skill-template",
+					lane: "Delivery",
+					x: 1510,
+					y: 624,
+					title: "Reusable template",
+					type: "Artifact",
+					badges: ["single HTML", "content-only"],
+					summary: "The final reusable shell where future diagrams should edit only cards, lanes, and connections.",
+					sections: [
+						{ title: "Responsibilities", items: ["Keep rendering code stable.", "Make the content block self-explanatory.", "Support elaborate diagrams without new dependencies."] },
+						{ title: "Inputs", items: ["Lanes.", "Cards.", "Orthogonal connectors.", "Detail sections."] }
+					],
+					risk: "If the example is too small, users will not learn how to build serious maps."
+				},
+				{
+					id: "learning-loop",
+					lane: "Delivery",
+					x: 1510,
+					y: 824,
+					title: "Learning loop",
+					type: "Feedback",
+					badges: ["comments", "iteration"],
+					summary: "Feeds browser comments, validation failures, and successful patterns back into the next design pass.",
+					sections: [
+						{ title: "Responsibilities", items: ["Turn user comments into precise edits.", "Carry accepted behavior forward.", "Keep the template useful for the next system."] },
+						{ title: "Backlinks", items: ["Comments link to nodes.", "Validation links to source.", "Final state links to the skill."] }
+					],
+					risk: "Iteration gets brittle when feedback is not tied to the artifact it changed."
 				}
 			],
 			edges: [
 				{
-					from: "entry",
-					to: "orchestrator",
+					from: "requester",
+					to: "intent-router",
 					kind: "control",
-					label: "normalize intent",
+					label: "route goal",
 					fromSide: "right",
 					toSide: "left",
-					busX: 280,
-					detail: "The entry point sends a normalized request into the coordinator."
+					busX: 326,
+					detail: "The request surface sends the normalized goal into routing."
 				},
 				{
-					from: "orchestrator",
-					to: "state",
-					kind: "write",
-					label: "persist state",
+					from: "context-capture",
+					to: "plan-builder",
+					kind: "source",
+					label: "provide evidence",
 					fromSide: "right",
 					toSide: "left",
-					busX: 588,
-					detail: "The coordinator writes durable workflow state before delivery."
+					busX: 326,
+					detail: "Captured browser and workspace context shapes the work plan."
 				},
 				{
-					from: "state",
-					to: "delivery",
+					from: "policy-gate",
+					to: "plan-builder",
+					kind: "validate",
+					label: "constrain scope",
+					fromSide: "right",
+					toSide: "left",
+					busX: 326,
+					detail: "Repo and browser safety rules constrain how the plan can execute."
+				},
+				{
+					from: "intent-router",
+					to: "plan-builder",
+					kind: "control",
+					label: "selected path",
+					fromSide: "bottom",
+					toSide: "top",
+					detail: "Routing decisions become a concrete implementation path."
+				},
+				{
+					from: "plan-builder",
+					to: "task-memory",
 					kind: "read",
-					label: "read result",
+					label: "load precedent",
+					fromSide: "bottom",
+					toSide: "top",
+					detail: "The plan reads previous decisions and validation expectations."
+				},
+				{
+					from: "task-memory",
+					to: "rollback-ledger",
+					kind: "write",
+					label: "record decisions",
+					fromSide: "bottom",
+					toSide: "top",
+					detail: "Accepted behavior is recorded so later edits do not regress it."
+				},
+				{
+					from: "intent-router",
+					to: "browser-agent",
+					kind: "control",
+					label: "inspect page",
 					fromSide: "right",
 					toSide: "left",
-					busX: 914,
-					detail: "The delivery surface reads the finalized state and presents it."
+					busX: 710,
+					detail: "The browser agent checks the current rendered state."
+				},
+				{
+					from: "plan-builder",
+					to: "file-workspace",
+					kind: "write",
+					label: "edit source",
+					fromSide: "right",
+					toSide: "left",
+					busX: 710,
+					detail: "The plan becomes a focused source edit."
+				},
+				{
+					from: "task-memory",
+					to: "execution-sandbox",
+					kind: "read",
+					label: "choose commands",
+					fromSide: "right",
+					toSide: "left",
+					busX: 710,
+					detail: "Remembered validation commands drive the runtime checks."
+				},
+				{
+					from: "rollback-ledger",
+					to: "artifact-store",
+					kind: "write",
+					label: "attach diff",
+					fromSide: "right",
+					toSide: "left",
+					busX: 710,
+					detail: "The change ledger stores enough evidence to explain the diff."
+				},
+				{
+					from: "browser-agent",
+					to: "design-review",
+					kind: "validate",
+					label: "visual proof",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1090,
+					detail: "Screenshots and DOM state support visual design review."
+				},
+				{
+					from: "file-workspace",
+					to: "validation-runner",
+					kind: "validate",
+					label: "source checks",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1090,
+					detail: "Changed source is validated by project checks."
+				},
+				{
+					from: "execution-sandbox",
+					to: "validation-runner",
+					kind: "event",
+					label: "run ci",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1090,
+					detail: "The runtime executes the validation command sequence."
+				},
+				{
+					from: "artifact-store",
+					to: "trace-backlinks",
+					kind: "source",
+					label: "evidence links",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1090,
+					detail: "Evidence artifacts connect back to nodes, edges, and source files."
+				},
+				{
+					from: "design-review",
+					to: "live-preview",
+					kind: "delivery",
+					label: "ship visible state",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1470,
+					detail: "Approved visual structure is visible in the live preview."
+				},
+				{
+					from: "validation-runner",
+					to: "pr-handoff",
+					kind: "delivery",
+					label: "check result",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1470,
+					detail: "Validation output becomes PR evidence."
+				},
+				{
+					from: "risk-register",
+					to: "pr-handoff",
+					kind: "risk",
+					label: "remaining risk",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1470,
+					detail: "Open risks are reported with the delivery state."
+				},
+				{
+					from: "trace-backlinks",
+					to: "skill-template",
+					kind: "generate",
+					label: "template model",
+					fromSide: "right",
+					toSide: "left",
+					busX: 1470,
+					detail: "The trace model becomes reusable template guidance."
+				},
+				{
+					from: "live-preview",
+					to: "context-capture",
+					kind: "event",
+					label: "browser comments",
+					fromSide: "top",
+					toSide: "top",
+					busY: 72,
+					detail: "Feedback from the rendered surface loops back into context capture."
+				},
+				{
+					from: "risk-register",
+					to: "policy-gate",
+					kind: "risk",
+					label: "tighten guardrails",
+					fromSide: "left",
+					toSide: "right",
+					busY: 712,
+					detail: "Discovered risks feed back into policy and scope constraints."
+				},
+				{
+					from: "trace-backlinks",
+					to: "artifact-store",
+					kind: "read",
+					label: "resolve backlink",
+					fromSide: "left",
+					toSide: "right",
+					busY: 922,
+					detail: "Backlink selection resolves to the stored evidence that explains it."
+				},
+				{
+					from: "pr-handoff",
+					to: "learning-loop",
+					kind: "event",
+					label: "review signal",
+					fromSide: "bottom",
+					toSide: "top",
+					detail: "PR review and CI feedback are routed into the next iteration."
+				},
+				{
+					from: "skill-template",
+					to: "learning-loop",
+					kind: "event",
+					label: "reuse feedback",
+					fromSide: "bottom",
+					toSide: "top",
+					detail: "Future usage of the template improves the next version of the skill."
+				},
+				{
+					from: "learning-loop",
+					to: "task-memory",
+					kind: "write",
+					label: "remember pattern",
+					fromSide: "bottom",
+					toSide: "bottom",
+					busY: 1000,
+					detail: "Successful interaction patterns are written back into task memory."
 				}
 			]
 		};

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -1,0 +1,824 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Interactive System Map</title>
+	<style>
+		:root {
+			color-scheme: light;
+			--app: #fbfcff;
+			--canvas: #fbfcff;
+			--canvas-line: #edf0f6;
+			--card: #ffffff;
+			--ink: #111318;
+			--muted: #6b7280;
+			--soft: #9aa3b2;
+			--blue: #5e6ad2;
+			--green: #26a269;
+			--amber: #d99028;
+			--red: #df5b67;
+			--violet: #8b6eea;
+			--border: rgba(15, 23, 42, .12);
+			--edge: #b9c1d0;
+		}
+
+		* { box-sizing: border-box; }
+
+		body {
+			margin: 0;
+			height: 100vh;
+			overflow: hidden;
+			background: var(--app);
+			color: var(--ink);
+			font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			letter-spacing: 0;
+		}
+
+		button, input { font: inherit; }
+
+		.app {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr);
+			height: 100vh;
+		}
+
+		.main {
+			display: grid;
+			grid-template-rows: 1fr;
+			min-width: 0;
+			height: 100vh;
+			background: var(--canvas);
+		}
+
+		.topbar {
+			position: fixed;
+			top: 14px;
+			left: 14px;
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			width: auto;
+			max-width: calc(100vw - 28px);
+			padding: 4px;
+			border: 1px solid var(--canvas-line);
+			border-radius: 10px;
+			background: rgba(255, 255, 255, .9);
+			backdrop-filter: blur(18px);
+			color: var(--ink);
+			z-index: 10;
+		}
+
+		.topbar::before {
+			content: "Menu";
+			display: inline-flex;
+			align-items: center;
+			height: 30px;
+			padding: 0 9px;
+			color: #3e4654;
+			font-size: 13px;
+			font-weight: 650;
+		}
+
+		.topbar:hover::before,
+		.topbar:focus-within::before {
+			display: none;
+		}
+
+		.search {
+			display: none;
+			width: min(420px, calc(100vw - 190px));
+			flex: 0 1 auto;
+			height: 36px;
+			border: 1px solid var(--canvas-line);
+			border-radius: 8px;
+			background: white;
+			color: var(--ink);
+			outline: none;
+			padding: 0 11px;
+		}
+
+		.topbar:hover .search,
+		.topbar:focus-within .search {
+			display: block;
+		}
+
+		.search:focus {
+			border-color: rgba(94, 106, 210, .45);
+			box-shadow: 0 0 0 3px rgba(94, 106, 210, .13);
+		}
+
+		.tool-group {
+			position: fixed;
+			right: 14px;
+			bottom: 14px;
+			display: flex;
+			gap: 4px;
+			padding: 4px;
+			border: 1px solid var(--canvas-line);
+			border-radius: 999px;
+			background: rgba(240, 242, 246, .94);
+			backdrop-filter: blur(18px);
+			z-index: 11;
+		}
+
+		.tool {
+			min-width: 34px;
+			height: 30px;
+			border: 0;
+			border-radius: 999px;
+			background: transparent;
+			color: #3e4654;
+			padding: 0 9px;
+			cursor: pointer;
+		}
+
+		.tool:hover {
+			background: white;
+		}
+
+		.stage {
+			position: relative;
+			overflow: auto;
+			padding: 68px 28px 28px;
+			overscroll-behavior: contain;
+			background-color: var(--canvas);
+			background-image: radial-gradient(circle, rgba(99, 110, 138, .16) 1px, transparent 1.2px);
+			background-size: 22px 22px;
+			background-position: 2px 2px;
+		}
+
+		.stage.space-pan {
+			cursor: grab;
+		}
+
+		.stage.space-pan.dragging {
+			cursor: grabbing;
+		}
+
+		.stage.space-pan * {
+			cursor: inherit !important;
+		}
+
+		.stage:focus {
+			outline: none;
+		}
+
+		.plane {
+			position: relative;
+			width: var(--plane-width);
+			height: var(--plane-height);
+			transform-origin: top left;
+			transition: transform .16s ease;
+		}
+
+		.lane {
+			position: absolute;
+			top: 0;
+			bottom: 0;
+			border-left: 1px solid rgba(148, 163, 184, .22);
+			background: transparent;
+		}
+
+		.lane-title {
+			position: absolute;
+			top: 10px;
+			left: 16px;
+			color: #9aa3b2;
+			font-size: 10px;
+			font-weight: 760;
+			letter-spacing: .08em;
+			text-transform: uppercase;
+		}
+
+		.edge-layer {
+			position: absolute;
+			inset: 0;
+			z-index: 1;
+			overflow: visible;
+		}
+
+		.node-layer {
+			position: relative;
+			z-index: 3;
+		}
+
+		.node {
+			position: absolute;
+			width: var(--card-width);
+			min-height: var(--card-height);
+			border: 1px solid var(--border);
+			border-radius: 7px;
+			background: rgba(255, 255, 255, .98);
+			overflow: hidden;
+			user-select: none;
+			transition: border-color .16s ease, opacity .16s ease, background-color .16s ease;
+		}
+
+		.node.hidden, .edge.hidden, .edge-label.hidden { display: none; }
+		.node.dimmed, .edge.dimmed, .edge-label.dimmed { opacity: .16; }
+
+		.node.focused {
+			border-color: rgba(94, 106, 210, .62);
+			background: #fbfbff;
+		}
+
+		.node-button {
+			width: 100%;
+			border: 0;
+			background: transparent;
+			color: inherit;
+			text-align: left;
+			padding: 13px;
+			cursor: pointer;
+		}
+
+		.meta {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 8px;
+			color: var(--muted);
+			font-size: 9px;
+			font-weight: 780;
+			letter-spacing: .06em;
+			text-transform: uppercase;
+		}
+
+		.node h2 {
+			margin: 9px 0 0;
+			color: var(--ink);
+			font-size: 14px;
+			line-height: 1.15;
+		}
+
+		.summary {
+			margin: 7px 0 0;
+			color: #586174;
+			font-size: 11px;
+			line-height: 1.35;
+			display: -webkit-box;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
+			overflow: hidden;
+		}
+
+		.badges {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 5px;
+			margin-top: 10px;
+		}
+
+		.badge {
+			border-radius: 999px;
+			background: #f1f3f8;
+			color: #566072;
+			font-size: 10px;
+			font-weight: 700;
+			padding: 3px 6px;
+		}
+
+		.details {
+			display: grid;
+			grid-template-rows: 0fr;
+			border-top: 1px solid transparent;
+			transition: grid-template-rows .18s ease;
+		}
+
+		.node.open .details {
+			grid-template-rows: 1fr;
+			border-top-color: var(--canvas-line);
+		}
+
+		.details-inner {
+			overflow: hidden;
+			padding: 0 13px;
+		}
+
+		.node.open .details-inner {
+			padding-bottom: 13px;
+		}
+
+		.details h3 {
+			margin: 11px 0 5px;
+			color: #2d3440;
+			font-size: 11px;
+		}
+
+		.details ul {
+			margin: 0;
+			padding-left: 16px;
+			color: #616b7d;
+			font-size: 11px;
+			line-height: 1.42;
+		}
+
+		.edge {
+			fill: none;
+			stroke: var(--edge);
+			stroke-width: 1.8;
+			stroke-linecap: round;
+			stroke-linejoin: round;
+			opacity: .78;
+			pointer-events: none;
+		}
+
+		.edge-hit {
+			fill: none;
+			stroke: transparent;
+			stroke-width: 18;
+			stroke-linecap: round;
+			stroke-linejoin: round;
+			cursor: pointer;
+			pointer-events: stroke;
+		}
+
+		.edge.source,
+		.edge.generate,
+		.edge.validate,
+		.edge.delivery,
+		.edge.read,
+		.edge.write,
+		.edge.event,
+		.edge.control { stroke: var(--edge); }
+		.edge.risk { stroke: #d6a0a7; stroke-dasharray: 3 6; }
+		.edge.selected { stroke: var(--blue); stroke-width: 3; opacity: 1; }
+
+		.edge-label {
+			font-size: 10px;
+			font-weight: 700;
+			fill: #5b6475;
+			paint-order: stroke;
+			stroke: var(--canvas);
+			stroke-width: 5px;
+			stroke-linejoin: round;
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		.edge-label.selected { opacity: 1; fill: #1c2430; }
+
+		@media (max-width: 920px) {
+			body { overflow: hidden; }
+			.app {
+				display: grid;
+				grid-template-columns: 1fr;
+				grid-template-rows: minmax(0, 1fr);
+				height: 100vh;
+			}
+			.main { min-height: 0; }
+			.topbar { top: 10px; left: 10px; max-width: calc(100vw - 20px); }
+			.search { width: min(320px, calc(100vw - 168px)); min-width: 0; }
+			.tool-group { right: 10px; bottom: 10px; }
+			.stage { padding: 60px 20px 20px; }
+		}
+	</style>
+</head>
+<body>
+	<div class="app">
+		<main class="main">
+			<header class="topbar">
+				<input id="search" class="search" type="search" placeholder="Search system">
+			</header>
+			<div class="tool-group" aria-label="View controls">
+				<button class="tool" id="zoomOut" title="Zoom out">-</button>
+				<button class="tool" id="zoomIn" title="Zoom in">+</button>
+				<button class="tool" id="fit" title="Fit view">Fit</button>
+				<button class="tool" id="reset" title="Reset">Reset</button>
+			</div>
+			<section id="stage" class="stage" tabindex="0">
+				<div id="plane" class="plane" aria-label="Interactive system diagram">
+					<div id="lanes"></div>
+					<svg id="edgeLayer" class="edge-layer" aria-hidden="true"></svg>
+					<div id="nodes" class="node-layer"></div>
+				</div>
+			</section>
+		</main>
+	</div>
+	<script>
+		/*
+			CONTENT ONLY.
+			Replace the map object below for each new diagram. Leave the shell,
+			rendering code, styling, scrolling, zooming, and Space-drag panning alone.
+
+			Coordinate model:
+			- plane.width / plane.height set the drawing surface.
+			- lanes are subtle vertical columns.
+			- node x/y values place card top-left corners.
+			- edge busX or busY creates an orthogonal dogleg route.
+		*/
+		const map = {
+			title: "Interactive System Map",
+			subtitle: "Replace this content model with the system under design.",
+			searchPlaceholder: "Search nodes, flows, owners, risks",
+			plane: { width: 1220, height: 720, cardWidth: 220, cardHeight: 132 },
+			lanes: [
+				{ title: "Entry", x: 0, width: 250 },
+				{ title: "Core", x: 294, width: 250 },
+				{ title: "Data", x: 590, width: 290 },
+				{ title: "Delivery", x: 924, width: 296 }
+			],
+			nodes: [
+				{
+					id: "entry",
+					lane: "Entry",
+					x: 22,
+					y: 168,
+					title: "Entry point",
+					type: "Interface",
+					badges: ["request", "user-facing"],
+					summary: "The first boundary where a user, agent, or external system enters.",
+					sections: [
+						{ title: "Responsibilities", items: ["Accept the initial intent.", "Normalize the request shape."] },
+						{ title: "Open Questions", items: ["Which inputs are trusted?", "What context is required?"] }
+					],
+					risk: "Ambiguous entry contracts push complexity into every downstream part."
+				},
+				{
+					id: "orchestrator",
+					lane: "Core",
+					x: 316,
+					y: 244,
+					title: "Coordinator",
+					type: "Service",
+					badges: ["routing", "policy"],
+					summary: "Chooses the workflow and coordinates the major system steps.",
+					sections: [
+						{ title: "Responsibilities", items: ["Select the next action.", "Track state across the flow."] },
+						{ title: "Inputs / Outputs", items: ["Input: normalized intent.", "Output: routed command or event."] }
+					],
+					risk: "A coordinator with too many special cases becomes the hidden architecture."
+				},
+				{
+					id: "state",
+					lane: "Data",
+					x: 632,
+					y: 244,
+					title: "State store",
+					type: "Data",
+					badges: ["source of truth", "audit"],
+					summary: "Persists the durable facts and history the workflow depends on.",
+					sections: [
+						{ title: "Responsibilities", items: ["Store canonical records.", "Expose queryable workflow state."] },
+						{ title: "Failure Modes", items: ["Partial writes.", "Stale reads.", "Schema drift."] }
+					],
+					risk: "Unclear ownership makes downstream behavior hard to reason about."
+				},
+				{
+					id: "delivery",
+					lane: "Delivery",
+					x: 970,
+					y: 244,
+					title: "Delivery surface",
+					type: "Output",
+					badges: ["result", "handoff"],
+					summary: "Presents the outcome or hands it to the next system boundary.",
+					sections: [
+						{ title: "Responsibilities", items: ["Render the final state.", "Expose actionable next steps."] },
+						{ title: "Open Questions", items: ["Who confirms success?", "What gets logged?"] }
+					],
+					risk: "Success can look complete while hidden handoff work is still pending."
+				}
+			],
+			edges: [
+				{
+					from: "entry",
+					to: "orchestrator",
+					kind: "control",
+					label: "normalize intent",
+					fromSide: "right",
+					toSide: "left",
+					busX: 280,
+					detail: "The entry point sends a normalized request into the coordinator."
+				},
+				{
+					from: "orchestrator",
+					to: "state",
+					kind: "write",
+					label: "persist state",
+					fromSide: "right",
+					toSide: "left",
+					busX: 588,
+					detail: "The coordinator writes durable workflow state before delivery."
+				},
+				{
+					from: "state",
+					to: "delivery",
+					kind: "read",
+					label: "read result",
+					fromSide: "right",
+					toSide: "left",
+					busX: 914,
+					detail: "The delivery surface reads the finalized state and presents it."
+				}
+			]
+		};
+
+		const nodeLayer = document.querySelector("#nodes");
+		const edgeLayer = document.querySelector("#edgeLayer");
+		const laneLayer = document.querySelector("#lanes");
+		const search = document.querySelector("#search");
+		const plane = document.querySelector("#plane");
+		const stage = document.querySelector("#stage");
+		let focus = null;
+		let selectedEdge = null;
+		let zoom = 1;
+		let spacePan = false;
+		let dragPan = null;
+
+		document.title = map.title;
+		search.placeholder = map.searchPlaceholder || "Search system";
+		plane.style.setProperty("--plane-width", `${map.plane.width}px`);
+		plane.style.setProperty("--plane-height", `${map.plane.height}px`);
+		plane.style.setProperty("--card-width", `${map.plane.cardWidth}px`);
+		plane.style.setProperty("--card-height", `${map.plane.cardHeight}px`);
+		edgeLayer.setAttribute("viewBox", `0 0 ${map.plane.width} ${map.plane.height}`);
+
+		function escapeHtml(value) {
+			return String(value ?? "").replace(/[&<>"']/g, char => ({
+				"&": "&amp;",
+				"<": "&lt;",
+				">": "&gt;",
+				'"': "&quot;",
+				"'": "&#39;"
+			}[char]));
+		}
+
+		function textFor(node) {
+			const sectionText = (node.sections || []).flatMap(section => [section.title, ...(section.items || [])]);
+			return [node.title, node.type, node.lane, node.summary, node.risk, ...(node.badges || []), ...sectionText].join(" ").toLowerCase();
+		}
+
+		function renderLanes() {
+			laneLayer.innerHTML = (map.lanes || []).map(lane => `
+				<div class="lane" style="left:${lane.x}px;width:${lane.width}px">
+					<span class="lane-title">${escapeHtml(lane.title)}</span>
+				</div>
+			`).join("");
+		}
+
+		function renderNodes() {
+			nodeLayer.innerHTML = map.nodes.map(node => `
+				<article class="node" data-node="${escapeHtml(node.id)}" style="left:${node.x}px;top:${node.y}px">
+					<button class="node-button" aria-expanded="false">
+						<div class="meta"><span>${escapeHtml(node.type)}</span><span>${escapeHtml(node.lane)}</span></div>
+						<h2>${escapeHtml(node.title)}</h2>
+						<p class="summary">${escapeHtml(node.summary)}</p>
+						<div class="badges">${(node.badges || []).map(badge => `<span class="badge">${escapeHtml(badge)}</span>`).join("")}</div>
+					</button>
+					<div class="details">
+						<div class="details-inner">
+							${(node.sections || []).map(section => `
+								<h3>${escapeHtml(section.title)}</h3>
+								<ul>${(section.items || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
+							`).join("")}
+							${node.risk ? `<h3>Risk</h3><ul><li>${escapeHtml(node.risk)}</li></ul>` : ""}
+						</div>
+					</div>
+				</article>
+			`).join("");
+
+			document.querySelectorAll(".node").forEach(card => {
+				card.querySelector(".node-button").addEventListener("click", () => {
+					const id = card.dataset.node;
+					focus = focus === id ? null : id;
+					selectedEdge = null;
+					card.classList.toggle("open");
+					card.querySelector(".node-button").setAttribute("aria-expanded", String(card.classList.contains("open")));
+					renderEdges();
+					applyState();
+				});
+			});
+		}
+
+		function anchor(node, side) {
+			const width = map.plane.cardWidth;
+			const height = map.plane.cardHeight;
+			if (side === "left") return {x: node.x, y: node.y + height / 2};
+			if (side === "right") return {x: node.x + width, y: node.y + height / 2};
+			if (side === "top") return {x: node.x + width / 2, y: node.y};
+			return {x: node.x + width / 2, y: node.y + height};
+		}
+
+		function route(start, end, edge) {
+			if (Number.isFinite(edge.busX)) {
+				return {
+					d: `M ${start.x} ${start.y} H ${edge.busX} V ${end.y} H ${end.x}`,
+					labelX: edge.busX,
+					labelY: Math.round((start.y + end.y) / 2) - 7,
+				};
+			}
+			if (Number.isFinite(edge.busY)) {
+				if (start.x === end.x) {
+					return {
+						d: `M ${start.x} ${start.y} V ${end.y}`,
+						labelX: start.x,
+						labelY: Math.round((start.y + end.y) / 2) - 7,
+					};
+				}
+				return {
+					d: `M ${start.x} ${start.y} V ${edge.busY} H ${end.x} V ${end.y}`,
+					labelX: Math.round((start.x + end.x) / 2),
+					labelY: edge.busY - 7,
+				};
+			}
+			if (edge.fromSide === "left" || edge.fromSide === "right") {
+				const midX = Math.round((start.x + end.x) / 2);
+				return {
+					d: `M ${start.x} ${start.y} H ${midX} V ${end.y} H ${end.x}`,
+					labelX: midX,
+					labelY: Math.round((start.y + end.y) / 2) - 7,
+				};
+			}
+			const midY = Math.round((start.y + end.y) / 2);
+			return {
+				d: `M ${start.x} ${start.y} V ${midY} H ${end.x} V ${end.y}`,
+				labelX: Math.round((start.x + end.x) / 2),
+				labelY: midY - 7,
+			};
+		}
+
+		function edgeKey(edge) {
+			return edge.id || `${edge.from}-${edge.to}-${edge.label}`;
+		}
+
+		function renderEdges() {
+			edgeLayer.innerHTML = `
+				<defs>
+					<marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+						<path d="M0,0 L0,6 L8,3 z" fill="#b9c1d0"></path>
+					</marker>
+				</defs>
+			`;
+			for (const edge of map.edges) {
+				const from = map.nodes.find(node => node.id === edge.from);
+				const to = map.nodes.find(node => node.id === edge.to);
+				if (!from || !to) continue;
+				const start = anchor(from, edge.fromSide || "right");
+				const end = anchor(to, edge.toSide || "left");
+				const path = route(start, end, edge);
+				const key = edgeKey(edge);
+				edgeLayer.insertAdjacentHTML("beforeend", `
+					<path class="edge-hit" data-edge="${escapeHtml(key)}" data-kind="${escapeHtml(edge.kind)}" data-from="${escapeHtml(edge.from)}" data-to="${escapeHtml(edge.to)}" d="${path.d}"></path>
+					<path class="edge ${escapeHtml(edge.kind)}" data-edge-line="${escapeHtml(key)}" d="${path.d}" marker-end="url(#arrow)"></path>
+					<text class="edge-label" data-edge-label="${escapeHtml(key)}" x="${path.labelX}" y="${path.labelY}">${escapeHtml(edge.label)}</text>
+				`);
+			}
+			document.querySelectorAll(".edge-hit").forEach(path => {
+				path.addEventListener("click", event => {
+					event.stopPropagation();
+					selectEdge(path.dataset.edge);
+				});
+			});
+		}
+
+		function selectEdge(key) {
+			const edge = map.edges.find(item => edgeKey(item) === key);
+			selectedEdge = selectedEdge === key ? null : key;
+			focus = edge ? edge.from : null;
+			applyState();
+		}
+
+		function clearSelection() {
+			selectedEdge = null;
+			focus = null;
+		}
+
+		function applyState() {
+			const query = search.value.trim().toLowerCase();
+			const visibleNodes = new Set(map.nodes.filter(node => !query || textFor(node).includes(query)).map(node => node.id));
+			const selected = map.edges.find(edge => edgeKey(edge) === selectedEdge);
+			const connected = id => !focus || id === focus || map.edges.some(edge => (edge.from === focus && edge.to === id) || (edge.to === focus && edge.from === id));
+
+			document.querySelectorAll(".node").forEach(card => {
+				const id = card.dataset.node;
+				const selectedNode = selected && (selected.from === id || selected.to === id);
+				card.classList.toggle("hidden", !visibleNodes.has(id));
+				card.classList.toggle("focused", id === focus || selectedNode);
+				card.classList.toggle("dimmed", !!focus && !connected(id) && !selectedNode);
+			});
+
+			document.querySelectorAll(".edge-hit").forEach(hit => {
+				const key = hit.dataset.edge;
+				const visible = visibleNodes.has(hit.dataset.from) && visibleNodes.has(hit.dataset.to);
+				const focusMatch = !focus || hit.dataset.from === focus || hit.dataset.to === focus || key === selectedEdge;
+				const line = document.querySelector(`[data-edge-line="${CSS.escape(key)}"]`);
+				const label = document.querySelector(`[data-edge-label="${CSS.escape(key)}"]`);
+				hit.classList.toggle("hidden", !visible);
+				line.classList.toggle("hidden", !visible);
+				label.classList.toggle("hidden", !visible);
+				line.classList.toggle("dimmed", !!focus && !focusMatch);
+				label.classList.toggle("dimmed", !!focus && !focusMatch);
+				line.classList.toggle("selected", key === selectedEdge);
+				label.classList.toggle("selected", key === selectedEdge);
+			});
+		}
+
+		function resetView() {
+			clearSelection();
+			zoom = 1;
+			search.value = "";
+			stage.scrollTo({ left: 0, top: 0, behavior: "smooth" });
+			plane.style.transform = "scale(1)";
+			document.querySelectorAll(".node").forEach(card => {
+				card.classList.remove("open");
+				card.querySelector(".node-button").setAttribute("aria-expanded", "false");
+			});
+			renderEdges();
+			applyState();
+		}
+
+		search.addEventListener("input", () => {
+			clearSelection();
+			applyState();
+		});
+
+		document.querySelector("#zoomIn").addEventListener("click", () => {
+			zoom = Math.min(1.25, zoom + .1);
+			plane.style.transform = `scale(${zoom})`;
+		});
+		document.querySelector("#zoomOut").addEventListener("click", () => {
+			zoom = Math.max(.65, zoom - .1);
+			plane.style.transform = `scale(${zoom})`;
+		});
+		document.querySelector("#fit").addEventListener("click", () => {
+			zoom = Math.max(.62, Math.min(1, (stage.clientWidth - 24) / map.plane.width));
+			plane.style.transform = `scale(${zoom})`;
+		});
+		document.querySelector("#reset").addEventListener("click", resetView);
+
+		function isTypingTarget(target) {
+			return target && ["INPUT", "TEXTAREA", "SELECT", "BUTTON"].includes(target.tagName);
+		}
+
+		function setSpacePan(active) {
+			spacePan = active;
+			stage.classList.toggle("space-pan", active);
+			if (!active) {
+				dragPan = null;
+				stage.classList.remove("dragging");
+			}
+		}
+
+		window.addEventListener("keydown", event => {
+			if (event.code !== "Space" || event.repeat || isTypingTarget(event.target)) return;
+			event.preventDefault();
+			setSpacePan(true);
+		});
+
+		window.addEventListener("keyup", event => {
+			if (event.code !== "Space") return;
+			event.preventDefault();
+			setSpacePan(false);
+		});
+
+		window.addEventListener("blur", () => setSpacePan(false));
+
+		stage.addEventListener("pointerdown", event => {
+			if (!spacePan || event.button !== 0) return;
+			event.preventDefault();
+			stage.focus({ preventScroll: true });
+			if (stage.setPointerCapture) {
+				try {
+					stage.setPointerCapture(event.pointerId);
+				} catch {
+					/* Pointer capture can fail for synthetic or interrupted events. */
+				}
+			}
+			dragPan = {
+				pointerId: event.pointerId,
+				x: event.clientX,
+				y: event.clientY,
+				scrollLeft: stage.scrollLeft,
+				scrollTop: stage.scrollTop,
+			};
+			stage.classList.add("dragging");
+		});
+
+		stage.addEventListener("pointermove", event => {
+			if (!dragPan || dragPan.pointerId !== event.pointerId) return;
+			event.preventDefault();
+			stage.scrollLeft = dragPan.scrollLeft - (event.clientX - dragPan.x);
+			stage.scrollTop = dragPan.scrollTop - (event.clientY - dragPan.y);
+		});
+
+		function endPan(event) {
+			if (!dragPan || dragPan.pointerId !== event.pointerId) return;
+			if (stage.releasePointerCapture && stage.hasPointerCapture?.(event.pointerId)) {
+				stage.releasePointerCapture(event.pointerId);
+			}
+			dragPan = null;
+			stage.classList.remove("dragging");
+		}
+
+		stage.addEventListener("pointerup", endPan);
+		stage.addEventListener("pointercancel", endPan);
+
+		renderLanes();
+		renderNodes();
+		renderEdges();
+		applyState();
+	</script>
+</body>
+</html>

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -1069,7 +1069,7 @@
 		const MAX_ZOOM = 1.6;
 		const GRID_SIZE = 22;
 		const GRID_OFFSET = 2;
-		const CONNECTOR_GAP = 18;
+		const CONNECTOR_GAP = 22;
 		const CORNER_RADIUS = 10;
 
 		document.title = map.title;
@@ -1230,6 +1230,203 @@
 			return commands.join(" ");
 		}
 
+		function cardObstacle(node) {
+			const width = map.plane.cardWidth;
+			const height = map.plane.cardHeight;
+			return {
+				left: node.x - CONNECTOR_GAP,
+				right: node.x + width + CONNECTOR_GAP,
+				top: node.y - CONNECTOR_GAP,
+				bottom: node.y + height + CONNECTOR_GAP,
+			};
+		}
+
+		function routeObstacles(edge) {
+			return map.nodes
+				.filter(node => node.id !== edge.from && node.id !== edge.to)
+				.map(cardObstacle);
+		}
+
+		function rangesOverlap(firstStart, firstEnd, secondStart, secondEnd) {
+			const firstMin = Math.min(firstStart, firstEnd);
+			const firstMax = Math.max(firstStart, firstEnd);
+			const secondMin = Math.min(secondStart, secondEnd);
+			const secondMax = Math.max(secondStart, secondEnd);
+			return Math.max(firstMin, secondMin) <= Math.min(firstMax, secondMax);
+		}
+
+		function segmentIntersectsRect(start, end, rect) {
+			if (start.x === end.x) {
+				return start.x >= rect.left
+					&& start.x <= rect.right
+					&& rangesOverlap(start.y, end.y, rect.top, rect.bottom);
+			}
+			if (start.y === end.y) {
+				return start.y >= rect.top
+					&& start.y <= rect.bottom
+					&& rangesOverlap(start.x, end.x, rect.left, rect.right);
+			}
+			return false;
+		}
+
+		function pathClear(points, obstacles) {
+			for (let index = 0; index < points.length - 1; index++) {
+				if (obstacles.some(rect => segmentIntersectsRect(points[index], points[index + 1], rect))) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		function pointBlocked(point, obstacles) {
+			return obstacles.some(rect => point.x >= rect.left
+				&& point.x <= rect.right
+				&& point.y >= rect.top
+				&& point.y <= rect.bottom);
+		}
+
+		function keyFor(point) {
+			return `${point.x},${point.y}`;
+		}
+
+		function pointFor(key) {
+			const [x, y] = key.split(",").map(Number);
+			return {x, y};
+		}
+
+		function pushHeap(heap, item) {
+			heap.push(item);
+			let index = heap.length - 1;
+			while (index > 0) {
+				const parent = Math.floor((index - 1) / 2);
+				if (heap[parent].cost <= item.cost) break;
+				heap[index] = heap[parent];
+				index = parent;
+			}
+			heap[index] = item;
+		}
+
+		function popHeap(heap) {
+			const result = heap[0];
+			const item = heap.pop();
+			if (!heap.length || !item) return result;
+			let index = 0;
+			while (true) {
+				let child = index * 2 + 1;
+				if (child >= heap.length) break;
+				if (child + 1 < heap.length && heap[child + 1].cost < heap[child].cost) child++;
+				if (heap[child].cost >= item.cost) break;
+				heap[index] = heap[child];
+				index = child;
+			}
+			heap[index] = item;
+			return result;
+		}
+
+		function addCoordinate(values, value, max) {
+			if (Number.isFinite(value) && value >= 0 && value <= max) values.add(value);
+		}
+
+		function routeGrid(start, end, edge) {
+			const xValues = new Set();
+			const yValues = new Set();
+			for (let x = 0; x <= map.plane.width; x += GRID_SIZE) xValues.add(x);
+			for (let y = 0; y <= map.plane.height; y += GRID_SIZE) yValues.add(y);
+			addCoordinate(xValues, start.x, map.plane.width);
+			addCoordinate(xValues, end.x, map.plane.width);
+			addCoordinate(xValues, edge.busX, map.plane.width);
+			addCoordinate(yValues, start.y, map.plane.height);
+			addCoordinate(yValues, end.y, map.plane.height);
+			addCoordinate(yValues, edge.busY, map.plane.height);
+
+			const xs = [...xValues].sort((first, second) => first - second);
+			const ys = [...yValues].sort((first, second) => first - second);
+			const xIndex = new Map(xs.map((x, index) => [x, index]));
+			const yIndex = new Map(ys.map((y, index) => [y, index]));
+			const obstacles = routeObstacles(edge);
+			const startKey = keyFor(start);
+			const endKey = keyFor(end);
+			const heap = [];
+			const distance = new Map([[startKey, 0]]);
+			const previous = new Map();
+			const direction = new Map();
+			pushHeap(heap, {key: startKey, cost: 0});
+
+			while (heap.length) {
+				const current = popHeap(heap);
+				if (!current || current.cost !== distance.get(current.key)) continue;
+				if (current.key === endKey) break;
+				const point = pointFor(current.key);
+				const xi = xIndex.get(point.x);
+				const yi = yIndex.get(point.y);
+				const neighbors = [];
+				if (xi > 0) neighbors.push({x: xs[xi - 1], y: point.y});
+				if (xi < xs.length - 1) neighbors.push({x: xs[xi + 1], y: point.y});
+				if (yi > 0) neighbors.push({x: point.x, y: ys[yi - 1]});
+				if (yi < ys.length - 1) neighbors.push({x: point.x, y: ys[yi + 1]});
+
+				for (const next of neighbors) {
+					const nextKey = keyFor(next);
+					if (nextKey !== endKey && pointBlocked(next, obstacles)) continue;
+					if (!pathClear([point, next], obstacles)) continue;
+					const nextDirection = next.x === point.x ? "vertical" : "horizontal";
+					const turnCost = direction.get(current.key) && direction.get(current.key) !== nextDirection ? GRID_SIZE : 0;
+					const stepCost = Math.abs(next.x - point.x) + Math.abs(next.y - point.y) + turnCost;
+					const nextCost = current.cost + stepCost;
+					if (nextCost >= (distance.get(nextKey) ?? Infinity)) continue;
+					distance.set(nextKey, nextCost);
+					previous.set(nextKey, current.key);
+					direction.set(nextKey, nextDirection);
+					pushHeap(heap, {key: nextKey, cost: nextCost});
+				}
+			}
+
+			if (!previous.has(endKey)) return [start, end];
+			const points = [];
+			let cursor = endKey;
+			while (cursor) {
+				points.push(pointFor(cursor));
+				if (cursor === startKey) break;
+				cursor = previous.get(cursor);
+			}
+			points.reverse();
+			return simplifyRoute(points);
+		}
+
+		function simplifyRoute(points) {
+			if (points.length <= 2) return points;
+			const simplified = [points[0]];
+			for (let index = 1; index < points.length - 1; index++) {
+				const previous = simplified[simplified.length - 1];
+				const point = points[index];
+				const next = points[index + 1];
+				if ((previous.x === point.x && point.x === next.x) || (previous.y === point.y && point.y === next.y)) continue;
+				simplified.push(point);
+			}
+			simplified.push(points[points.length - 1]);
+			return simplified;
+		}
+
+		function routeLabel(points) {
+			let segment = {start: points[0], end: points[1] || points[0], length: 0};
+			for (let index = 0; index < points.length - 1; index++) {
+				const start = points[index];
+				const end = points[index + 1];
+				const length = Math.abs(end.x - start.x) + Math.abs(end.y - start.y);
+				if (length > segment.length) segment = {start, end, length};
+			}
+			if (segment.start.y === segment.end.y) {
+				return {
+					labelX: Math.round((segment.start.x + segment.end.x) / 2),
+					labelY: segment.start.y - 7,
+				};
+			}
+			return {
+				labelX: segment.start.x,
+				labelY: Math.round((segment.start.y + segment.end.y) / 2) - 7,
+			};
+		}
+
 		function routed(points, labelX, labelY) {
 			return {
 				d: roundedPath(points),
@@ -1239,41 +1436,9 @@
 		}
 
 		function route(start, end, edge) {
-			if (Number.isFinite(edge.busX)) {
-				return routed(
-					[start, {x: edge.busX, y: start.y}, {x: edge.busX, y: end.y}, end],
-					edge.busX,
-					Math.round((start.y + end.y) / 2) - 7
-				);
-			}
-			if (Number.isFinite(edge.busY)) {
-				if (start.x === end.x) {
-					return routed(
-						[start, end],
-						start.x,
-						Math.round((start.y + end.y) / 2) - 7
-					);
-				}
-				return routed(
-					[start, {x: start.x, y: edge.busY}, {x: end.x, y: edge.busY}, end],
-					Math.round((start.x + end.x) / 2),
-					edge.busY - 7
-				);
-			}
-			if (edge.fromSide === "left" || edge.fromSide === "right") {
-				const midX = Math.round((start.x + end.x) / 2);
-				return routed(
-					[start, {x: midX, y: start.y}, {x: midX, y: end.y}, end],
-					midX,
-					Math.round((start.y + end.y) / 2) - 7
-				);
-			}
-			const midY = Math.round((start.y + end.y) / 2);
-			return routed(
-				[start, {x: start.x, y: midY}, {x: end.x, y: midY}, end],
-				Math.round((start.x + end.x) / 2),
-				midY - 7
-			);
+			const points = routeGrid(start, end, edge);
+			const label = routeLabel(points);
+			return routed(points, label.labelX, label.labelY);
 		}
 
 		function edgeKey(edge) {

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -1116,9 +1116,7 @@
 			document.querySelectorAll(".node").forEach(card => {
 				card.querySelector(".node-button").addEventListener("click", () => {
 					const id = card.dataset.node;
-					focus = id;
-					selectedEdge = null;
-					renderEdges();
+					clearSelection();
 					applyState();
 					openDetail(id, card);
 				});

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -507,27 +507,27 @@
 			Coordinate model:
 			- plane.width / plane.height set the drawing surface.
 			- lanes are subtle vertical columns.
-			- node x/y values place card top-left corners.
+			- node x/y values place card top-left corners; keep them on the 22px grid.
 			- edge busX or busY creates an orthogonal dogleg route.
 		*/
 		const map = {
 			title: "Agentic Design System Map",
 			subtitle: "A richer starter diagram showing orchestration, evidence, quality gates, and delivery loops.",
 			searchPlaceholder: "Search nodes, flows, evidence, owners, risks",
-			plane: { width: 1840, height: 1040, cardWidth: 242, cardHeight: 138 },
+			plane: { width: 1848, height: 1056, cardWidth: 242, cardHeight: 154 },
 			lanes: [
-				{ title: "Intake", x: 0, width: 286 },
-				{ title: "Reasoning", x: 326, width: 326 },
-				{ title: "Tools + Data", x: 710, width: 324 },
-				{ title: "Quality", x: 1090, width: 324 },
-				{ title: "Delivery", x: 1470, width: 324 }
+				{ title: "Intake", x: 0, width: 308 },
+				{ title: "Reasoning", x: 330, width: 330 },
+				{ title: "Tools + Data", x: 704, width: 330 },
+				{ title: "Quality", x: 1078, width: 330 },
+				{ title: "Delivery", x: 1452, width: 352 }
 			],
 			nodes: [
 				{
 					id: "requester",
 					lane: "Intake",
-					x: 34,
-					y: 134,
+					x: 44,
+					y: 132,
 					title: "Request surface",
 					type: "Interface",
 					badges: ["prompt", "user-facing"],
@@ -541,7 +541,7 @@
 				{
 					id: "context-capture",
 					lane: "Intake",
-					x: 34,
+					x: 44,
 					y: 374,
 					title: "Context capture",
 					type: "Collector",
@@ -556,8 +556,8 @@
 				{
 					id: "policy-gate",
 					lane: "Intake",
-					x: 34,
-					y: 614,
+					x: 44,
+					y: 616,
 					title: "Policy gate",
 					type: "Guardrail",
 					badges: ["safety", "scope"],
@@ -571,8 +571,8 @@
 				{
 					id: "intent-router",
 					lane: "Reasoning",
-					x: 370,
-					y: 104,
+					x: 374,
+					y: 110,
 					title: "Intent router",
 					type: "Reasoner",
 					badges: ["classification", "skill"],
@@ -586,8 +586,8 @@
 				{
 					id: "plan-builder",
 					lane: "Reasoning",
-					x: 370,
-					y: 324,
+					x: 374,
+					y: 330,
 					title: "Plan builder",
 					type: "Planner",
 					badges: ["steps", "dependencies"],
@@ -601,8 +601,8 @@
 				{
 					id: "task-memory",
 					lane: "Reasoning",
-					x: 370,
-					y: 544,
+					x: 374,
+					y: 550,
 					title: "Task memory",
 					type: "Reference",
 					badges: ["history", "decisions"],
@@ -616,8 +616,8 @@
 				{
 					id: "rollback-ledger",
 					lane: "Reasoning",
-					x: 370,
-					y: 764,
+					x: 374,
+					y: 770,
 					title: "Change ledger",
 					type: "Trace",
 					badges: ["diff", "ownership"],
@@ -631,8 +631,8 @@
 				{
 					id: "browser-agent",
 					lane: "Tools + Data",
-					x: 750,
-					y: 104,
+					x: 748,
+					y: 110,
 					title: "Browser agent",
 					type: "Tool",
 					badges: ["in-app", "DOM"],
@@ -646,8 +646,8 @@
 				{
 					id: "file-workspace",
 					lane: "Tools + Data",
-					x: 750,
-					y: 324,
+					x: 748,
+					y: 330,
 					title: "Workspace files",
 					type: "Source",
 					badges: ["HTML", "skill"],
@@ -661,8 +661,8 @@
 				{
 					id: "execution-sandbox",
 					lane: "Tools + Data",
-					x: 750,
-					y: 544,
+					x: 748,
+					y: 550,
 					title: "Execution sandbox",
 					type: "Runtime",
 					badges: ["Bun", "checks"],
@@ -676,8 +676,8 @@
 				{
 					id: "artifact-store",
 					lane: "Tools + Data",
-					x: 750,
-					y: 764,
+					x: 748,
+					y: 770,
 					title: "Artifact store",
 					type: "Evidence",
 					badges: ["screenshots", "diffs"],
@@ -691,8 +691,8 @@
 				{
 					id: "design-review",
 					lane: "Quality",
-					x: 1130,
-					y: 144,
+					x: 1122,
+					y: 154,
 					title: "Design review",
 					type: "Evaluator",
 					badges: ["layout", "modern"],
@@ -706,8 +706,8 @@
 				{
 					id: "validation-runner",
 					lane: "Quality",
-					x: 1130,
-					y: 384,
+					x: 1122,
+					y: 396,
 					title: "Validation runner",
 					type: "Verifier",
 					badges: ["CI", "browser"],
@@ -721,8 +721,8 @@
 				{
 					id: "risk-register",
 					lane: "Quality",
-					x: 1130,
-					y: 624,
+					x: 1122,
+					y: 616,
 					title: "Risk register",
 					type: "Control",
 					badges: ["open issues", "tradeoffs"],
@@ -736,8 +736,8 @@
 				{
 					id: "trace-backlinks",
 					lane: "Quality",
-					x: 1130,
-					y: 824,
+					x: 1122,
+					y: 836,
 					title: "Backlink graph",
 					type: "Trace",
 					badges: ["nodes", "edges"],
@@ -751,8 +751,8 @@
 				{
 					id: "live-preview",
 					lane: "Delivery",
-					x: 1510,
-					y: 144,
+					x: 1496,
+					y: 154,
 					title: "Live preview",
 					type: "Surface",
 					badges: ["localhost", "interactive"],
@@ -766,8 +766,8 @@
 				{
 					id: "pr-handoff",
 					lane: "Delivery",
-					x: 1510,
-					y: 384,
+					x: 1496,
+					y: 396,
 					title: "PR handoff",
 					type: "Delivery",
 					badges: ["signed commit", "CI"],
@@ -781,8 +781,8 @@
 				{
 					id: "skill-template",
 					lane: "Delivery",
-					x: 1510,
-					y: 624,
+					x: 1496,
+					y: 616,
 					title: "Reusable template",
 					type: "Artifact",
 					badges: ["single HTML", "content-only"],
@@ -796,8 +796,8 @@
 				{
 					id: "learning-loop",
 					lane: "Delivery",
-					x: 1510,
-					y: 824,
+					x: 1496,
+					y: 836,
 					title: "Learning loop",
 					type: "Feedback",
 					badges: ["comments", "iteration"],
@@ -817,7 +817,7 @@
 					label: "route goal",
 					fromSide: "right",
 					toSide: "left",
-					busX: 326,
+					busX: 330,
 					detail: "The request surface sends the normalized goal into routing."
 				},
 				{
@@ -827,7 +827,7 @@
 					label: "provide evidence",
 					fromSide: "right",
 					toSide: "left",
-					busX: 326,
+					busX: 330,
 					detail: "Captured browser and workspace context shapes the work plan."
 				},
 				{
@@ -837,7 +837,7 @@
 					label: "constrain scope",
 					fromSide: "right",
 					toSide: "left",
-					busX: 326,
+					busX: 330,
 					detail: "Repo and browser safety rules constrain how the plan can execute."
 				},
 				{
@@ -874,7 +874,7 @@
 					label: "inspect page",
 					fromSide: "right",
 					toSide: "left",
-					busX: 710,
+					busX: 704,
 					detail: "The browser agent checks the current rendered state."
 				},
 				{
@@ -884,7 +884,7 @@
 					label: "edit source",
 					fromSide: "right",
 					toSide: "left",
-					busX: 710,
+					busX: 704,
 					detail: "The plan becomes a focused source edit."
 				},
 				{
@@ -894,7 +894,7 @@
 					label: "choose commands",
 					fromSide: "right",
 					toSide: "left",
-					busX: 710,
+					busX: 704,
 					detail: "Remembered validation commands drive the runtime checks."
 				},
 				{
@@ -904,7 +904,7 @@
 					label: "attach diff",
 					fromSide: "right",
 					toSide: "left",
-					busX: 710,
+					busX: 704,
 					detail: "The change ledger stores enough evidence to explain the diff."
 				},
 				{
@@ -914,7 +914,7 @@
 					label: "visual proof",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1090,
+					busX: 1078,
 					detail: "Screenshots and DOM state support visual design review."
 				},
 				{
@@ -924,7 +924,7 @@
 					label: "source checks",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1090,
+					busX: 1078,
 					detail: "Changed source is validated by project checks."
 				},
 				{
@@ -934,7 +934,7 @@
 					label: "run ci",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1090,
+					busX: 1078,
 					detail: "The runtime executes the validation command sequence."
 				},
 				{
@@ -944,7 +944,7 @@
 					label: "evidence links",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1090,
+					busX: 1078,
 					detail: "Evidence artifacts connect back to nodes, edges, and source files."
 				},
 				{
@@ -954,7 +954,7 @@
 					label: "ship visible state",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1470,
+					busX: 1452,
 					detail: "Approved visual structure is visible in the live preview."
 				},
 				{
@@ -964,7 +964,7 @@
 					label: "check result",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1470,
+					busX: 1452,
 					detail: "Validation output becomes PR evidence."
 				},
 				{
@@ -974,7 +974,7 @@
 					label: "remaining risk",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1470,
+					busX: 1452,
 					detail: "Open risks are reported with the delivery state."
 				},
 				{
@@ -984,7 +984,7 @@
 					label: "template model",
 					fromSide: "right",
 					toSide: "left",
-					busX: 1470,
+					busX: 1452,
 					detail: "The trace model becomes reusable template guidance."
 				},
 				{
@@ -994,7 +994,7 @@
 					label: "browser comments",
 					fromSide: "top",
 					toSide: "top",
-					busY: 72,
+					busY: 66,
 					detail: "Feedback from the rendered surface loops back into context capture."
 				},
 				{
@@ -1004,7 +1004,7 @@
 					label: "tighten guardrails",
 					fromSide: "left",
 					toSide: "right",
-					busY: 712,
+					busY: 704,
 					detail: "Discovered risks feed back into policy and scope constraints."
 				},
 				{
@@ -1014,7 +1014,7 @@
 					label: "resolve backlink",
 					fromSide: "left",
 					toSide: "right",
-					busY: 922,
+					busY: 924,
 					detail: "Backlink selection resolves to the stored evidence that explains it."
 				},
 				{
@@ -1042,7 +1042,7 @@
 					label: "remember pattern",
 					fromSide: "bottom",
 					toSide: "bottom",
-					busY: 1000,
+					busY: 1034,
 					detail: "Successful interaction patterns are written back into task memory."
 				}
 			]
@@ -1069,6 +1069,8 @@
 		const MAX_ZOOM = 1.6;
 		const GRID_SIZE = 22;
 		const GRID_OFFSET = 2;
+		const CONNECTOR_GAP = 18;
+		const CORNER_RADIUS = 10;
 
 		document.title = map.title;
 		search.placeholder = map.searchPlaceholder || "Search system";
@@ -1193,48 +1195,85 @@
 		function anchor(node, side) {
 			const width = map.plane.cardWidth;
 			const height = map.plane.cardHeight;
-			if (side === "left") return {x: node.x, y: node.y + height / 2};
-			if (side === "right") return {x: node.x + width, y: node.y + height / 2};
-			if (side === "top") return {x: node.x + width / 2, y: node.y};
-			return {x: node.x + width / 2, y: node.y + height};
+			if (side === "left") return {x: node.x - CONNECTOR_GAP, y: node.y + height / 2};
+			if (side === "right") return {x: node.x + width + CONNECTOR_GAP, y: node.y + height / 2};
+			if (side === "top") return {x: node.x + width / 2, y: node.y - CONNECTOR_GAP};
+			return {x: node.x + width / 2, y: node.y + height + CONNECTOR_GAP};
+		}
+
+		function roundedPath(points) {
+			if (points.length < 2) return "";
+			const commands = [`M ${points[0].x} ${points[0].y}`];
+			for (let index = 1; index < points.length - 1; index++) {
+				const previous = points[index - 1];
+				const point = points[index];
+				const next = points[index + 1];
+				const into = {x: point.x - previous.x, y: point.y - previous.y};
+				const out = {x: next.x - point.x, y: next.y - point.y};
+				const intoLength = Math.abs(into.x) + Math.abs(into.y);
+				const outLength = Math.abs(out.x) + Math.abs(out.y);
+				if (!intoLength || !outLength) continue;
+				const radius = Math.min(CORNER_RADIUS, intoLength / 2, outLength / 2);
+				const before = {
+					x: point.x - Math.sign(into.x) * radius,
+					y: point.y - Math.sign(into.y) * radius,
+				};
+				const after = {
+					x: point.x + Math.sign(out.x) * radius,
+					y: point.y + Math.sign(out.y) * radius,
+				};
+				commands.push(`L ${before.x} ${before.y}`);
+				commands.push(`Q ${point.x} ${point.y} ${after.x} ${after.y}`);
+			}
+			const last = points[points.length - 1];
+			commands.push(`L ${last.x} ${last.y}`);
+			return commands.join(" ");
+		}
+
+		function routed(points, labelX, labelY) {
+			return {
+				d: roundedPath(points),
+				labelX,
+				labelY,
+			};
 		}
 
 		function route(start, end, edge) {
 			if (Number.isFinite(edge.busX)) {
-				return {
-					d: `M ${start.x} ${start.y} H ${edge.busX} V ${end.y} H ${end.x}`,
-					labelX: edge.busX,
-					labelY: Math.round((start.y + end.y) / 2) - 7,
-				};
+				return routed(
+					[start, {x: edge.busX, y: start.y}, {x: edge.busX, y: end.y}, end],
+					edge.busX,
+					Math.round((start.y + end.y) / 2) - 7
+				);
 			}
 			if (Number.isFinite(edge.busY)) {
 				if (start.x === end.x) {
-					return {
-						d: `M ${start.x} ${start.y} V ${end.y}`,
-						labelX: start.x,
-						labelY: Math.round((start.y + end.y) / 2) - 7,
-					};
+					return routed(
+						[start, end],
+						start.x,
+						Math.round((start.y + end.y) / 2) - 7
+					);
 				}
-				return {
-					d: `M ${start.x} ${start.y} V ${edge.busY} H ${end.x} V ${end.y}`,
-					labelX: Math.round((start.x + end.x) / 2),
-					labelY: edge.busY - 7,
-				};
+				return routed(
+					[start, {x: start.x, y: edge.busY}, {x: end.x, y: edge.busY}, end],
+					Math.round((start.x + end.x) / 2),
+					edge.busY - 7
+				);
 			}
 			if (edge.fromSide === "left" || edge.fromSide === "right") {
 				const midX = Math.round((start.x + end.x) / 2);
-				return {
-					d: `M ${start.x} ${start.y} H ${midX} V ${end.y} H ${end.x}`,
-					labelX: midX,
-					labelY: Math.round((start.y + end.y) / 2) - 7,
-				};
+				return routed(
+					[start, {x: midX, y: start.y}, {x: midX, y: end.y}, end],
+					midX,
+					Math.round((start.y + end.y) / 2) - 7
+				);
 			}
 			const midY = Math.round((start.y + end.y) / 2);
-			return {
-				d: `M ${start.x} ${start.y} V ${midY} H ${end.x} V ${end.y}`,
-				labelX: Math.round((start.x + end.x) / 2),
-				labelY: midY - 7,
-			};
+			return routed(
+				[start, {x: start.x, y: midY}, {x: end.x, y: midY}, end],
+				Math.round((start.x + end.x) / 2),
+				midY - 7
+			);
 		}
 
 		function edgeKey(edge) {

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -1294,7 +1294,7 @@
 
 			document.querySelectorAll(".node").forEach(card => {
 				const id = card.dataset.node;
-				const selectedNode = selected && (selected.from === id || selected.to === id);
+				const selectedNode = !!selected && (selected.from === id || selected.to === id);
 				card.classList.toggle("hidden", !visibleNodes.has(id));
 				card.classList.toggle("focused", id === focus || selectedNode);
 				card.classList.toggle("dimmed", !!focus && !connected(id) && !selectedNode);

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -279,41 +279,6 @@
 			padding: 3px 6px;
 		}
 
-		.details {
-			display: grid;
-			grid-template-rows: 0fr;
-			border-top: 1px solid transparent;
-			transition: grid-template-rows .18s ease;
-		}
-
-		.node.open .details {
-			grid-template-rows: 1fr;
-			border-top-color: var(--canvas-line);
-		}
-
-		.details-inner {
-			overflow: hidden;
-			padding: 0 13px;
-		}
-
-		.node.open .details-inner {
-			padding-bottom: 13px;
-		}
-
-		.details h3 {
-			margin: 11px 0 5px;
-			color: #2d3440;
-			font-size: 11px;
-		}
-
-		.details ul {
-			margin: 0;
-			padding-left: 16px;
-			color: #616b7d;
-			font-size: 11px;
-			line-height: 1.42;
-		}
-
 		.edge {
 			fill: none;
 			stroke: var(--edge);
@@ -359,6 +324,132 @@
 
 		.edge-label.selected { opacity: 1; fill: #1c2430; }
 
+		.detail-overlay {
+			position: fixed;
+			inset: 0;
+			display: grid;
+			place-items: center;
+			padding: 36px 18px;
+			opacity: 0;
+			pointer-events: none;
+			transition: opacity .18s ease;
+			z-index: 40;
+		}
+
+		.detail-overlay[hidden] {
+			display: none;
+		}
+
+		.detail-overlay.open {
+			opacity: 1;
+			pointer-events: auto;
+		}
+
+		.detail-backdrop {
+			position: absolute;
+			inset: 0;
+			border: 0;
+			background: rgba(247, 249, 253, .68);
+			backdrop-filter: blur(16px) saturate(1.1);
+			cursor: zoom-out;
+		}
+
+		.detail-card {
+			position: relative;
+			width: min(560px, calc(100vw - 36px));
+			max-height: min(720px, calc(100vh - 72px));
+			overflow: auto;
+			border: 1px solid rgba(15, 23, 42, .14);
+			border-radius: 10px;
+			background: rgba(255, 255, 255, .96);
+			color: var(--ink);
+			animation: hero-in .26s cubic-bezier(.2, .8, .2, 1);
+		}
+
+		.detail-card.closing {
+			animation: hero-out .18s ease forwards;
+		}
+
+		@keyframes hero-in {
+			from {
+				opacity: .24;
+				transform: translate(var(--hero-x, 0), var(--hero-y, 12px)) scale(var(--hero-scale, .86));
+			}
+			to {
+				opacity: 1;
+				transform: translate(0, 0) scale(1);
+			}
+		}
+
+		@keyframes hero-out {
+			to {
+				opacity: 0;
+				transform: translate(var(--hero-x, 0), var(--hero-y, 12px)) scale(var(--hero-scale, .86));
+			}
+		}
+
+		.detail-close {
+			position: absolute;
+			top: 12px;
+			right: 12px;
+			width: 30px;
+			height: 30px;
+			border: 1px solid var(--canvas-line);
+			border-radius: 999px;
+			background: #f7f8fb;
+			color: #4a5261;
+			cursor: pointer;
+		}
+
+		.detail-close:hover {
+			background: white;
+		}
+
+		.detail-hero {
+			padding: 22px 22px 18px;
+			border-bottom: 1px solid var(--canvas-line);
+		}
+
+		.detail-hero h2 {
+			margin: 10px 40px 0 0;
+			font-size: 24px;
+			line-height: 1.08;
+		}
+
+		.detail-summary {
+			margin: 10px 0 0;
+			color: #4f5a6b;
+			font-size: 14px;
+			line-height: 1.45;
+		}
+
+		.detail-body {
+			display: grid;
+			gap: 16px;
+			padding: 18px 22px 22px;
+		}
+
+		.detail-section {
+			display: grid;
+			gap: 7px;
+		}
+
+		.detail-section h3 {
+			margin: 0;
+			color: #2d3440;
+			font-size: 12px;
+			letter-spacing: .04em;
+			text-transform: uppercase;
+		}
+
+		.detail-section ul {
+			margin: 0;
+			padding-left: 18px;
+			color: #616b7d;
+			font-size: 13px;
+			line-height: 1.48;
+		}
+
 		@media (max-width: 920px) {
 			body { overflow: hidden; }
 			.app {
@@ -372,6 +463,9 @@
 			.search { width: min(320px, calc(100vw - 168px)); min-width: 0; }
 			.tool-group { right: 10px; bottom: 10px; }
 			.stage { padding: 60px 20px 20px; }
+			.detail-overlay { padding: 18px 12px; }
+			.detail-card { width: calc(100vw - 24px); max-height: calc(100vh - 36px); }
+			.detail-hero h2 { font-size: 21px; }
 		}
 	</style>
 </head>
@@ -395,6 +489,10 @@
 				</div>
 			</section>
 		</main>
+	</div>
+	<div id="detailOverlay" class="detail-overlay" hidden>
+		<button id="detailBackdrop" class="detail-backdrop" type="button" aria-label="Close details"></button>
+		<article id="detailCard" class="detail-card" role="dialog" aria-modal="true" aria-labelledby="detailTitle" tabindex="-1"></article>
 	</div>
 	<script>
 		/*
@@ -521,8 +619,12 @@
 		const search = document.querySelector("#search");
 		const plane = document.querySelector("#plane");
 		const stage = document.querySelector("#stage");
+		const detailOverlay = document.querySelector("#detailOverlay");
+		const detailBackdrop = document.querySelector("#detailBackdrop");
+		const detailCard = document.querySelector("#detailCard");
 		let focus = null;
 		let selectedEdge = null;
+		let activeDetail = null;
 		let zoom = 1;
 		let spacePan = false;
 		let dragPan = null;
@@ -561,35 +663,92 @@
 		function renderNodes() {
 			nodeLayer.innerHTML = map.nodes.map(node => `
 				<article class="node" data-node="${escapeHtml(node.id)}" style="left:${node.x}px;top:${node.y}px">
-					<button class="node-button" aria-expanded="false">
+					<button class="node-button" aria-haspopup="dialog">
 						<div class="meta"><span>${escapeHtml(node.type)}</span><span>${escapeHtml(node.lane)}</span></div>
 						<h2>${escapeHtml(node.title)}</h2>
 						<p class="summary">${escapeHtml(node.summary)}</p>
 						<div class="badges">${(node.badges || []).map(badge => `<span class="badge">${escapeHtml(badge)}</span>`).join("")}</div>
 					</button>
-					<div class="details">
-						<div class="details-inner">
-							${(node.sections || []).map(section => `
-								<h3>${escapeHtml(section.title)}</h3>
-								<ul>${(section.items || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
-							`).join("")}
-							${node.risk ? `<h3>Risk</h3><ul><li>${escapeHtml(node.risk)}</li></ul>` : ""}
-						</div>
-					</div>
 				</article>
 			`).join("");
 
 			document.querySelectorAll(".node").forEach(card => {
 				card.querySelector(".node-button").addEventListener("click", () => {
 					const id = card.dataset.node;
-					focus = focus === id ? null : id;
+					focus = id;
 					selectedEdge = null;
-					card.classList.toggle("open");
-					card.querySelector(".node-button").setAttribute("aria-expanded", String(card.classList.contains("open")));
 					renderEdges();
 					applyState();
+					openDetail(id, card);
 				});
 			});
+		}
+
+		function renderDetail(node) {
+			return `
+				<button class="detail-close" type="button" aria-label="Close details">&times;</button>
+				<div class="detail-hero">
+					<div class="meta"><span>${escapeHtml(node.type)}</span><span>${escapeHtml(node.lane)}</span></div>
+					<h2 id="detailTitle">${escapeHtml(node.title)}</h2>
+					<p class="detail-summary">${escapeHtml(node.summary)}</p>
+					<div class="badges">${(node.badges || []).map(badge => `<span class="badge">${escapeHtml(badge)}</span>`).join("")}</div>
+				</div>
+				<div class="detail-body">
+					${(node.sections || []).map(section => `
+						<section class="detail-section">
+							<h3>${escapeHtml(section.title)}</h3>
+							<ul>${(section.items || []).map(item => `<li>${escapeHtml(item)}</li>`).join("")}</ul>
+						</section>
+					`).join("")}
+					${node.risk ? `
+						<section class="detail-section">
+							<h3>Risk</h3>
+							<ul><li>${escapeHtml(node.risk)}</li></ul>
+						</section>
+					` : ""}
+				</div>
+			`;
+		}
+
+		function setHeroOrigin(sourceCard) {
+			const rect = sourceCard.getBoundingClientRect();
+			const targetWidth = Math.min(560, window.innerWidth - 36);
+			const targetX = window.innerWidth / 2;
+			const targetY = window.innerHeight / 2;
+			const sourceX = rect.left + rect.width / 2;
+			const sourceY = rect.top + rect.height / 2;
+			detailCard.style.setProperty("--hero-x", `${Math.round(sourceX - targetX)}px`);
+			detailCard.style.setProperty("--hero-y", `${Math.round(sourceY - targetY)}px`);
+			detailCard.style.setProperty("--hero-scale", String(Math.max(.42, Math.min(.92, rect.width / targetWidth))));
+		}
+
+		function openDetail(id, sourceCard) {
+			const node = map.nodes.find(item => item.id === id);
+			if (!node) return;
+			activeDetail = id;
+			setHeroOrigin(sourceCard);
+			detailCard.classList.remove("closing");
+			detailCard.innerHTML = renderDetail(node);
+			detailOverlay.hidden = false;
+			requestAnimationFrame(() => detailOverlay.classList.add("open"));
+			detailCard.querySelector(".detail-close").addEventListener("click", () => closeDetail());
+			detailCard.focus?.({ preventScroll: true });
+		}
+
+		function closeDetail({ clearFocus = false } = {}) {
+			if (detailOverlay.hidden) return;
+			detailCard.classList.add("closing");
+			detailOverlay.classList.remove("open");
+			window.setTimeout(() => {
+				detailOverlay.hidden = true;
+				detailCard.classList.remove("closing");
+				detailCard.innerHTML = "";
+			}, 180);
+			activeDetail = null;
+			if (clearFocus) {
+				clearSelection();
+				applyState();
+			}
 		}
 
 		function anchor(node, side) {
@@ -674,6 +833,7 @@
 		}
 
 		function selectEdge(key) {
+			closeDetail();
 			const edge = map.edges.find(item => edgeKey(item) === key);
 			selectedEdge = selectedEdge === key ? null : key;
 			focus = edge ? edge.from : null;
@@ -716,22 +876,28 @@
 		}
 
 		function resetView() {
+			closeDetail({ clearFocus: true });
 			clearSelection();
 			zoom = 1;
 			search.value = "";
 			stage.scrollTo({ left: 0, top: 0, behavior: "smooth" });
 			plane.style.transform = "scale(1)";
-			document.querySelectorAll(".node").forEach(card => {
-				card.classList.remove("open");
-				card.querySelector(".node-button").setAttribute("aria-expanded", "false");
-			});
 			renderEdges();
 			applyState();
 		}
 
 		search.addEventListener("input", () => {
+			closeDetail();
 			clearSelection();
 			applyState();
+		});
+
+		detailBackdrop.addEventListener("click", () => closeDetail());
+		window.addEventListener("keydown", event => {
+			if (event.key === "Escape" && !detailOverlay.hidden) {
+				event.preventDefault();
+				closeDetail();
+			}
 		});
 
 		document.querySelector("#zoomIn").addEventListener("click", () => {

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -139,10 +139,11 @@
 
 		.stage {
 			position: relative;
-			overflow: auto;
+			overflow: hidden;
 			padding: 68px 28px 28px;
 			overscroll-behavior: contain;
 			cursor: grab;
+			touch-action: none;
 			background-color: var(--canvas);
 			background-image: radial-gradient(circle, rgba(99, 110, 138, .16) 1px, transparent 1.2px);
 			background-size: 22px 22px;
@@ -171,6 +172,7 @@
 			width: var(--plane-width);
 			height: var(--plane-height);
 			transform-origin: top left;
+			will-change: transform;
 			transition: transform .16s ease;
 		}
 
@@ -500,7 +502,7 @@
 		/*
 			CONTENT ONLY.
 			Replace the map object below for each new diagram. Leave the shell,
-			rendering code, styling, scrolling, zooming, and canvas panning alone.
+			rendering code, styling, zooming, and transform-based canvas panning alone.
 
 			Coordinate model:
 			- plane.width / plane.height set the drawing surface.
@@ -628,6 +630,8 @@
 		let selectedEdge = null;
 		let activeDetail = null;
 		let zoom = 1;
+		let panX = 0;
+		let panY = 0;
 		let spacePan = false;
 		let dragPan = null;
 
@@ -877,13 +881,24 @@
 			});
 		}
 
+		function applyView({ animate = true } = {}) {
+			plane.style.transition = animate ? "transform .16s ease" : "none";
+			plane.style.transform = `translate(${panX}px, ${panY}px) scale(${zoom})`;
+			if (!animate) {
+				requestAnimationFrame(() => {
+					plane.style.transition = "transform .16s ease";
+				});
+			}
+		}
+
 		function resetView() {
 			closeDetail({ clearFocus: true });
 			clearSelection();
 			zoom = 1;
+			panX = 0;
+			panY = 0;
 			search.value = "";
-			stage.scrollTo({ left: 0, top: 0, behavior: "smooth" });
-			plane.style.transform = "scale(1)";
+			applyView();
 			renderEdges();
 			applyState();
 		}
@@ -904,15 +919,18 @@
 
 		document.querySelector("#zoomIn").addEventListener("click", () => {
 			zoom = Math.min(1.25, zoom + .1);
-			plane.style.transform = `scale(${zoom})`;
+			applyView();
 		});
 		document.querySelector("#zoomOut").addEventListener("click", () => {
 			zoom = Math.max(.65, zoom - .1);
-			plane.style.transform = `scale(${zoom})`;
+			applyView();
 		});
 		document.querySelector("#fit").addEventListener("click", () => {
-			zoom = Math.max(.62, Math.min(1, (stage.clientWidth - 24) / map.plane.width));
-			plane.style.transform = `scale(${zoom})`;
+			const pad = 56;
+			zoom = Math.max(.35, Math.min(1.15, (stage.clientWidth - pad) / map.plane.width, (stage.clientHeight - pad) / map.plane.height));
+			panX = Math.round((stage.clientWidth - map.plane.width * zoom) / 2) - 28;
+			panY = Math.round((stage.clientHeight - map.plane.height * zoom) / 2) - 68;
+			applyView();
 		});
 		document.querySelector("#reset").addEventListener("click", resetView);
 
@@ -963,8 +981,8 @@
 				pointerId: event.pointerId,
 				x: event.clientX,
 				y: event.clientY,
-				scrollLeft: stage.scrollLeft,
-				scrollTop: stage.scrollTop,
+				panX,
+				panY,
 			};
 			stage.classList.add("dragging");
 		});
@@ -972,9 +990,18 @@
 		stage.addEventListener("pointermove", event => {
 			if (!dragPan || dragPan.pointerId !== event.pointerId) return;
 			event.preventDefault();
-			stage.scrollLeft = dragPan.scrollLeft - (event.clientX - dragPan.x);
-			stage.scrollTop = dragPan.scrollTop - (event.clientY - dragPan.y);
+			panX = dragPan.panX + (event.clientX - dragPan.x);
+			panY = dragPan.panY + (event.clientY - dragPan.y);
+			applyView({ animate: false });
 		});
+
+		stage.addEventListener("wheel", event => {
+			if (!detailOverlay.hidden) return;
+			event.preventDefault();
+			panX -= event.deltaX;
+			panY -= event.deltaY;
+			applyView({ animate: false });
+		}, { passive: false });
 
 		function endPan(event) {
 			if (!dragPan || dragPan.pointerId !== event.pointerId) return;
@@ -991,6 +1018,7 @@
 		renderLanes();
 		renderNodes();
 		renderEdges();
+		applyView({ animate: false });
 		applyState();
 	</script>
 </body>

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -634,6 +634,10 @@
 		let panY = 0;
 		let spacePan = false;
 		let dragPan = null;
+		const MIN_ZOOM = .35;
+		const MAX_ZOOM = 1.6;
+		const GRID_SIZE = 22;
+		const GRID_OFFSET = 2;
 
 		document.title = map.title;
 		search.placeholder = map.searchPlaceholder || "Search system";
@@ -884,8 +888,39 @@
 		function applyView({ animate = true } = {}) {
 			plane.style.transition = animate ? "transform .16s ease" : "none";
 			plane.style.transform = `translate(${panX}px, ${panY}px) scale(${zoom})`;
-			stage.style.backgroundSize = `${22 * zoom}px ${22 * zoom}px`;
-			stage.style.backgroundPosition = `${2 + panX}px ${2 + panY}px`;
+			stage.style.backgroundSize = `${GRID_SIZE * zoom}px ${GRID_SIZE * zoom}px`;
+			stage.style.backgroundPosition = `${GRID_OFFSET + panX}px ${GRID_OFFSET + panY}px`;
+		}
+
+		function clamp(value, min, max) {
+			return Math.max(min, Math.min(max, value));
+		}
+
+		function viewportPoint(clientX, clientY) {
+			const rect = stage.getBoundingClientRect();
+			const style = getComputedStyle(stage);
+			return {
+				x: clientX - rect.left - parseFloat(style.paddingLeft),
+				y: clientY - rect.top - parseFloat(style.paddingTop),
+			};
+		}
+
+		function viewportCenter() {
+			const rect = stage.getBoundingClientRect();
+			return {
+				x: rect.left + rect.width / 2,
+				y: rect.top + rect.height / 2,
+			};
+		}
+
+		function setZoomAt(nextZoom, clientX, clientY, { animate = true } = {}) {
+			const point = viewportPoint(clientX, clientY);
+			const worldX = (point.x - panX) / zoom;
+			const worldY = (point.y - panY) / zoom;
+			zoom = clamp(nextZoom, MIN_ZOOM, MAX_ZOOM);
+			panX = point.x - worldX * zoom;
+			panY = point.y - worldY * zoom;
+			applyView({ animate });
 		}
 
 		function resetView() {
@@ -915,16 +950,16 @@
 		});
 
 		document.querySelector("#zoomIn").addEventListener("click", () => {
-			zoom = Math.min(1.25, zoom + .1);
-			applyView();
+			const center = viewportCenter();
+			setZoomAt(zoom + .1, center.x, center.y);
 		});
 		document.querySelector("#zoomOut").addEventListener("click", () => {
-			zoom = Math.max(.65, zoom - .1);
-			applyView();
+			const center = viewportCenter();
+			setZoomAt(zoom - .1, center.x, center.y);
 		});
 		document.querySelector("#fit").addEventListener("click", () => {
 			const pad = 56;
-			zoom = Math.max(.35, Math.min(1.15, (stage.clientWidth - pad) / map.plane.width, (stage.clientHeight - pad) / map.plane.height));
+			zoom = Math.max(MIN_ZOOM, Math.min(1.15, (stage.clientWidth - pad) / map.plane.width, (stage.clientHeight - pad) / map.plane.height));
 			panX = Math.round((stage.clientWidth - map.plane.width * zoom) / 2) - 28;
 			panY = Math.round((stage.clientHeight - map.plane.height * zoom) / 2) - 68;
 			applyView();
@@ -995,9 +1030,8 @@
 		stage.addEventListener("wheel", event => {
 			if (!detailOverlay.hidden) return;
 			event.preventDefault();
-			panX -= event.deltaX;
-			panY -= event.deltaY;
-			applyView({ animate: false });
+			const zoomFactor = Math.exp(-event.deltaY * .0015);
+			setZoomAt(zoom * zoomFactor, event.clientX, event.clientY, { animate: false });
 		}, { passive: false });
 
 		function endPan(event) {

--- a/plugins/design/skills/interactive-system-design/assets/system-map-template.html
+++ b/plugins/design/skills/interactive-system-design/assets/system-map-template.html
@@ -884,11 +884,8 @@
 		function applyView({ animate = true } = {}) {
 			plane.style.transition = animate ? "transform .16s ease" : "none";
 			plane.style.transform = `translate(${panX}px, ${panY}px) scale(${zoom})`;
-			if (!animate) {
-				requestAnimationFrame(() => {
-					plane.style.transition = "transform .16s ease";
-				});
-			}
+			stage.style.backgroundSize = `${22 * zoom}px ${22 * zoom}px`;
+			stage.style.backgroundPosition = `${2 + panX}px ${2 + panY}px`;
 		}
 
 		function resetView() {


### PR DESCRIPTION
## Summary
- Add `design:interactive-system-design` for co-creating single-file interactive HTML system diagrams.
- Define the artifact contract around orthogonal SVG connectors, foldout cards, controls, and in-app Browser verification.
- Update design plugin metadata and regenerate marketplace/plugin artifacts.

## Validation
- `python3 /Users/luca/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/design/skills/interactive-system-design`
- `bun run marketplace:write`
- `bun run ci`
- `git diff --check`