### PR TITLE
feat(design): add dashboard design skill

### DIFF
--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -50,6 +50,7 @@
 				"api-design",
 				"architecture",
 				"c4-diagrams",
+				"dashboard-design",
 				"data-modeling",
 				"design-options",
 				"design-review",

--- a/plugins/design/.claude-plugin/plugin.json
+++ b/plugins/design/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
 		"./skills/api-design",
 		"./skills/architecture",
 		"./skills/c4-diagrams",
+		"./skills/dashboard-design",
 		"./skills/data-modeling",
 		"./skills/design-options",
 		"./skills/design-review",

--- a/plugins/design/README.md
+++ b/plugins/design/README.md
@@ -5,6 +5,7 @@ Design and architecture skills for product UI, Apple platforms, system architect
 - `design:api-design`
 - `design:architecture`
 - `design:c4-diagrams`
+- `design:dashboard-design`
 - `design:data-modeling`
 - `design:design-options`
 - `design:design-review`

--- a/plugins/design/skills/dashboard-design/SKILL.md
+++ b/plugins/design/skills/dashboard-design/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: dashboard-design
+description: Designs decision-first dashboards, admin consoles, operational workbenches, database management interfaces, support queues, analytics surfaces, settings hubs, and internal tools. Use when creating, redesigning, reviewing, or implementing dashboard-like product UI; when choosing dashboard archetypes, layout, metrics, charts, tables, filters, forms, actions, states, permissions, accessibility, or domain-specific dashboard patterns; or when the user asks for "dashboard UX", "admin UI", "ops console", "management dashboard", "support workbench", "database console", or similar.
+---
+
+# Dashboard Design
+Use this skill to design dashboards as decision-and-action surfaces, not decorative card grids. A dashboard should help a specific person observe state, understand what changed, prioritize, act, and verify the result.
+
+## Core Workflow
+1. Read `references/foundations-and-taxonomy.md` and `references/dashboard-brief.md` before proposing structure or UI. Produce or infer the dashboard brief: user, decision, action, time horizon, scope, entities, data freshness, permissions, and failure cost.
+2. Classify the surface before choosing a layout:
+   - **Dashboard** for at-a-glance status and branching.
+   - **Workbench or queue** for repeated operational processing.
+   - **Resource detail** for one entity with status, history, and contextual operations.
+   - **Explorer** for open-ended investigation.
+   - **Settings hub or wizard** for configuration and risky setup.
+   - **Report or scorecard** for stable review and communication.
+3. Choose one primary archetype. Secondary patterns are allowed only when they support the dominant task model.
+4. Load the narrow references for the surface, components, and domain being designed.
+5. Specify non-happy-path states before finishing: empty, loading, stale, partial, error, permission denied, unsafe action, long-running job, and data-quality uncertainty.
+6. Review the output against `references/review-checklist.md` and `references/common-antipatterns.md`.
+
+## Routing
+|Need|Read|
+|---|---|
+|Core decision model, taxonomy, product-surface choice|`references/foundations-and-taxonomy.md`|
+|Required dashboard brief and clarifying questions|`references/dashboard-brief.md`|
+|Navigation, page hierarchy, headers, tabs, responsive layout patterns|`references/information-architecture-and-layouts.md`|
+|Metric contracts, KPI cards, status, freshness, charts, visualization choices|`references/metrics-status-and-charts.md`|
+|Tables, lists, queues, row actions, bulk actions, pagination, inline editing|`references/tables-lists-and-queues.md`|
+|Scope, filters, search, time controls, URLs, saved views, filter result states|`references/filters-search-scope-and-time.md`|
+|Forms, settings UX, input choice, validation, save models, secrets, destructive flows|`references/forms-and-configuration.md`|
+|Action hierarchy, feedback, optimistic updates, jobs, empty/loading/error states, permissions, auditability|`references/actions-states-and-safety.md`|
+|Keyboard, focus, targets, table accessibility, chart accessibility, localization|`references/accessibility-and-internationalization.md`|
+|Application operations, services, incidents, deployments, logs, jobs|`references/application-operations.md`|
+|Database fleets, database detail, query workbenches, schema browsing, backups, replication, destructive flows|`references/database-management.md`|
+|Support inboxes, reply composers, customer context, manager dashboards, SLA, routing, sensitive data|`references/customer-support.md`|
+|Security, identity, billing, product analytics, moderation, commerce, AI/ML operations, internal admin|`references/additional-domains.md`|
+|Tokens, dashboard components, component states, density, card usage, content style|`references/component-system.md`|
+|Agent design algorithm|`references/agent-execution.md`|
+|Recommended output structure and minimal wireframe output|`references/dashboard-output-specification.md`|
+|Final review checklist|`references/review-checklist.md`|
+|Common anti-patterns to reject|`references/common-antipatterns.md`|
+|Research basis and source links|`references/research-basis.md`|
+
+## Design Rules
+- Start from the decision. Do not begin with chart libraries, KPI cards, decorative cards, or visual style.
+- Keep the distance between a signal and its appropriate action short. A warning should lead to the affected object, evidence, and next safe operation.
+- Treat metrics as contracts: name, definition, scope, source, time window, freshness, thresholds, permissions, and empty/error behavior.
+- Prefer dense but organized operational UI over marketing composition. Admin surfaces should scan well, preserve context, and support repeat use.
+- Make scope and time visible. Hidden tenant, environment, region, segment, or date range choices make dashboards untrustworthy.
+- Use charts only when visual comparison helps. Tables, queues, timelines, or status lists are often better for operational work.
+- Build tables for real data volume: sorting, filtering, column priority, row actions, bulk actions, pagination or virtualization, and narrow-screen behavior.
+- Choose form containers deliberately. Avoid large settings forms in modals; use pages, drawers, wizards, or review screens when complexity or risk requires it.
+- Mark unknown, stale, partial, and delayed data honestly. Never let missing telemetry look healthy.
+- Pair risky actions with eligibility, consequences, audit trail, permission handling, and post-action verification.
+
+## Expected Outputs
+When designing or reviewing a dashboard, include:
+
+1. Dashboard brief.
+2. Primary archetype and any secondary pattern.
+3. Information hierarchy and page structure.
+4. Component plan for metrics, charts, tables, filters, forms, actions, and states.
+5. Responsive and accessibility behavior.
+6. Safety, permission, audit, and data-trust handling.
+7. Wireframe or implementation notes when the user is building UI.
+8. Review findings or anti-patterns found when auditing existing work.
+
+For implementation tasks, convert the plan into the target framework using the existing project design system. Keep this skill responsible for dashboard product structure; use companion frontend or platform skills for framework-specific code conventions when needed.

--- a/plugins/design/skills/dashboard-design/SKILL.md
+++ b/plugins/design/skills/dashboard-design/SKILL.md
@@ -13,7 +13,7 @@ Use this skill to design dashboards as decision-and-action surfaces, not decorat
 
 ## Core Workflow
 1. Choose advisory conversation mode, autonomous build/review mode, or mixed mode from the user's request.
-2. Read `references/foundations-and-taxonomy.md` and `references/dashboard-brief.md` before proposing structure or UI. Produce, ask for, or infer the dashboard brief: user, decision, action, time horizon, scope, entities, data freshness, permissions, and failure cost.
+2. Read `references/dashboard-defaults.md`, `references/foundations-and-taxonomy.md`, and `references/dashboard-brief.md` before proposing structure or UI. Produce, ask for, or infer the dashboard brief: user, decision, action, time horizon, scope, entities, data freshness, permissions, and failure cost.
 3. Classify the surface before choosing a layout:
    - **Dashboard** for at-a-glance status and branching.
    - **Workbench or queue** for repeated operational processing.
@@ -29,6 +29,7 @@ Use this skill to design dashboards as decision-and-action surfaces, not decorat
 ## Routing
 |Need|Read|
 |---|---|
+|Strong default preferences for dashboard product shape, visual tone, data trust, and build/advice behavior|`references/dashboard-defaults.md`|
 |Core decision model, taxonomy, product-surface choice|`references/foundations-and-taxonomy.md`|
 |Required dashboard brief and clarifying questions|`references/dashboard-brief.md`|
 |Navigation, page hierarchy, headers, tabs, responsive layout patterns|`references/information-architecture-and-layouts.md`|
@@ -60,6 +61,13 @@ Use this skill to design dashboards as decision-and-action surfaces, not decorat
 - Choose form containers deliberately. Avoid large settings forms in modals; use pages, drawers, wizards, or review screens when complexity or risk requires it.
 - Mark unknown, stale, partial, and delayed data honestly. Never let missing telemetry look healthy.
 - Pair risky actions with eligibility, consequences, audit trail, permission handling, and post-action verification.
+
+## Default Preferences
+- Treat `references/dashboard-defaults.md` as strong default guidance whenever product context does not clearly point elsewhere.
+- Default to decision/action-first, dense operational surfaces with restrained system UI, visible scope/freshness, capable tables, and preserved drill-down context.
+- Use cards sparingly, charts only when they change the decision, and saved views for repeated operational filter/sort/column setups.
+- Keep risky actions explicit and auditable, copy concrete and terse, and empty states specific to the reason nothing is shown.
+- Let product-specific design systems override visual tone, but not decision/action clarity, data trust, or safety without a clear reason.
 
 ## Expected Outputs
 For advisory conversations, include the dashboard brief, recommended archetype, key trade-offs, questions that still matter, and the next decision the person should make.

--- a/plugins/design/skills/dashboard-design/SKILL.md
+++ b/plugins/design/skills/dashboard-design/SKILL.md
@@ -1,24 +1,30 @@
 ---
 name: dashboard-design
-description: Designs decision-first dashboards, admin consoles, operational workbenches, database management interfaces, support queues, analytics surfaces, settings hubs, and internal tools. Use when creating, redesigning, reviewing, or implementing dashboard-like product UI; when choosing dashboard archetypes, layout, metrics, charts, tables, filters, forms, actions, states, permissions, accessibility, or domain-specific dashboard patterns; or when the user asks for "dashboard UX", "admin UI", "ops console", "management dashboard", "support workbench", "database console", or similar.
+description: Designs decision-first dashboards, admin consoles, operational workbenches, database management interfaces, support queues, analytics surfaces, settings hubs, and internal tools. Use for advisory conversations with a person asking for dashboard UX advice and for autonomous agent work when creating, redesigning, reviewing, or implementing dashboard-like product UI. Trigger when choosing dashboard archetypes, layout, metrics, charts, tables, filters, forms, actions, states, permissions, accessibility, or domain-specific dashboard patterns; or when the user asks for "dashboard UX", "admin UI", "ops console", "management dashboard", "support workbench", "database console", or similar.
 ---
 
 # Dashboard Design
 Use this skill to design dashboards as decision-and-action surfaces, not decorative card grids. A dashboard should help a specific person observe state, understand what changed, prioritize, act, and verify the result.
 
+## Usage Modes
+- **Advisory conversation**: Use when the user wants help thinking through a dashboard, wants critique, or asks what the product surface should do. Ask only the clarifying questions that change the recommendation. Explain the decision model, trade-offs, and recommended pattern in plain language. Do not jump to implementation details unless the user asks to build.
+- **Autonomous build or review**: Use when the user asks the agent to create, modify, or review dashboard UI. Infer the dashboard brief from the repo, product context, existing UI, data model, and user request. If important context is missing, state assumptions and keep moving when the risk is low; ask before making high-impact product, security, or data-model assumptions. Produce implementation-ready structure, states, and validation notes before editing UI.
+- **Mixed mode**: Start conversationally when the user is still deciding, then switch to autonomous build mode once the desired surface, audience, and primary action are clear.
+
 ## Core Workflow
-1. Read `references/foundations-and-taxonomy.md` and `references/dashboard-brief.md` before proposing structure or UI. Produce or infer the dashboard brief: user, decision, action, time horizon, scope, entities, data freshness, permissions, and failure cost.
-2. Classify the surface before choosing a layout:
+1. Choose advisory conversation mode, autonomous build/review mode, or mixed mode from the user's request.
+2. Read `references/foundations-and-taxonomy.md` and `references/dashboard-brief.md` before proposing structure or UI. Produce, ask for, or infer the dashboard brief: user, decision, action, time horizon, scope, entities, data freshness, permissions, and failure cost.
+3. Classify the surface before choosing a layout:
    - **Dashboard** for at-a-glance status and branching.
    - **Workbench or queue** for repeated operational processing.
    - **Resource detail** for one entity with status, history, and contextual operations.
    - **Explorer** for open-ended investigation.
    - **Settings hub or wizard** for configuration and risky setup.
    - **Report or scorecard** for stable review and communication.
-3. Choose one primary archetype. Secondary patterns are allowed only when they support the dominant task model.
-4. Load the narrow references for the surface, components, and domain being designed.
-5. Specify non-happy-path states before finishing: empty, loading, stale, partial, error, permission denied, unsafe action, long-running job, and data-quality uncertainty.
-6. Review the output against `references/review-checklist.md` and `references/common-antipatterns.md`.
+4. Choose one primary archetype. Secondary patterns are allowed only when they support the dominant task model.
+5. Load the narrow references for the surface, components, and domain being designed.
+6. Specify non-happy-path states before finishing: empty, loading, stale, partial, error, permission denied, unsafe action, long-running job, and data-quality uncertainty.
+7. Review the output against `references/review-checklist.md` and `references/common-antipatterns.md`.
 
 ## Routing
 |Need|Read|
@@ -56,7 +62,9 @@ Use this skill to design dashboards as decision-and-action surfaces, not decorat
 - Pair risky actions with eligibility, consequences, audit trail, permission handling, and post-action verification.
 
 ## Expected Outputs
-When designing or reviewing a dashboard, include:
+For advisory conversations, include the dashboard brief, recommended archetype, key trade-offs, questions that still matter, and the next decision the person should make.
+
+When designing, reviewing, or building a dashboard, include:
 
 1. Dashboard brief.
 2. Primary archetype and any secondary pattern.

--- a/plugins/design/skills/dashboard-design/agents/openai.yaml
+++ b/plugins/design/skills/dashboard-design/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Dashboard Design"
-  short_description: "Design decision-first dashboards"
-  default_prompt: "Use $dashboard-design to design a decision-first dashboard for this product."
+  short_description: "Advise on and build dashboards"
+  default_prompt: "Use $dashboard-design to advise on or build a decision-first dashboard for this product."

--- a/plugins/design/skills/dashboard-design/agents/openai.yaml
+++ b/plugins/design/skills/dashboard-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dashboard Design"
+  short_description: "Design decision-first dashboards"
+  default_prompt: "Use $dashboard-design to design a decision-first dashboard for this product."

--- a/plugins/design/skills/dashboard-design/references/accessibility-and-internationalization.md
+++ b/plugins/design/skills/dashboard-design/references/accessibility-and-internationalization.md
@@ -1,0 +1,69 @@
+# Accessibility and Internationalization
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 16. Accessibility and internationalization
+Target WCAG 2.2 AA unless a stricter requirement applies. WCAG 2.2 covers labels and instructions, error identification, focus, status messages, and minimum target sizing among other criteria.[^wcag22]
+
+### 16.1 Keyboard and focus
+MUST:
+
+- make every interactive element operable by keyboard;
+- provide a visible focus indicator;
+- use a logical focus order;
+- return focus sensibly after closing dialogs or drawers;
+- keep focus stable during live updates;
+- support escape for dismissible overlays where safe;
+- avoid keyboard traps in grids, charts, and code editors.
+
+### 16.2 Target size
+WCAG 2.2’s minimum target-size criterion uses 24 × 24 CSS pixels with defined exceptions.[^wcag-target] Critical controls SHOULD generally be larger, especially on touch devices.
+
+### 16.3 Forms
+- Use semantic labels and fieldsets/legends for grouped controls.
+- Identify required fields consistently.
+- Associate helper text and errors with controls.
+- Provide an error summary for long forms.
+- Do not rely on placeholder text.
+- Do not ask users to re-enter information already provided in the same process unless necessary.
+- Announce save, error, and background status without stealing focus.
+
+### 16.4 Tables and grids
+- Use semantic tables for tabular data.
+- Associate headers with cells.
+- Expose sort state.
+- Provide accessible names for row and bulk actions.
+- Ensure sticky headers do not obscure focused content.
+- Test virtualized grids with keyboard and assistive technologies.
+- Offer a simpler detail or export path when a highly interactive grid cannot expose all information accessibly.
+
+### 16.5 Charts
+Critical charts SHOULD provide:
+
+- a concise text summary;
+- accessible title/description;
+- keyboard-accessible data points when interaction is essential;
+- a data table or downloadable data;
+- non-color distinctions;
+- sufficient contrast for graphical elements;
+- reduced-motion behavior.
+
+### 16.6 Status messages
+Saving, filtering, job completion, and errors SHOULD be announced as status updates without unexpectedly moving focus. A visual toast alone may not be sufficient.
+
+### 16.7 Internationalization
+Design for:
+
+- longer translated labels;
+- right-to-left layout;
+- locale-specific number and date formatting;
+- decimal and thousands separators;
+- currency and tax context;
+- pluralization;
+- user-selected timezone;
+- daylight-saving transitions;
+- week-start differences;
+- names and addresses that do not fit a single cultural template.
+
+Store and process exact timestamps independently from how they are displayed.
+
+---

--- a/plugins/design/skills/dashboard-design/references/actions-states-and-safety.md
+++ b/plugins/design/skills/dashboard-design/references/actions-states-and-safety.md
@@ -1,0 +1,226 @@
+# Actions, States, and Safety
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 13. Actions, feedback, and long-running operations
+
+### 13.1 Action hierarchy
+Use:
+
+- one primary action per task area;
+- secondary actions for useful alternatives;
+- tertiary/link actions for navigation or low-emphasis operations;
+- a separated danger action for destructive operations.
+
+Button text SHOULD name the result:
+
+- “Create database”
+- “Roll back to v2.14.3”
+- “Assign 12 conversations”
+- “Save routing rule”
+
+Avoid vague labels such as “Submit,” “OK,” or “Proceed” when a specific result is known.
+
+### 13.2 Feedback placement
+|Feedback type|Best location|
+|---|---|
+|Field validation|At the field, plus summary when needed|
+|Section-level failure|Within the affected section|
+|Whole-page outage or permission issue|Banner near page top|
+|Successful small reversible action|Toast with undo|
+|Background job started|Toast plus durable jobs center|
+|Persistent degraded state|Inline status/banner, not a transient toast|
+|Destructive result|Dedicated result state with recovery information|
+
+### 13.3 Optimistic updates
+Use optimistic UI only when:
+
+- success is highly likely;
+- rollback is safe;
+- conflict risk is low;
+- the UI can clearly revert on failure.
+
+Do not optimistically claim completion for:
+
+- database creation;
+- access-policy propagation;
+- deployment;
+- backup restore;
+- bulk mutation across many records;
+- external integration setup.
+
+For these, acknowledge that the operation started and show durable progress.
+
+### 13.4 Long-running job model
+Every long-running operation SHOULD have:
+
+```yaml
+job:
+  id: job_01J...
+  type: database_restore
+  target: db-prod-eu-2
+  initiated_by: user_123
+  started_at: 2026-06-19T10:41:00+02:00
+  state: running
+  progress:
+    percent: 64
+    phase: applying_wal
+  cancellable: false
+  logs_url: /jobs/job_01J/logs
+  result_url: null
+```
+
+UI requirements:
+
+- persistent job center or activity drawer;
+- queued/running/succeeded/failed/cancelled states;
+- current phase, not a fake percentage when progress is unknowable;
+- start time and elapsed time;
+- target resource;
+- initiator;
+- cancellation rules;
+- logs or diagnostic detail;
+- retry only when safe and idempotent;
+- final result and next action.
+
+### 13.5 Partial success
+Bulk and distributed actions may partially succeed.
+
+Never summarize partial success as simply “Done.” Show:
+
+```text
+Change completed for 87 of 100 databases.
+10 were skipped because they already used the target version.
+3 failed because maintenance windows were locked.
+
+[View failed items] [Download results] [Retry eligible failures]
+```
+
+### 13.6 Real-time updates
+Live updates MUST not:
+
+- steal focus;
+- close a menu or dialog;
+- clear input;
+- reset scroll;
+- reorder the row being acted on;
+- replace a user-selected time range;
+- silently change the active record.
+
+Buffer or visually mark incoming items when necessary. Let the user apply a refresh deliberately during detailed work.
+
+---
+
+## 14. Empty, loading, stale, error, and partial states
+Empty states are not one condition. Carbon identifies empty states as moments when there is no data, including first use, deletion, or unavailability.[^carbon-empty]
+
+### 14.1 State matrix
+|State|Meaning|Required response|
+|---|---|---|
+|**First use**|Nothing has been created|Explain value and provide creation/onboarding action|
+|**Valid empty**|Zero items is expected|Confirm the good or neutral state|
+|**Filtered empty**|Data exists, current filters match none|Show filters and clear/edit action|
+|**No permission**|Data may exist but user cannot view it|Explain required role or request-access path|
+|**Not configured**|Data source or integration missing|Explain setup and consequences|
+|**Loading**|Request is pending|Preserve layout and context|
+|**Delayed/stale**|Last result is old|Retain last known data, mark stale, explain|
+|**Partial**|Some sources or regions succeeded|Show coverage and affected scope|
+|**Error**|Request failed|Explain what failed, preserve context, offer retry|
+|**Unsupported**|Feature does not apply|Explain why; avoid a generic blank state|
+
+### 14.2 Loading
+Use skeletons when the final layout is known. Use a spinner for small isolated actions or when structure is not yet available.
+
+For dashboard loading:
+
+- render the page shell immediately;
+- load independent panels independently;
+- avoid blocking the entire page for one slow widget;
+- preserve prior data during refresh when safe;
+- display a subtle refresh state rather than replacing all content with skeletons.
+
+### 14.3 Error messages
+A useful error says:
+
+- what failed;
+- which scope is affected;
+- whether existing data is retained;
+- whether the action may have partially applied;
+- what the user can do;
+- how to obtain a support/debug identifier.
+
+Bad:
+
+> Something went wrong.
+
+Better:
+
+> Query results could not be loaded for `production / eu-west` after 10:41. The chart still shows data through 10:40. Retry, change the time range, or open diagnostics with request ID `req_83F2`.
+
+### 14.4 Unknown is not healthy
+If monitoring stops, the interface MUST not show green because no errors arrived. Use an unknown/stale state.
+
+---
+
+## 15. Permissions, safety, secrets, and auditability
+Operational dashboards are security-sensitive control planes. Visual permission checks are not sufficient; authorization must be enforced on every request. OWASP recommends least privilege, deny-by-default behavior, and permission validation for every request.[^owasp-authz]
+
+### 15.1 Role model
+A useful baseline:
+
+|Role|Typical capability|
+|---|---|
+|**Viewer**|Read status, metrics, logs permitted by scope|
+|**Operator**|Acknowledge, assign, retry, restart, execute approved runbooks|
+|**Editor**|Change non-critical configuration|
+|**Admin**|Manage resources, access, and high-impact configuration|
+|**Security admin**|Access policies, secrets, audit, security controls|
+|**Billing admin**|Plans, invoices, budgets, payment methods|
+|**Owner**|Organization-wide destructive and ownership actions|
+
+Real products may use attributes and relationships in addition to roles—for example environment, team ownership, region, tenant, and resource sensitivity.
+
+### 15.2 Hide versus disable
+- **Hide** an action when revealing it adds no value or would leak sensitive capability.
+- **Disable with explanation** when seeing the action helps the user understand the workflow or request access.
+- **Show read-only state** when the user needs visibility into effective configuration.
+
+Never imply that a disabled button is the only enforcement mechanism.
+
+### 15.3 Production safety
+For production-changing pages:
+
+- display an environment badge in the header;
+- repeat environment and target in confirmations;
+- visually distinguish production without relying only on color;
+- prevent accidental scope changes during an open form;
+- require fresh permission evaluation on submit;
+- support maintenance windows or approvals where appropriate;
+- log actor, target, before/after, source, and result.
+
+### 15.4 Impersonation and support access
+If staff may impersonate a customer or tenant:
+
+- display a persistent impersonation banner;
+- show the real actor and impersonated identity;
+- limit duration and scope;
+- require a reason;
+- prohibit or elevate highly sensitive actions;
+- log every action as both identities;
+- provide an obvious exit.
+
+### 15.5 Audit log requirements
+Audit events SHOULD include:
+
+- immutable event ID;
+- actor and authentication context;
+- action;
+- target type and ID;
+- organization/environment scope;
+- timestamp and timezone;
+- request source/IP where appropriate;
+- before/after values with secrets redacted;
+- reason, ticket, or approval reference;
+- result and error;
+- correlation/request ID.
+
+---

--- a/plugins/design/skills/dashboard-design/references/additional-domains.md
+++ b/plugins/design/skills/dashboard-design/references/additional-domains.md
@@ -1,0 +1,146 @@
+# Additional Dashboard Domains
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 20. Additional dashboard possibilities
+
+### 20.1 Security operations
+Primary archetypes: command center + investigation + queue.
+
+Show:
+
+- active detections by severity and confidence;
+- affected assets/users;
+- investigation status and owner;
+- attack timeline;
+- correlated events;
+- containment actions;
+- evidence preservation;
+- false-positive and suppression workflow;
+- audit trail.
+
+Avoid severity-only sorting. Include confidence, blast radius, asset criticality, and recency.
+
+### 20.2 Access and identity administration
+Primary archetypes: fleet + resource detail + configuration.
+
+Show:
+
+- users, groups, service accounts;
+- roles and effective permissions;
+- inherited access;
+- privileged access;
+- stale accounts/keys;
+- last activity;
+- pending access reviews;
+- audit events.
+
+Permission changes SHOULD have before/after diff and effective-access preview.
+
+### 20.3 Billing, cost, and usage
+Primary archetypes: tactical scorecard + analytical drill-down.
+
+Show:
+
+- current spend;
+- forecast;
+- budget/threshold;
+- cost by product/team/environment;
+- usage drivers;
+- anomalies;
+- commitments/credits;
+- invoices;
+- optimization opportunities with confidence and trade-offs.
+
+Always distinguish actual, estimated, forecast, and invoiced amounts.
+
+### 20.4 Product analytics and growth
+Primary archetypes: scorecard + explorer.
+
+Show:
+
+- activation;
+- retention/cohorts;
+- funnel conversion;
+- feature adoption;
+- engagement frequency;
+- experiment results;
+- segment comparison;
+- data-quality coverage.
+
+Do not combine incomparable cohorts or hide experiment uncertainty behind a green badge.
+
+### 20.5 Content and moderation
+Primary archetypes: queue/workbench + audit.
+
+Show:
+
+- content preview;
+- policy category;
+- model score and reasons;
+- reporter context;
+- user history where permitted;
+- severity and reach;
+- decision actions;
+- appeal status;
+- reviewer notes;
+- policy version;
+- audit trail.
+
+The interface SHOULD distinguish model suggestion from policy decision and human judgment.
+
+### 20.6 Commerce and fulfillment
+Primary archetypes: operational monitor + queue + resource detail.
+
+Show:
+
+- order backlog;
+- payment failures;
+- inventory risk;
+- fulfillment exceptions;
+- carrier delays;
+- returns/refunds;
+- customer impact;
+- margin/cost context.
+
+Actionable exceptions should link to the affected order, customer, warehouse, or payment attempt.
+
+### 20.7 AI/ML and agent operations
+Primary archetypes: monitor + investigation + review queue.
+
+Show:
+
+- request volume;
+- latency;
+- error rate;
+- token/compute cost;
+- model/version distribution;
+- quality/evaluation score;
+- safety-policy events;
+- tool-call success;
+- fallback/escalation rate;
+- human review outcomes;
+- drift and data coverage;
+- trace of model, prompt, tools, and final action.
+
+MUST distinguish:
+
+- measured quality from proxy metrics;
+- offline evaluation from production behavior;
+- model error from tool/integration error;
+- suggestion from autonomous action;
+- raw user content from redacted evaluation data.
+
+### 20.8 Internal administration
+Examples:
+
+- employee/service desk;
+- procurement;
+- finance operations;
+- compliance evidence;
+- project portfolio;
+- facilities;
+- asset management.
+
+Choose archetypes according to the job. A finance close process is a workflow/queue; an executive finance view is a scorecard; expense investigation is a table/detail workbench.
+
+---

--- a/plugins/design/skills/dashboard-design/references/agent-execution.md
+++ b/plugins/design/skills/dashboard-design/references/agent-execution.md
@@ -1,0 +1,128 @@
+# Agent Execution Algorithm
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 22. Agent execution algorithm
+The agent SHOULD follow this algorithm.
+
+### Step 1: identify the job
+Write one sentence:
+
+> `[User] needs to [decision/action] within [time] using [scope/data], because [consequence].`
+
+### Step 2: classify the surface
+Choose:
+
+- decision horizon;
+- primary archetype;
+- secondary archetype, if necessary;
+- dashboard, report, explorer, workbench, resource detail, settings, wizard, or audit.
+
+### Step 3: model the domain
+List:
+
+- entities;
+- relationships;
+- states;
+- events;
+- metrics;
+- actions;
+- permissions;
+- risk levels;
+- data sources and freshness.
+
+### Step 4: rank information
+Use this score:
+
+```text
+priority = decision_relevance × urgency × confidence × actionability
+```
+
+This is a prioritization aid, not a literal requirement to compute a number.
+
+Remove information that does not change a decision or establish trust.
+
+### Step 5: choose the structure
+Map the primary task:
+
+|Task|Structure|
+|---|---|
+|Monitor state|Command center or overview|
+|Process items|Queue/workbench|
+|Compare resources|Fleet table|
+|Operate one resource|Resource detail|
+|Diagnose|Investigation workspace|
+|Configure|Full-page form or configuration hub|
+|Create safely|Wizard + review|
+|Prove history|Audit timeline|
+|Review outcomes|Scorecard/report|
+
+### Step 6: define drill-downs
+For every summary, answer:
+
+- What detail opens?
+- Is scope preserved?
+- Is time preserved?
+- Is the next action available?
+- Can the user return without losing state?
+
+### Step 7: define forms and actions
+For every mutation:
+
+- container;
+- validation;
+- permission;
+- impact;
+- confirmation strength;
+- reversibility;
+- progress model;
+- audit event;
+- partial-failure behavior.
+
+### Step 8: enumerate states
+At page and component level:
+
+- initial loading;
+- refresh;
+- first-use empty;
+- filtered empty;
+- stale;
+- partial;
+- error;
+- no permission;
+- saving;
+- conflict;
+- job running;
+- success;
+- partial success;
+- failure.
+
+### Step 9: design responsive priority
+Create an explicit narrow-screen order. Do not rely on automatic wrapping alone.
+
+### Step 10: audit accessibility and safety
+Check:
+
+- keyboard/focus;
+- labels/errors;
+- color-independent status;
+- target size;
+- chart alternatives;
+- exact scope;
+- least privilege;
+- secrets;
+- production safety;
+- auditability.
+
+### Step 11: output implementation-ready detail
+The output MUST specify:
+
+- page hierarchy;
+- component inventory;
+- data contract;
+- actions and states;
+- responsive behavior;
+- accessibility notes;
+- analytics/telemetry for UX success;
+- open assumptions.
+
+---

--- a/plugins/design/skills/dashboard-design/references/application-operations.md
+++ b/plugins/design/skills/dashboard-design/references/application-operations.md
@@ -1,0 +1,180 @@
+# Domain Blueprint: Application Operations
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 17. Domain blueprint: application operations
+Application operations combines monitoring, alerting, investigation, deployment, and mitigation. OpenTelemetry organizes observability around signals such as metrics, traces, and logs, with context used to correlate them.[^otel-signals] Google SRE recommends that service dashboards answer basic service questions and prominently cover latency, traffic, errors, and saturation—the four golden signals.[^google-sre-monitoring]
+
+### 17.1 Product-area information architecture
+```text
+Apps
+├─ Overview
+├─ Services
+├─ Deployments
+├─ Incidents
+├─ Alerts
+├─ Logs
+├─ Traces
+├─ Metrics / Explore
+├─ Jobs / Queues
+└─ Settings
+```
+
+### 17.2 Operations home
+Primary users: on-call engineers and service owners.
+
+Recommended structure:
+
+```text
+Production · All regions · Live                 Last update 10:42:11
+
+[1 active incident: Checkout failures in EU] [Open incident]
+
+[Availability] [Error rate] [p95 latency] [Traffic] [Saturation]
+
+Service health
+[Service | Status | SLO burn | Error rate | p95 | Last deploy | Owner]
+
+Recent changes                    Alerts needing action
+[Deployments / config / flags]    [Severity / age / service / status]
+```
+
+MUST include:
+
+- customer-impact status;
+- active incidents;
+- SLO/SLI status where available;
+- recent changes;
+- actionable alerts;
+- scope and freshness;
+- direct links to evidence.
+
+### 17.3 Service detail
+Header:
+
+```text
+checkout-api  Degraded
+Production · eu-west · Team Commerce
+Version v2.14.3 · deployed 34 min ago
+[Open incident] [View logs] [Roll back] [More]
+```
+
+Overview sections:
+
+1. SLO and error-budget status.
+2. Golden signals.
+3. Dependency health.
+4. Recent deployments/config changes.
+5. Active alerts and incidents.
+6. Top errors or endpoints.
+7. Runbooks and owner/contact.
+
+Use data links that preserve service, labels, and time range when moving from a chart to detail. Grafana explicitly supports data links/actions that carry variables such as labels and time range.[^grafana-data-links]
+
+### 17.4 Alert UX
+An alert row SHOULD show:
+
+- severity;
+- state: firing, pending, acknowledged, resolved, silenced;
+- customer impact or SLO relevance;
+- service/resource;
+- start time and duration;
+- current value and threshold;
+- owner/on-call route;
+- related incident;
+- recent correlated change;
+- primary next action.
+
+Alert detail SHOULD include:
+
+- plain-language condition;
+- query and evaluation window;
+- no-data/error behavior;
+- firing instances;
+- notification history;
+- runbook;
+- linked dashboard with preserved context;
+- silence/acknowledge rules;
+- change history.
+
+Most dashboards SHOULD be reachable from alerts, and browsing should be guided by links rather than requiring users to guess where to look.[^grafana-best-practices]
+
+### 17.5 Incident workspace
+```text
+SEV-1 · Checkout failures in EU        [Change status] [Add responder]
+Started 10:17 · Commander Sam · Customer impact confirmed
+
+[Summary] [Timeline] [Evidence] [Responders] [Postmortem]
+
+Current impact / hypothesis / mitigation
+
+Timeline ---------------------- | Actions / runbook
+10:17 alert fired               | [Roll back v2.14.3]
+10:20 incident opened           | [Disable feature flag]
+10:24 deploy correlated         | [Post status update]
+
+Metrics / logs / traces with incident time window
+```
+
+MUST:
+
+- preserve a shared incident time window;
+- show ownership and current status;
+- distinguish fact, hypothesis, and action;
+- record timeline events automatically and manually;
+- link changes to outcomes;
+- make customer communication status visible;
+- preserve evidence after resolution.
+
+### 17.6 Deployment dashboard
+Fleet/list fields:
+
+- app/service;
+- environment;
+- version/commit;
+- actor/source pipeline;
+- started/finished;
+- rollout stage;
+- health checks;
+- affected regions/instances;
+- current status;
+- rollback eligibility.
+
+Deployment detail:
+
+- artifact and commit diff;
+- rollout plan;
+- health gates;
+- logs;
+- related alerts/incidents;
+- previous version;
+- pause/resume/rollback actions;
+- audit trail.
+
+Do not label a deployment “successful” solely because the pipeline ended. Distinguish technical completion from post-deploy health.
+
+### 17.7 Logs, traces, and metrics
+Provide correlation paths:
+
+- metric spike → exemplars/traces or scoped logs;
+- trace → related logs and service metrics;
+- log record → trace ID, deployment, host/container, customer/tenant when permitted;
+- incident → all signals with shared time/scope.
+
+Traces represent the path of a request through an application; correlated context allows signals to be connected across distributed components.[^otel-traces][^otel-context]
+
+### 17.8 Jobs and queues
+Show:
+
+- queue depth;
+- oldest item age;
+- throughput;
+- success/failure rate;
+- retry/dead-letter counts;
+- worker saturation;
+- estimated drain time;
+- top failure reasons;
+- affected tenants.
+
+Prefer outcome and work metrics over a page dominated by CPU/memory. Resource metrics are supporting evidence unless capacity is the immediate problem.
+
+---

--- a/plugins/design/skills/dashboard-design/references/common-antipatterns.md
+++ b/plugins/design/skills/dashboard-design/references/common-antipatterns.md
@@ -1,0 +1,111 @@
+# Common Dashboard Anti-Patterns
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 25. Common anti-patterns
+
+### 25.1 The KPI wall
+**Symptom:** Many equally sized cards with numbers and arrows.
+
+**Why it fails:** No decision hierarchy, no causal context, no obvious action.
+
+**Fix:** Keep only decision-driving KPIs, group by outcome, add target/context, and link to exceptions or detail.
+
+### 25.2 The chart zoo
+**Symptom:** A donut, gauge, treemap, radar chart, and area chart on one page.
+
+**Why it fails:** Visual novelty replaces comparability.
+
+**Fix:** Use a small chart vocabulary and choose by question.
+
+### 25.3 Every page is called a dashboard
+**Symptom:** Settings forms, raw logs, and queues are forced into card grids.
+
+**Why it fails:** The structure conflicts with the task.
+
+**Fix:** Name and design the surface as a workbench, explorer, detail page, settings page, or wizard.
+
+### 25.4 Hidden scope
+**Symptom:** The user cannot tell whether data is production, staging, one region, or all tenants.
+
+**Why it fails:** Decisions and actions can be dangerously misapplied.
+
+**Fix:** Keep scope in the header/context bar and repeat it for consequential actions.
+
+### 25.5 Green because data stopped
+**Symptom:** Monitoring silence appears healthy.
+
+**Why it fails:** Missing evidence is treated as evidence of health.
+
+**Fix:** Use unknown/stale status with last successful update.
+
+### 25.6 Auto-refresh chaos
+**Symptom:** Rows reorder while the user is clicking; charts reset zoom; a selected item disappears.
+
+**Why it fails:** Live data destroys task continuity.
+
+**Fix:** Stabilize selection and sorting, buffer updates, and preserve user state.
+
+### 25.7 Modal as default form container
+**Symptom:** A large settings form or rule builder is placed in a modal.
+
+**Why it fails:** Poor space, weak navigation, fragile error handling, and lost context.
+
+**Fix:** Use a drawer for moderate contextual editing or a full page/wizard for complex work.
+
+### 25.8 Placeholder-only forms
+**Symptom:** Inputs are unlabeled once typing begins.
+
+**Why it fails:** Users lose context and assistive technology support suffers.
+
+**Fix:** Persistent labels, helper text, and explicit units.
+
+### 25.9 Switches that secretly submit
+**Symptom:** A switch appears to change immediately but actually requires a hidden Save button, or changes a critical setting instantly.
+
+**Why it fails:** The control’s behavioral model is unclear.
+
+**Fix:** Use switches for immediate, independent state only when safe; otherwise use a checkbox or explicit form save.
+
+### 25.10 Confirmation fatigue
+**Symptom:** Every trivial action opens “Are you sure?”
+
+**Why it fails:** Users click through automatically and miss genuinely dangerous confirmations.
+
+**Fix:** Use undo for reversible actions and reserve strong confirmation for real risk.
+
+### 25.11 Destructive action as a red primary button
+**Symptom:** “Delete database” is the most prominent action on the page.
+
+**Why it fails:** Visual hierarchy encourages the wrong action.
+
+**Fix:** Separate destructive actions and reveal them through an appropriate risk flow.
+
+### 25.12 Permission theater
+**Symptom:** Buttons are hidden in the UI, but the backend accepts unauthorized requests.
+
+**Why it fails:** UI is not an authorization boundary.
+
+**Fix:** Enforce authorization for every request and treat UI behavior as explanation, not protection.
+
+### 25.13 “No data” for every failure
+**Symptom:** Empty, permission, delayed, and failed states look identical.
+
+**Why it fails:** Users cannot diagnose or recover.
+
+**Fix:** Model and message each state separately.
+
+### 25.14 Metrics without contracts
+**Symptom:** Two dashboards show different “resolution time” values.
+
+**Why it fails:** Definitions, exclusions, windows, or timezones differ.
+
+**Fix:** Central metric definitions with source, owner, and freshness.
+
+### 25.15 Action without verification
+**Symptom:** The user restarts, rolls back, or changes a setting, but the UI only says “Success.”
+
+**Why it fails:** Request acceptance is confused with operational outcome.
+
+**Fix:** Show job result and post-action health verification.
+
+---

--- a/plugins/design/skills/dashboard-design/references/component-system.md
+++ b/plugins/design/skills/dashboard-design/references/component-system.md
@@ -1,0 +1,108 @@
+# Component and Design-System Requirements
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 21. Component and design-system requirements
+A dashboard product SHOULD have a reusable component system rather than bespoke cards on every page.
+
+### 21.1 Foundation tokens
+Define:
+
+- spacing scale;
+- typography roles;
+- semantic colors;
+- border and elevation rules;
+- radii;
+- motion durations and reduced-motion behavior;
+- breakpoints;
+- density modes;
+- z-index layers;
+- chart palette;
+- focus style.
+
+### 21.2 Core components
+At minimum:
+
+- app shell and navigation;
+- page header;
+- breadcrumbs;
+- environment/scope selector;
+- time picker;
+- filter bar and chips;
+- search/combobox;
+- status indicator;
+- metric card;
+- chart frame with common loading/error/empty behavior;
+- table/data grid;
+- data list;
+- pagination;
+- primary-detail drawer;
+- tabs;
+- description list;
+- timeline;
+- alert/banner/toast;
+- empty state;
+- skeleton;
+- form controls;
+- error summary;
+- modal/drawer;
+- wizard;
+- code/query editor wrapper;
+- job progress and jobs center;
+- confirmation/review pattern;
+- audit diff.
+
+### 21.3 Component state contract
+Every data-bearing component MUST define:
+
+```yaml
+states:
+  - loading_initial
+  - loading_refresh
+  - loaded
+  - empty_first_use
+  - empty_filtered
+  - stale
+  - partial
+  - error_recoverable
+  - error_terminal
+  - permission_denied
+```
+
+Every interactive component MUST define:
+
+```yaml
+interaction_states:
+  - default
+  - hover
+  - focus_visible
+  - active
+  - selected
+  - disabled
+  - saving
+  - success
+  - error
+```
+
+### 21.4 Density
+Support at least:
+
+- **comfortable** — general product use and touch-friendly layouts;
+- **compact** — expert tables and queues.
+
+Density MUST not reduce touch targets, focus visibility, or readable line height below accessible requirements. Compact mode is an information-density option, not permission to make controls unusable.
+
+### 21.5 Card usage
+Use cards to create meaningful groups, not to put a border around every piece of text.
+
+Avoid nested cards. Prefer whitespace, headings, dividers, and aligned layout when the relationship is already clear.
+
+### 21.6 Content style
+- Use nouns for destinations: “Databases,” “Incidents,” “Backups.”
+- Use verbs for actions: “Create database,” “Retry job.”
+- Use sentence case.
+- Use consistent domain terms.
+- Avoid unexplained acronyms.
+- Make error and warning copy concrete.
+- Name the object and environment in risky actions.
+
+---

--- a/plugins/design/skills/dashboard-design/references/customer-support.md
+++ b/plugins/design/skills/dashboard-design/references/customer-support.md
@@ -1,0 +1,206 @@
+# Domain Blueprint: Customer Support
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 19. Domain blueprint: customer support
+Customer-support products usually require two distinct surfaces:
+
+1. **Agent workbench** — process conversations efficiently.
+2. **Manager dashboard** — monitor queue health, capacity, SLA, quality, and trends.
+
+Do not merge them into one compromised interface.
+
+Zendesk’s support dashboards cover backlog, unsolved tickets, satisfaction, SLA, and agent activity.[^zendesk-dashboard] Intercom’s real-time dashboard focuses on inbox health, unassigned and waiting conversations, teammate capacity, response times, SLA miss rate, and CSAT.[^intercom-dashboard]
+
+### 19.1 Product-area information architecture
+```text
+Support
+├─ Inbox / queues
+├─ My work
+├─ Customers
+├─ Tickets / conversations
+├─ Knowledge
+├─ Workflows / routing
+├─ Macros / templates
+├─ Reports
+├─ Team / capacity
+├─ SLA policies
+└─ Settings / audit
+```
+
+### 19.2 Agent workbench
+```text
+[My queue] [Search] [Status] [Priority] [Channel] [Sort]
+
+Conversation list 35% | Conversation 45% | Customer context 20%
+                      | Thread            | Identity / plan
+                      | Composer          | Recent activity
+                      | Actions           | Past tickets
+```
+
+Conversation list SHOULD show:
+
+- customer/requester;
+- subject or latest meaningful message;
+- channel;
+- status;
+- priority;
+- SLA/due time;
+- assignee/team;
+- waiting-on state;
+- age and last update;
+- tags or risk flags only when useful.
+
+The workbench SHOULD support:
+
+- next/previous item;
+- reply, note, and forwarding modes;
+- assignment;
+- status transition;
+- macros/templates;
+- attachment handling;
+- customer context;
+- related incidents/status;
+- collision awareness when another agent is viewing or typing;
+- draft preservation;
+- keyboard shortcuts with help.
+
+### 19.3 Reply composer
+Structure:
+
+```text
+Mode: [Reply to customer | Internal note]
+Recipients / channel context
+
+[Rich text composer]
+[Attachments] [Macro] [Knowledge] [AI assist]
+
+Status after send [Pending ▼]     [Send]
+```
+
+MUST:
+
+- visually distinguish public reply from internal note;
+- preserve drafts;
+- warn before sending sensitive internal content publicly when detectable;
+- expose recipient/channel;
+- show attachment upload state;
+- make send state explicit;
+- handle failure without losing content;
+- identify AI-generated content and keep the human in control.
+
+### 19.4 Customer context panel
+Show only support-relevant context:
+
+- identity and organization;
+- plan/tier and entitlements;
+- locale/timezone;
+- recent conversations;
+- product/app status;
+- account health flags;
+- recent billing or deployment events when authorized;
+- consent and sensitive-data markers;
+- internal notes.
+
+Avoid a dumping ground of every CRM field. Prioritize data that changes the response or escalation.
+
+### 19.5 Manager real-time dashboard
+Recommended structure:
+
+```text
+Support · All inboxes · Today / Live
+
+[Unassigned] [Waiting first reply] [SLA at risk] [Open] [Active agents]
+
+Queue health by inbox/team --------------------------------
+[Inbox | Unassigned | Oldest | SLA risk | Capacity | Status]
+
+Arrival vs completion trend       Agent/team capacity
+
+Oldest / highest-risk conversations table
+```
+
+Operational metrics:
+
+- new volume;
+- open backlog;
+- unassigned count;
+- waiting for first reply;
+- oldest waiting time;
+- SLA at risk and breached;
+- active/available teammates;
+- arrivals versus completions;
+- current channel queue.
+
+Quality/performance metrics belong in a tactical report unless they affect immediate decisions:
+
+- first response time;
+- resolution time;
+- reopen rate;
+- one-touch resolution;
+- CSAT;
+- escalation rate;
+- backlog aging;
+- knowledge deflection;
+- automation containment with quality guardrails.
+
+### 19.6 Capacity UX
+Do not show “agents online” without queue context. Pair capacity with:
+
+- active workload;
+- assigned/open count;
+- unassigned count;
+- arrival rate;
+- oldest wait;
+- channel capability;
+- availability state and reason;
+- schedule/timezone if appropriate.
+
+Avoid simplistic individual leaderboards. They can reward closing easy tickets, discourage collaboration, and ignore case complexity. Prefer team-level outcomes plus drill-down for coaching with appropriate context.
+
+### 19.7 SLA UX
+An SLA indicator SHOULD show:
+
+- policy and target;
+- metric being timed;
+- time remaining or breach duration;
+- business versus calendar time;
+- pause conditions;
+- priority;
+- escalation path.
+
+Use relative urgency in queues but provide the exact due timestamp. Make paused timers visibly distinct from active ones.
+
+### 19.8 Routing and automation
+Use a rule builder with:
+
+- entry conditions;
+- priority/order;
+- assignment action;
+- capacity/availability behavior;
+- fallback;
+- test conversation;
+- conflict detection;
+- version history;
+- publish/rollback;
+- explanation on each conversation: “Assigned to Billing because …”.
+
+### 19.9 Support reporting
+Separate:
+
+- real-time operations;
+- daily/weekly team management;
+- monthly strategic outcomes;
+- quality review;
+- customer-segment analysis.
+
+Each needs different freshness, aggregation, and behavior. Do not use a live operational queue as a historical performance report.
+
+### 19.10 Sensitive customer data
+- Mask PII according to role and purpose.
+- Log access to sensitive records.
+- Make exports explicit and permissioned.
+- Avoid exposing full payment, credential, health, or private content in list views.
+- Protect copied content and screenshots where policy requires it.
+- Distinguish customer-visible and internal fields throughout the workflow.
+
+---

--- a/plugins/design/skills/dashboard-design/references/dashboard-brief.md
+++ b/plugins/design/skills/dashboard-design/references/dashboard-brief.md
@@ -1,0 +1,97 @@
+# Dashboard Brief
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 5. The dashboard brief an agent must create first
+Before generating UI, the agent MUST produce a brief containing the following.
+
+```yaml
+dashboard_brief:
+  name: "Production overview"
+  primary_user: "On-call application engineer"
+  secondary_users:
+    - "Service owner"
+    - "Support escalation engineer"
+
+  primary_job: >
+    Detect customer-impacting degradation, identify the affected service,
+    and reach the correct investigation or mitigation action quickly.
+
+  decisions:
+    - "Is there active customer impact?"
+    - "Which service, region, tenant, or release is involved?"
+    - "Should I acknowledge, escalate, roll back, or investigate?"
+
+  decision_horizon: "minutes"
+  archetype: "monitor"
+  secondary_archetype: "incident queue"
+
+  scope_dimensions:
+    - environment
+    - region
+    - service
+    - tenant
+  default_scope:
+    environment: production
+    region: all
+
+  entities:
+    - service
+    - deployment
+    - incident
+    - alert
+    - region
+
+  freshness:
+    target: "60 seconds"
+    stale_after: "3 minutes"
+    behavior_when_stale: "Show stale badge and retain last known values"
+
+  key_metrics:
+    - name: "Availability SLI"
+      definition: "Successful eligible requests / all eligible requests"
+      unit: "%"
+      window: "rolling 30 days"
+      comparison: "SLO target"
+
+  critical_actions:
+    - "Open incident"
+    - "Acknowledge alert"
+    - "Open runbook"
+    - "View logs/traces"
+    - "Roll back deployment"
+
+  risk_level: "high"
+  permissions:
+    viewer: ["view"]
+    operator: ["view", "acknowledge", "open_incident"]
+    admin: ["view", "acknowledge", "open_incident", "rollback"]
+
+  device_priority:
+    desktop: "primary"
+    mobile: "triage and acknowledgement only"
+
+  success_criteria:
+    - "A user can locate the highest-impact active issue within 10 seconds"
+    - "Every alert has a clear investigation path"
+    - "Production-changing actions show scope and impact before confirmation"
+```
+
+### 5.1 Required questions
+The brief MUST answer:
+
+- Who is using the surface?
+- What recurring job are they doing?
+- What decision will the information change?
+- How quickly must they decide?
+- What is the cost of a wrong action?
+- What entities and relationships matter?
+- Which scope is global and which is local?
+- How fresh must the data be?
+- What happens if data is missing or stale?
+- What actions are allowed for each role?
+- Which tasks must work on a narrow screen?
+- How will success be measured?
+
+If these answers are unknown, the agent SHOULD state assumptions explicitly rather than silently inventing them.
+
+---

--- a/plugins/design/skills/dashboard-design/references/dashboard-defaults.md
+++ b/plugins/design/skills/dashboard-design/references/dashboard-defaults.md
@@ -1,0 +1,70 @@
+# Dashboard Defaults
+Use these as strong defaults when designing, reviewing, or building dashboard-like product surfaces. They are not strict house rules: override them when the product domain, audience, platform, or existing design system clearly calls for a different choice.
+
+## Philosophy
+**Default to decision/action-first dashboards** - A dashboard should help someone decide what matters and what to do next. A polished surface that does not change a decision, shorten a workflow, or establish trust is decoration.
+
+**Optimize for repeated operational use** - Most admin consoles, workbenches, and internal tools are used repeatedly by people trying to scan, compare, triage, and act. Prefer compact hierarchy, stable controls, and clear data over presentation-heavy composition.
+
+**Treat product context as the override mechanism** - Use these defaults when the repo or user has not supplied a stronger product-specific design system. Keep the decision/action, data-trust, and safety principles unless there is a concrete reason to depart.
+
+## Layout and Navigation
+**Use dense operational layouts by default** - Compact spacing and high information throughput make dashboard work faster when users are scanning many entities, alerts, or work items. Use more spacious layouts for executive scorecards, review reports, onboarding, or mixed non-technical audiences.
+
+**Prefer restrained system UI** - Default to quiet surfaces, semantic color, readable contrast, familiar controls, and a Linear/Stripe-like precision. This keeps attention on the data and actions rather than the chrome.
+
+**Use structured bands, panes, and tables before card grids** - Full-width sections, split panes, drawers, and tables preserve hierarchy and scale better than floating cards. Cards are acceptable for meaningful repeated entities or compact summaries, but a card grid should not be the default page structure.
+
+**Keep navigation stable** - Prefer a predictable sidebar or header with visible current location and persistent scope. Command-driven access can augment expert workflows, but it should not replace obvious navigation for core dashboard areas.
+
+**Preserve context through drill-downs** - Summary clicks should open filtered lists, detail drawers, tabs, or routes that retain scope, time range, filters, and scroll position where practical. The user should not have to rebuild context after following a signal.
+
+## Metrics, Charts, and Tables
+**Use KPI rows only when summaries are actionable** - Top-level summaries should explain priority, link to detail, or support a decision. Avoid vanity numbers that occupy prime space without changing the next action.
+
+**Make charts earn their place** - Use charts when trend shape, anomaly detection, comparison, distribution, or composition changes the decision. Use concise text, status rows, timelines, or tables when they communicate the answer faster.
+
+**Prefer capable tables and lists for many resources** - When a dashboard contains many resources or work items, provide clear columns, sorting, filtering, row actions, bulk actions, pagination or virtualization, and useful empty states.
+
+**Use saved views for repeated operational setups** - If users repeatedly apply the same scope, filters, sort, columns, or grouping, include saved views or presets by default. They make repeated work faster and reduce the risk of hidden ad hoc filtering.
+
+## Scope, Trust, and State
+**Make scope visible** - Workspace, tenant, environment, region, segment, and time range should live in a stable context area when they affect interpretation. Hidden scope makes dashboards untrustworthy.
+
+**Surface data freshness and uncertainty when decisions depend on them** - Show freshness, stale states, partial coverage, unknown states, and source confidence where they affect action. Monitoring that stops should never look healthy just because no new errors arrived.
+
+**Use semantic status language** - Pair severity color with text, icons, labels, and accessible structure. Do not rely on color alone or use dramatic color treatment where a precise status label would communicate better.
+
+**Prioritize narrow screens by task value** - On small screens, keep the most important status, identity, and action path first. Move dense comparison into focused views instead of trying to preserve the whole desktop grid.
+
+## Actions and Configuration
+**Keep risky actions explicit and auditable** - Production-affecting or destructive actions need clear target, consequence, eligibility, permission handling, audit event, and post-action verification. Avoid both casual one-click danger and confirmation-heavy flows that do not improve understanding.
+
+**Choose form containers by complexity and risk** - Use full pages for complex or high-impact configuration, drawers for moderate contextual edits, and modals only for short focused decisions. Do not put large settings or rule builders in modals by default.
+
+**Place actions near their signals** - A warning, failed job, risky resource, or breaching queue should lead directly to the affected object, evidence, and the next safe action. Do not strand users with a status and no path forward.
+
+## Copy and Empty States
+**Use concrete, terse copy** - Labels should name the object, state, action, and consequence. Avoid marketing language, vague verbs, and clever labels in operational surfaces.
+
+**Make empty states specific** - Distinguish first use, valid empty, filtered empty, no permission, not configured, loading, stale, partial, error, and unsupported states. Each should explain what happened and provide the appropriate next action when one exists.
+
+## Advisory vs Build Mode
+**For advisory conversations, stay concise** - Return the decision brief, recommended archetype, key trade-offs, questions that still matter, and the next decision. Do not produce a full build spec unless asked.
+
+**For autonomous builds, infer ordinary details and ask only on high-impact gaps** - Infer layout, density, component choice, and common states from the repo and product context. Ask before assuming core users, destructive workflows, security posture, billing impact, or other high-impact product decisions.
+
+**Use a compact internal spec before code** - In build mode, form a brief internal spec for audience, decision, scope, data, layout, actions, states, and validation. The final response should mention the key design choices without dumping the full internal working unless useful.
+
+**Verify rendered dashboards visually** - After implementation, inspect desktop and narrow-screen renders for hierarchy, density, overlap, contrast, state clarity, and whether the main decision/action path is obvious.
+
+## Anti-Patterns
+**Anti-pattern: decorative dashboards** - Walls of cards and charts can look complete while failing to help users decide or act. Replace decorative sections with priority, evidence, and action.
+
+**Anti-pattern: hidden context** - If scope, time, environment, permissions, or freshness are hard to find, users cannot trust the page. Surface the context that changes interpretation.
+
+**Anti-pattern: charts as filler** - A chart that does not reveal a trend, comparison, distribution, composition, or anomaly is usually weaker than a status row or table.
+
+**Anti-pattern: card grids as IA** - Cards are components, not an information architecture. If the page needs comparison, prioritization, or repeated work, use tables, queues, panes, and filters.
+
+**Anti-pattern: action without verification** - Starting a job, retry, rollback, restore, or delete flow without durable progress, final result, and recovery or verification path leaves the operator guessing.

--- a/plugins/design/skills/dashboard-design/references/dashboard-output-specification.md
+++ b/plugins/design/skills/dashboard-design/references/dashboard-output-specification.md
@@ -1,0 +1,62 @@
+# Dashboard Output Specification
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 23. Agent output specification
+Use this template for a generated dashboard design.
+
+Use this field contract for a generated dashboard design:
+
+|Field|What to specify|
+|---|---|
+|`title`|Name of the surface, such as `Database fleet`.|
+|`purpose`|The decision or action the surface supports.|
+|`users`|Primary user and secondary users.|
+|`classification`|Decision horizon, product surface, primary archetype, and secondary archetype if any.|
+|`scope`|Global controls, local controls, and defaults such as workspace, environment, region, or time range.|
+|`layout`|Header content, section order, component placement, and drill-down behavior.|
+|`metrics`|Metric contracts, thresholds, freshness, and click-through behavior.|
+|`table_or_queue`|Default sort, columns, row navigation, row actions, bulk actions, and pagination or virtualization.|
+|`interactions`|Trigger, result, state preservation, and failure behavior for each important interaction.|
+|`forms`|Container, fields, validation, save model, review step, and job model for every mutation.|
+|`permissions`|What each role can view or change, plus disabled or hidden-action behavior.|
+|`states`|Loading, loaded, empty, filtered empty, stale, partial, permission denied, and error states.|
+|`accessibility`|Keyboard, focus, semantic table, chart summary, status text, and target-size requirements.|
+|`responsive`|Narrow-screen priority order and detail behavior.|
+|`telemetry`|Success events, guardrail metrics, and audit events.|
+|`assumptions`|Data volume, freshness expectations, missing product context, and unresolved decisions.|
+
+Compact example:
+
+```text
+title: Database fleet
+purpose: Find unhealthy or risky databases and reach corrective action.
+primary user: Database platform operator
+classification: operational dashboard, fleet + primary-detail
+scope: workspace, environment, region; default production and all regions
+layout: header with title, purpose, freshness, create action; risk summary before fleet table
+table: sort by severity, impact, name; columns include status, load, storage, backup, owner
+interactions: status summaries filter the table; selecting a row opens a detail drawer
+forms: create database uses a high-risk wizard with review and async job state
+permissions: viewers read; operators run approved actions; admins create and delete
+states: loading, filtered empty, stale, partial region failure, permission denied, error
+responsive: preserve status, name, storage risk, backup state, and primary action first
+telemetry: issue opened, summary filter applied, corrective action started
+assumptions: fleet data arrives within two minutes
+```
+
+### 23.1 Minimal wireframe output
+An agent SHOULD also provide a text wireframe:
+
+```text
+┌ Database fleet ─ Production ─ All regions ─ Updated 10:42 ┐
+│ 3 critical  │ 7 storage risks │ 2 backup failures          │
+├────────────────────────────────────────────────────────────┤
+│ Search  Status  Engine  Region  Owner  Saved view   Create │
+├────────────────────────────────────────────────────────────┤
+│ Name        Status   Load   Storage   Repl.   Backup  Owner │
+│ orders      Critical 92%    4% left   8m      1h ago  Core  │
+│ analytics   Healthy  34%    61%       0s      2h ago  Data  │
+└────────────────────────────────────────────────────────────┘
+```
+
+---

--- a/plugins/design/skills/dashboard-design/references/database-management.md
+++ b/plugins/design/skills/dashboard-design/references/database-management.md
@@ -1,0 +1,266 @@
+# Domain Blueprint: Database Management
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 18. Domain blueprint: database management
+Database management spans fleet monitoring, performance diagnosis, schema/data work, backups, replication, access, and dangerous operations. PostgreSQL’s monitoring guidance covers current activity, cumulative statistics, locks, progress, and disk usage; AWS RDS similarly combines fleet monitoring, instance metrics, activity, logs, and performance insights.[^postgres-monitoring][^aws-rds-monitoring]
+
+### 18.1 Product-area information architecture
+```text
+Databases
+├─ Fleet
+├─ Instances / clusters
+├─ Query performance
+├─ Backups
+├─ Replication
+├─ Jobs / maintenance
+├─ Users & access
+├─ Audit log
+└─ Settings / policies
+```
+
+Within one database:
+
+```text
+Overview
+Activity
+Queries
+Schema
+Data browser
+Backups
+Replication
+Logs
+Configuration
+Access
+Audit
+```
+
+### 18.2 Fleet dashboard
+Recommended table:
+
+|Field|Why it matters|
+|---|---|
+|Name|Identity|
+|Environment|Risk and scope|
+|Engine/version|Compatibility and maintenance|
+|Region|Failure domain and latency|
+|Status|Current state|
+|DB load / connections|Work pressure|
+|CPU / memory / storage|Capacity evidence|
+|Replication lag|Recovery/read consistency|
+|Backup status|Recoverability|
+|Maintenance/version warning|Planned risk|
+|Owner|Accountability|
+
+Top summary:
+
+- total databases;
+- healthy/degraded/critical/unknown;
+- backup failures;
+- storage risk;
+- high load;
+- replication issues;
+- pending maintenance.
+
+AWS’s fleet-health model similarly summarizes instance state and provides an overview table for alarm state, load, and recency.[^aws-fleet]
+
+### 18.3 Database detail overview
+```text
+orders-prod  PostgreSQL 18  Degraded
+Production · eu-west-1 · primary · Team Commerce
+[Connect] [Open query editor] [Create backup] [More]
+
+[DB load] [Connections] [Storage] [Replication lag] [Backup age]
+
+Load over time + deployment/maintenance annotations
+
+Top waits / top queries / blocking locks
+
+Recent events and configuration changes
+```
+
+### 18.4 Query performance workbench
+Controls:
+
+- database;
+- time window;
+- normalized query search;
+- user/application;
+- wait type;
+- minimum duration;
+- execution count;
+- sort by total time, mean, p95, rows, I/O, or calls.
+
+Results SHOULD show:
+
+- normalized query fingerprint;
+- total and average time;
+- percentile latency if available;
+- calls;
+- rows;
+- CPU/I/O/waits;
+- last seen;
+- plan changes;
+- associated application/service;
+- safe access to sample text.
+
+Detail MAY include:
+
+- execution plan visualization;
+- plan diff;
+- bind/sample values only when permitted and redacted;
+- indexes used/missed;
+- blocking/lock context;
+- related deployments;
+- recommendation with confidence and caveats.
+
+Never present a generated index or query rewrite as a one-click safe fix without impact, locking, storage, and rollback considerations.
+
+### 18.5 Activity and locks
+Provide a live table with:
+
+- process/session ID;
+- user/application;
+- database;
+- state;
+- query duration;
+- transaction age;
+- wait event;
+- blocking relationship;
+- client/source;
+- current query with redaction.
+
+Actions such as cancel query or terminate session MUST:
+
+- explain difference;
+- identify affected transaction and application;
+- show target and duration;
+- require appropriate permission;
+- produce an audit event;
+- report actual result, including race conditions where the session ended first.
+
+### 18.6 Schema and data browser
+Schema navigation:
+
+- searchable tree or object list;
+- tables, views, indexes, functions, types;
+- object owner and permissions;
+- size and activity;
+- dependencies;
+- DDL with copy/export;
+- recent changes.
+
+Data browser:
+
+- default read-only in production;
+- explicit row limits;
+- clear ordering caveat;
+- type-aware formatting;
+- sensitive-column redaction;
+- safe filter builder;
+- generated query preview;
+- export permission and audit;
+- no hidden full-table scan caused by innocent UI behavior.
+
+### 18.7 Query editor
+MUST include:
+
+- current database/environment and role;
+- read/write status;
+- syntax highlighting;
+- query history with sensitivity controls;
+- cancellation;
+- elapsed time;
+- row limit;
+- execution plan option;
+- transaction state;
+- clear error location;
+- result grid and export rules.
+
+For production write queries:
+
+- use a visually persistent production context;
+- warn when no `WHERE` clause is detected for destructive statements, while acknowledging that static detection is imperfect;
+- support transaction/rollback workflow where possible;
+- require elevated permission or approval according to policy;
+- do not store sensitive literal values in analytics or URLs.
+
+### 18.8 Backups and restore
+Backup list:
+
+- source database;
+- backup type;
+- start/end;
+- status;
+- size;
+- retention/expiry;
+- encryption;
+- region/location;
+- restore-test status;
+- initiator.
+
+Restore wizard:
+
+1. Select backup or point in time.
+2. Select target strategy: new database, overwrite, or alternate environment.
+3. Configure capacity/network/access.
+4. Review data-loss window, downtime, dependencies, and cost.
+5. Confirm and monitor job.
+
+A recent backup is central to recovery; database guidance treats regular backups as a foundational maintenance task.[^postgres-maintenance]
+
+### 18.9 Replication and high availability
+Show:
+
+- topology;
+- primary and replicas;
+- role and health;
+- replication lag in time and bytes;
+- replay position;
+- region/zone;
+- connection/read traffic;
+- failover readiness;
+- last test;
+- data-loss objective and recovery-time objective if defined.
+
+Failover controls MUST distinguish planned switchover from emergency failover and explain expected downtime, data loss risk, DNS/connection behavior, and rollback limitations.
+
+### 18.10 Database configuration forms
+For each parameter show:
+
+- current value;
+- effective value;
+- source/inheritance;
+- default;
+- valid range;
+- unit;
+- restart/reload requirement;
+- dynamic versus static behavior;
+- risk or recommendation;
+- last changed by/at.
+
+Bulk parameter changes SHOULD produce a change set with validation and review rather than saving each field independently.
+
+### 18.11 Delete database flow
+A severe-risk flow SHOULD show:
+
+- exact database and environment;
+- dependent apps/integrations;
+- active connections;
+- latest verified backup and retention;
+- replicas/readers affected;
+- scheduled jobs;
+- deletion protection state;
+- recovery window after deletion, if any;
+- required approval or reauthentication;
+- typed resource name only when deliberate identity confirmation is valuable.
+
+Offer safer alternatives:
+
+- disable writes;
+- stop/suspend;
+- archive;
+- create final backup;
+- reduce capacity;
+- detach app connections.
+
+---

--- a/plugins/design/skills/dashboard-design/references/filters-search-scope-and-time.md
+++ b/plugins/design/skills/dashboard-design/references/filters-search-scope-and-time.md
@@ -1,0 +1,80 @@
+# Filters, Search, Scope, and Time
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 11. Filters, search, scope, and time
+
+### 11.1 Distinguish four concepts
+|Concept|Meaning|Example|
+|---|---|---|
+|**Scope**|The universe being viewed|Organization, environment, service, inbox|
+|**Filter**|A subset within that universe|Status = critical, owner = platform|
+|**Search**|Match a known or partially known item|Database name, customer email, trace ID|
+|**Query**|An explicit analytical expression|`status:error AND latency_ms > 500`|
+
+Treating all four as generic filter chips makes the UI confusing.
+
+### 11.2 Global versus local controls
+Global controls affect the entire page and SHOULD appear in a stable context bar. Local controls belong near the component they affect.
+
+Example:
+
+```text
+Global: Workspace · Production · All regions · Last 6 hours
+Local chart: Group by service · p95
+Local table: Status · Owner · Search
+```
+
+A control’s visual placement MUST match its scope.
+
+### 11.3 Time controls
+A time picker SHOULD support:
+
+- useful presets;
+- custom start/end;
+- timezone;
+- relative versus fixed ranges;
+- compare-to-previous or compare-to-baseline when relevant;
+- live mode for real-time operations;
+- clear indication when different widgets have different windows.
+
+For incident investigation, preserve an absolute time window when sharing a link. “Last 30 minutes” should not silently become a different incident window when opened later.
+
+### 11.4 URL and saved-state behavior
+Meaningful dashboard state SHOULD be shareable:
+
+- resource scope;
+- time range;
+- filters;
+- search query;
+- selected tab;
+- comparison mode;
+- optionally selected record.
+
+Do not put secrets, raw customer PII, or sensitive queries into URLs.
+
+### 11.5 Saved views
+Saved views are useful when users repeatedly apply the same scope, filters, sort, columns, and grouping.
+
+Specify:
+
+- private versus shared;
+- owner;
+- default view;
+- permission to edit shared views;
+- behavior when fields are removed;
+- whether the view includes time range;
+- last updated and usage.
+
+### 11.6 Filter result states
+Distinguish:
+
+- no records exist;
+- records exist but no filters match;
+- the user lacks access;
+- data is still loading;
+- the query failed;
+- the source is delayed.
+
+A filtered-empty state SHOULD show active filters and a direct clear or edit action.
+
+---

--- a/plugins/design/skills/dashboard-design/references/forms-and-configuration.md
+++ b/plugins/design/skills/dashboard-design/references/forms-and-configuration.md
@@ -1,0 +1,300 @@
+# Forms and Configuration UX
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 12. Forms and configuration UX
+Forms are where dashboards become control planes. They require more care than the overview because errors can change production systems, expose data, or disrupt customers.
+
+Carbon and PatternFly both describe forms as groups of related controls that may live on pages, in side panels, dialogs, or wizards depending on the task.[^carbon-forms][^patternfly-forms]
+
+### 12.1 Choose the correct form container
+|Structure|Use when|Good examples|Avoid when|
+|---|---|---|---|
+|**Inline edit**|One independent, low-risk value|Rename resource, change owner|Dependencies or broad impact|
+|**Popover**|Tiny, reversible adjustment that must stay in context|Change a display option|Any complex validation|
+|**Drawer / side panel**|Moderate form; context from the underlying page remains useful|Edit alert, assign ticket, change metadata|User needs full width or many sections|
+|**Modal**|Short, focused, interruptive decision|Confirm archive, add small tag set|Large forms, code editors, multi-step tasks|
+|**Full page**|Complex or high-impact configuration|App settings, database connection, routing rules|One or two trivial fields|
+|**Wizard / stepper**|Ordered dependencies, onboarding, or review|Create database, restore backup, connect integration|Frequent expert edits that can be handled on one page|
+|**Bulk editor**|Apply a shared change across many records|Assign owner, change plan, add tags|Items require individual decisions|
+|**Builder / canvas**|Users compose rules, schemas, workflows, or queries|Routing workflow, permission policy|Simple choices better represented by standard controls|
+|**Code/query editor**|Expert syntax is the natural model|SQL, log query, JSON policy|Novices have no guided alternative or validation|
+
+### 12.2 Practical complexity heuristic
+These are defaults, not laws:
+
+- **1–3 simple fields, low risk:** inline, popover, or small modal.
+- **3–8 related fields with useful page context:** drawer.
+- **More than roughly 8 fields, multiple sections, or significant explanation:** full page.
+- **Dependencies across concepts, creation workflow, or mandatory review:** wizard.
+- **Any size with severe irreversible impact:** dedicated review and confirmation, usually not a casual modal.
+
+Risk overrides field count. A one-field “delete production database” action is still high complexity from a decision perspective.
+
+### 12.3 Form anatomy
+```text
+Title
+One-sentence purpose and consequence
+
+Section heading
+Optional section description
+
+Label
+Helper text when needed
+[Input] unit / suffix
+Inline validation or warning
+
+Additional sections
+
+[Cancel]                         [Primary submit]
+```
+
+For long or high-risk forms, add:
+
+- unsaved-change state;
+- section navigation;
+- review summary;
+- effective-value preview;
+- impact estimate;
+- change reason;
+- documentation link;
+- last changed by/at;
+- audit-history link.
+
+### 12.4 Grouping and ordering
+Group fields by the user’s mental model and workflow:
+
+1. identity;
+2. behavior;
+3. capacity or limits;
+4. access and security;
+5. notifications;
+6. advanced options.
+
+Do not mirror an internal database schema if it produces incoherent sections.
+
+Within a section:
+
+- ask the easiest orienting questions first;
+- place dependent fields directly after their controller;
+- place dangerous or advanced settings later;
+- keep related units and thresholds together;
+- avoid multi-column layouts when field order or error association could become ambiguous.
+
+Top-aligned labels are a strong default because they keep labels near controls and adapt well to narrow screens.[^patternfly-forms]
+
+### 12.5 Labels, helper text, and placeholders
+MUST:
+
+- use a persistent visible label;
+- make label wording specific;
+- identify required or optional status consistently;
+- provide expected format where it is not obvious;
+- associate help and errors programmatically with the field.
+
+Do not use placeholder text as the only label. It disappears during entry, has weak contrast in many implementations, and cannot carry durable meaning.
+
+Good:
+
+```text
+Connection timeout
+How long a request may wait before the connection is closed.
+[ 30 ] seconds
+```
+
+Bad:
+
+```text
+[ Enter value ]
+```
+
+### 12.6 Input selection
+|Need|Preferred control|Notes|
+|---|---|---|
+|Enable an immediate binary state|Switch|Label the resulting state; save immediately only when safe|
+|Include/exclude an option in a submitted form|Checkbox|Works independently|
+|Choose one of 2–5 visible options|Radio group|Show all options and descriptions|
+|Choose one from a longer list|Select or combobox|Add search for large lists|
+|Choose several from a short list|Checkboxes|Make “none” valid when appropriate|
+|Choose several from a long list|Multi-select/combobox|Show selected values clearly|
+|Enter bounded number|Number input plus unit|Define min, max, step, and decimal behavior|
+|Choose date/time|Date/time picker plus text entry|Include timezone and format|
+|Enter secret|Secret field|Never reveal stored value; support replace/revoke/test|
+|Enter structured expression|Builder or code editor|Validate syntax and semantics separately|
+|Select hierarchical items|Tree or drill-down picker|Use when hierarchy is essential, not for a small flat set|
+
+PatternFly recommends switches for two states, radio buttons for one choice among a small set, checkboxes for multiple choices in a short set, and selects for longer option lists.[^patternfly-forms]
+
+### 12.7 Defaults
+A default is a product decision. It MAY create cost, risk, or bias.
+
+Defaults SHOULD be:
+
+- safe;
+- common;
+- reversible;
+- transparent;
+- appropriate to current scope.
+
+For infrastructure:
+
+- show estimated cost before creation;
+- do not default to public access;
+- do not preselect broad permissions;
+- make production-safe backup and recovery settings clear;
+- explain whether defaults are inherited from organization policy.
+
+### 12.8 Validation timing
+Use three layers:
+
+1. **Input constraints** — prevent impossible characters or values when appropriate.
+2. **Inline validation** — after a field is complete or loses focus; do not scold while the user is still typing.
+3. **Submission validation** — validate cross-field and server-side rules.
+
+Errors MUST:
+
+- identify the field;
+- describe the problem in text;
+- suggest a correction when possible;
+- preserve entered values;
+- move focus to an error summary or first error in a predictable way;
+- remain until corrected.
+
+WCAG requires text identification of detected input errors and labels or instructions for required input.[^wcag-forms]
+
+### 12.9 Warnings versus errors
+- **Error:** submission cannot or must not proceed.
+- **Warning:** submission may proceed, but the user should understand a consequence.
+- **Info:** contextual guidance without a risk condition.
+
+Do not use an error style for optional advice. Warning fatigue makes genuine risk easier to miss.
+
+### 12.10 Dependent fields and progressive disclosure
+When a choice reveals more fields:
+
+- reveal them directly below the controller;
+- preserve or clearly reset previous values;
+- update validation and review state;
+- announce dynamic changes accessibly;
+- avoid large layout jumps where possible.
+
+Use an “Advanced” section for uncommon expert options, but keep any option that materially changes security, cost, data loss, or availability visible enough to be reviewed.
+
+### 12.11 Save models
+Choose one save model and communicate it clearly.
+
+#### Explicit save
+Best for related configuration that should be applied atomically.
+
+- Track dirty state.
+- Keep save/cancel visible for long pages.
+- Warn before navigation with unsaved changes.
+- Show conflict if the server value changed meanwhile.
+
+#### Immediate save
+Best for independent, reversible preferences.
+
+- Show saving and saved state.
+- Revert on failure.
+- Provide undo when useful.
+- Do not use for consequential settings merely because switches look convenient.
+
+#### Draft + publish
+Best for workflows, routing rules, content, or policies.
+
+- Distinguish draft from live version.
+- Preview effective behavior.
+- Show validation status.
+- Identify publisher and publication time.
+- Preserve version history and rollback.
+
+### 12.12 Review screens
+A review screen is valuable when a task:
+
+- creates cost;
+- changes access;
+- affects production;
+- deletes or overwrites data;
+- starts a long-running operation;
+- involves many sections or collaborators.
+
+GOV.UK’s check-answers pattern recommends a review before confirmation for small-to-medium transactions, with section-level reviews possible for very large ones.[^govuk-check]
+
+A review SHOULD show:
+
+- target resource and environment;
+- consequential choices;
+- cost or capacity estimate;
+- affected users/resources;
+- downtime or restart behavior;
+- backup/recovery state;
+- editable links to the relevant section;
+- final action wording that names the result.
+
+### 12.13 Destructive and high-risk actions
+A safe sequence is:
+
+1. State the action and target.
+2. Explain impact and reversibility.
+3. Show dependencies and affected resources.
+4. Offer a safer alternative if one exists.
+5. Require an appropriate confirmation.
+6. Reauthenticate or require elevated approval for the highest-risk operations.
+7. Create an audit event.
+8. Show progress and final result.
+
+Confirmation strength SHOULD match risk:
+
+|Risk|Appropriate confirmation|
+|---|---|
+|Low, reversible|Undo toast or simple confirmation|
+|Moderate|Confirmation dialog with impact summary|
+|High|Dedicated review, explicit target, reason, and permissions check|
+|Severe / irreversible|Review + typed target or equivalent deliberate action + reauthentication/approval + recovery guidance|
+
+Typed confirmation is not a universal safety mechanism. It is appropriate only when deliberate target verification adds value. Do not make users type generic words such as `DELETE` for routine reversible actions.
+
+WCAG guidance recognizes reversibility and review/correction as ways to prevent consequential errors.[^wcag-error-prevention]
+
+### 12.14 Forms for secrets and credentials
+- Never repopulate an existing secret.
+- Show that a secret exists and when it was last rotated.
+- Use “Replace,” “Rotate,” or “Revoke,” not ambiguous “Edit.”
+- Allow connection testing without exposing the value.
+- Explain which services will restart or lose access.
+- Redact secrets in logs, previews, errors, and audit records.
+- Avoid placing secrets in URLs, copied commands, or client-visible analytics.
+
+### 12.15 Forms for rules and workflows
+A rule builder SHOULD expose:
+
+```text
+WHEN [conditions]
+IF/ELSE [optional branches]
+THEN [actions]
+EXCEPT [exclusions]
+```
+
+Also provide:
+
+- natural-language summary;
+- validation;
+- test cases or sample matching records;
+- conflict and precedence explanation;
+- draft/publish state;
+- version history;
+- rollback;
+- “why did this rule run?” evidence in operational records.
+
+### 12.16 One question per page
+For novice, public, or cognitively demanding journeys, one primary question per page can reduce cognitive load. GOV.UK recommends this approach for question pages.[^govuk-question]
+
+For expert admin products, a compact grouped form may be faster. Choose based on:
+
+- frequency;
+- expertise;
+- field dependencies;
+- error cost;
+- need for overview;
+- device constraints.
+
+---

--- a/plugins/design/skills/dashboard-design/references/foundations-and-taxonomy.md
+++ b/plugins/design/skills/dashboard-design/references/foundations-and-taxonomy.md
@@ -1,0 +1,162 @@
+# Dashboard Foundations and Taxonomy
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 1. How to use this playbook
+This document uses three levels of guidance:
+
+- **MUST** — the default requirement. Deviate only when a documented user need requires it.
+- **SHOULD** — the expected choice in most cases.
+- **MAY** — an optional pattern that depends on context.
+
+The numbers in this guide—such as field counts or suggested breakpoints—are **decision heuristics, not universal laws**. Complexity, risk, user expertise, device constraints, and data volume matter more than a fixed count.
+
+An agent should use the playbook in this order:
+
+1. Define the user, decision, action, and time horizon.
+2. Classify the surface and dashboard archetype.
+3. Model entities, states, permissions, and data freshness.
+4. Choose a page structure.
+5. Map information and actions into components.
+6. Specify all non-happy-path states.
+7. Review safety, accessibility, responsiveness, and data trust.
+
+Do not begin with a chart library, a card grid, or a visual style. Those are implementation choices, not the product model.
+
+---
+
+## 2. The core idea: a dashboard is a decision surface
+A dashboard is a compact collection of related information that helps a person understand a situation and decide what to do next. Classic dashboard guidance emphasizes at-a-glance information and actionability.[^nng-dashboard] Modern BI products similarly describe dashboards as single-page highlights that lead to deeper reports.[^powerbi-dashboard]
+
+For operational software, however, a useful dashboard is rarely just a wall of charts. It is usually part of a broader **decision-and-action loop**:
+
+> **Observe → understand → prioritize → act → verify**
+
+Every dashboard should answer at least one of these questions:
+
+1. **What is the current state?**
+2. **What changed?**
+3. **What needs attention?**
+4. **Why is it happening?**
+5. **What action should I take?**
+6. **Did the action work?**
+
+A dashboard that answers none of them is decoration.
+
+### 2.1 Design around decisions, not available data
+Bad starting point:
+
+> “We have 42 metrics. Put them on a page.”
+
+Good starting point:
+
+> “An on-call engineer needs to decide within two minutes whether an alert is customer-impacting, identify the affected service and recent change, and open the correct investigation view.”
+
+The second statement immediately determines:
+
+- audience;
+- urgency;
+- required freshness;
+- information priority;
+- drill-down path;
+- relevant actions;
+- acceptable density;
+- failure cost.
+
+### 2.2 The action-distance rule
+The UI SHOULD minimize the distance between a signal and its appropriate action.
+
+Examples:
+
+- A firing alert links to the affected service, runbook, logs, traces, and incident action.
+- A database storage warning links to growth history, largest tables, cleanup guidance, and resize controls.
+- An SLA-breaching support queue opens the affected conversations with the relevant filter already applied.
+- A failed deployment links to build output, changed version, rollback eligibility, and the prior healthy release.
+
+A number without a next step is usually a report, not an operational control.
+
+---
+
+## 3. Dashboard taxonomy
+There are two useful ways to classify dashboards:
+
+1. **By decision horizon** — how quickly and how often a decision is made.
+2. **By interaction mode** — whether the user is monitoring, triaging, investigating, configuring, or reviewing.
+
+The familiar business taxonomy includes strategic, tactical, operational, and analytical dashboards.[^qlik-types] It is useful, but incomplete for software administration. Product teams also need queues, workbenches, resource details, fleet views, and configuration hubs.
+
+### 3.1 Classification by decision horizon
+|Type|Primary question|Decision horizon|Typical users|Data freshness|Interaction depth|Typical output|
+|---|---|---:|---|---|---|---|
+|**Operational**|What needs action now?|Seconds to hours|Operators, agents, on-call staff|Live to minutes|Fast triage and direct action|Resolve, reroute, acknowledge, restart, roll back|
+|**Tactical**|Where should the team focus next?|Days to weeks|Team leads, service owners, managers|Hourly to daily|Segment, compare, plan|Reallocate capacity, fix recurring issues, prioritize work|
+|**Strategic**|Are we progressing toward goals?|Weeks to quarters|Executives, directors, owners|Daily to monthly|Low-to-medium depth|Change strategy, budget, goals, policy|
+|**Analytical**|Why did this happen and what patterns exist?|Ad hoc|Analysts, engineers, specialists|Depends on source|High exploration|Hypothesis, diagnosis, forecast, recommendation|
+
+### 3.2 Classification by interaction mode
+|Archetype|Main job|Best default structure|Common examples|
+|---|---|---|---|
+|**Monitor / command center**|Maintain awareness and spot exceptions|Status summary + alerts + trends + recent changes|Production health, NOC, security operations|
+|**Queue / workbench**|Process items in priority order|Filterable list + detail pane + actions|Support inbox, moderation queue, incident triage|
+|**Fleet / inventory**|Compare and manage many resources|Summary + table/grid + primary-detail|Databases, services, workers, tenants, devices|
+|**Resource detail**|Understand and operate one entity|Header + status + tabs/sections + contextual actions|One app, database, customer, deployment|
+|**Investigation / explorer**|Form and test hypotheses|Query/filter controls + visual results + raw evidence|Logs, traces, query analysis, product analytics|
+|**Configuration hub**|Inspect and change system behavior|Categorized settings + forms + change history|App settings, routing rules, connection pools|
+|**Workflow / wizard**|Complete a multi-step task safely|Ordered steps + validation + review|Create database, restore backup, onboard integration|
+|**Scorecard / review**|Track outcomes against targets|KPI hierarchy + trends + explanations|Executive, cost, reliability, support performance|
+|**Audit / timeline**|Establish who changed what and when|Searchable event stream + details + export|Security audit, deployment history, admin activity|
+|**Personal home**|Resume work and see relevant changes|Assigned work + recent items + shortcuts|Agent home, developer home, team overview|
+
+### 3.3 Choose one primary archetype
+A page MAY contain a secondary pattern, but it MUST have one dominant task model.
+
+Good combinations:
+
+- Fleet table + primary-detail drawer.
+- Monitor summary + incident list.
+- Resource detail + small investigation panel.
+- Queue + customer context sidebar.
+
+Bad combinations:
+
+- Executive scorecard + full log explorer + settings form + bulk admin table on one page.
+- Eight unrelated mini-dashboards arranged by whichever card fits the grid.
+
+### 3.4 Mapping domain needs to archetypes
+|Domain need|Primary archetype|Secondary archetype|Avoid|
+|---|---|---|---|
+|Watch production health|Monitor|Resource detail|Dense editable settings on the overview|
+|Handle active incidents|Queue/workbench|Investigation|Hiding incident actions below charts|
+|Manage many databases|Fleet|Primary-detail|One card per database when there are dozens|
+|Tune a slow database|Resource detail|Investigation|Mixing fleet-wide and instance-specific scope|
+|Answer customer conversations|Queue/workbench|Customer detail|KPI cards dominating the agent workspace|
+|Manage support staffing|Operational monitor|Tactical scorecard|Showing individual-agent rankings without context|
+|Configure routing or automation|Configuration hub|Wizard|Modal containing a large rules builder|
+|Review quarterly reliability|Strategic scorecard|Analytical drill-down|Live alert noise in the executive view|
+
+---
+
+## 4. Choose the right product surface before choosing a layout
+Many products call every authenticated page a “dashboard.” This creates poor UX because different jobs require different structures.
+
+|Surface|Best for|Distinguishing behavior|Usually not appropriate for|
+|---|---|---|---|
+|**Dashboard**|At-a-glance status and priorities|Summarizes; links outward|Deep editing or long investigation|
+|**Report**|Stable, reviewable output|Defined metrics, period, and grouping|Real-time operations|
+|**Explorer**|Open-ended analysis|Flexible query, filter, grouping, comparison|Novice users needing a clear next action|
+|**Workbench**|Repeated operational processing|Dense queue, keyboard flow, direct actions|Executive communication|
+|**Resource detail**|One entity|Persistent identity, state, history, operations|Comparing a large fleet|
+|**Settings page**|Configuration|Explicit save model, validation, permissions|Monitoring current health|
+|**Wizard**|Ordered, risky, or dependent setup|Step state, back/next, review|Frequent expert editing|
+|**Audit log**|Immutable history|Search, actors, timestamps, before/after|Current-state monitoring|
+
+### 4.1 Dashboard versus report
+Use a dashboard when the user needs to **monitor and branch**. Use a report when the user needs to **review, communicate, or archive** a defined result.
+
+A dashboard SHOULD link to reports or explorers for detail rather than trying to contain every breakdown. Microsoft’s dashboard guidance recommends keeping the essential story on one screen and using related reports for detail.[^powerbi-design]
+
+### 4.2 Dashboard versus workbench
+A support agent resolving conversations needs a workbench, not a managerial KPI dashboard. The primary content should be the queue and the active conversation. Metrics can appear as compact workload context, not as the visual center.
+
+Likewise, an incident commander needs an incident workspace with timeline, ownership, status, evidence, and actions—not merely a service-health dashboard.
+
+---

--- a/plugins/design/skills/dashboard-design/references/information-architecture-and-layouts.md
+++ b/plugins/design/skills/dashboard-design/references/information-architecture-and-layouts.md
@@ -1,0 +1,312 @@
+# Information Architecture and Layouts
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 6. Information architecture
+
+### 6.1 Stable application shell
+A mature admin product usually needs:
+
+1. **Product/global navigation** — major domains such as Apps, Databases, Support, Billing, and Settings.
+2. **Workspace or organization selector** — the tenant or account boundary.
+3. **Environment selector** — production, staging, development, or custom environments.
+4. **Search or command palette** — resources, customers, tickets, commands, documentation.
+5. **Notifications and active jobs** — durable access to background operations.
+6. **Help and documentation** — contextual, not generic only.
+7. **User and role menu** — identity, role, preferences, sign out.
+
+The shell MUST preserve the user’s scope. Switching from an app overview to logs should retain the relevant environment, app, region, and time range when those concepts still apply.
+
+### 6.2 Page hierarchy
+A strong default dashboard hierarchy is:
+
+1. **Identity and scope**
+2. **Current status and urgent exceptions**
+3. **Primary actions**
+4. **Outcome metrics**
+5. **Trends and contributing factors**
+6. **Detailed records**
+7. **Definitions, freshness, and supporting context**
+
+For an operational dashboard, exceptions generally outrank aggregate KPIs. For a strategic dashboard, outcome KPIs and trend against target may outrank individual events.
+
+### 6.3 Page-header anatomy
+```text
+Breadcrumbs
+Page title                         Primary action
+Short purpose / entity metadata    Secondary actions
+Status · environment · region · owner · last updated
+Global scope and time controls
+```
+
+Rules:
+
+- The title MUST identify the object or task, not a generic category such as “Overview.”
+- Environment MUST be unmistakable on pages that can change production.
+- Status MUST include text, not color alone.
+- The primary action MUST match the page’s main job.
+- Rare actions SHOULD be in an overflow menu.
+- Destructive actions MUST not visually compete with the primary constructive action.
+
+### 6.4 Navigation depth
+Use this default hierarchy:
+
+```text
+Product area
+  └─ Fleet / collection
+       └─ Resource detail
+            ├─ Overview
+            ├─ Activity or performance
+            ├─ Logs / events / history
+            ├─ Configuration
+            └─ Access / audit
+```
+
+Avoid more than two persistent side-navigation levels. Deeper hierarchy is usually better represented with breadcrumbs, tabs, local navigation, or a tree when the hierarchy itself is the user’s object of work.
+
+### 6.5 Tabs
+Use tabs when:
+
+- all tabs describe the same entity;
+- users switch between sibling views;
+- each tab can be independently linked;
+- labels are stable and short.
+
+Do not use tabs to conceal a sequential workflow, unrelated product areas, or form sections that must be reviewed together.
+
+Tabs SHOULD preserve filters only when those filters remain semantically valid. They SHOULD have stable URLs.
+
+### 6.6 Progressive disclosure
+Show the minimum information needed for the current decision, then offer detail through:
+
+- expandable rows;
+- a detail drawer;
+- a popover for definitions;
+- a focused detail page;
+- an advanced section;
+- raw data or query view.
+
+Progressive disclosure is not an excuse to hide essential status, impact, or risk.
+
+---
+
+## 7. Page and layout structures
+
+### 7.1 Pattern A: overview → drill-down
+Best for:
+
+- application health;
+- account overview;
+- strategic scorecards;
+- cost summaries.
+
+```text
+[Scope] [Time] [Refresh]
+
+[Critical status or exception banner]
+
+[KPI] [KPI] [KPI] [KPI]
+
+[Primary trend ---------------------] [Breakdown]
+
+[Exceptions / recent changes / records table --------]
+```
+
+Rules:
+
+- Limit the first row to the few metrics that determine the next decision.
+- Each summary block SHOULD link to its detail.
+- Do not repeat the same metric in a card, chart, and table without adding meaning.
+
+### 7.2 Pattern B: command center
+Best for:
+
+- production operations;
+- security operations;
+- live fulfillment;
+- real-time support management.
+
+```text
+[Global status] [Active incidents] [Critical alerts] [Freshness]
+
+[Service or region health matrix -------------------------]
+
+[Alert / incident queue ----------] [Recent changes ------]
+
+[Traffic/errors/latency trend -----------------------------]
+```
+
+Rules:
+
+- Optimize for glanceability and exception detection.
+- Keep status vocabulary small and consistent.
+- Auto-refresh MUST not reset scroll, selection, or the user’s current investigation.
+- New items SHOULD enter predictably; avoid rows jumping while the user is acting.
+
+### 7.3 Pattern C: queue / workbench
+Best for:
+
+- customer support;
+- moderation;
+- incident triage;
+- approval workflows;
+- job failure handling.
+
+```text
+[Saved view] [Search] [Filters] [Sort] [Queue count]
+
+[List / queue 40%] | [Selected item detail 60%]
+                    | [Context]
+                    | [Timeline]
+                    | [Primary action composer]
+```
+
+PatternFly describes primary-detail layouts as useful for moving through a list and editing or inspecting items without losing list context.[^patternfly-primary-detail]
+
+Rules:
+
+- Preserve list position and filters when the detail changes.
+- Support next/previous navigation.
+- Distinguish row selection from checkbox selection.
+- Keep the high-frequency action visible.
+- Provide keyboard shortcuts only with discoverable help and conflict-safe behavior.
+
+### 7.4 Pattern D: fleet / inventory
+Best for:
+
+- databases;
+- services;
+- environments;
+- tenants;
+- integrations;
+- devices.
+
+```text
+[Summary: total / healthy / warning / critical]
+
+[Search] [Facets] [Saved view] [Columns] [Create]
+
+[Resource table ------------------------------------------]
+[Name | Status | Region | Version | Load | Owner | Updated]
+```
+
+Rules:
+
+- Default sort SHOULD surface actionable exceptions, not alphabetical order, when operational urgency is the main job.
+- Use cards only for a small, visually distinct set. Use a table or data list for a large fleet.
+- Fleet status SHOULD distinguish **unknown** from healthy.
+- Multi-select actions MUST state the number and scope of selected resources.
+
+### 7.5 Pattern E: resource detail
+Best for one app, database, customer, integration, or deployment.
+
+```text
+[Back] Resource name       Status         [Primary action]
+       Environment · ID · owner           [More]
+
+[Overview] [Performance] [Activity] [Configuration] [Access]
+
+[Tab content]
+```
+
+Rules:
+
+- Resource identity and current scope MUST remain visible.
+- Actions MUST operate on the visible resource and environment.
+- High-risk actions MUST repeat the target in the confirmation.
+- The overview SHOULD summarize linked subpages, not duplicate them entirely.
+
+### 7.6 Pattern F: investigation workspace
+Best for logs, traces, query performance, analytics, and debugging.
+
+```text
+[Query / filter builder ----------------] [Run]
+[Time range] [Group by] [Compare] [Save view]
+
+[Visualization / result summary --------------------------]
+
+[Raw events or records table -----------------------------]
+
+[Selected record detail drawer]
+```
+
+Rules:
+
+- Make the active query and scope visible.
+- Give every query a shareable representation, usually in the URL or saved view.
+- Preserve the query when navigating to a record and back.
+- Show query cost, truncation, sampling, or row limits when relevant.
+- Separate “no matches” from “query failed” and “data unavailable.”
+
+### 7.7 Pattern G: configuration hub
+Best for related categories of settings.
+
+```text
+[Settings navigation] | [Section title]
+                      | [Description / docs]
+                      | [Form section]
+                      | [Form section]
+                      | [Save / cancel]
+```
+
+Rules:
+
+- Group settings by the user’s mental model, not backend service ownership.
+- Show current effective value and inheritance source when settings can be inherited.
+- Explain operational consequences near the control.
+- Provide change history for sensitive configuration.
+
+### 7.8 Pattern H: wizard
+Best for setup with dependencies, ordered steps, or meaningful review.
+
+```text
+Steps: 1 Basics — 2 Capacity — 3 Access — 4 Review
+
+[Step title]
+[Why this information is needed]
+[Fields]
+
+[Back]                               [Save draft] [Continue]
+```
+
+Rules:
+
+- Steps SHOULD represent meaningful user concepts, not arbitrary field counts.
+- Back MUST retain entered data.
+- Do not ask for the same information again in later steps; WCAG 2.2 includes a redundant-entry criterion for multi-step processes.[^wcag-redundant]
+- The final review MUST show consequential choices and allow targeted editing.
+- Creation progress after submission belongs in a job/progress view, not a fake extra wizard step.
+
+### 7.9 Pattern I: audit timeline
+Best for changes, access, deployments, support actions, and security events.
+
+```text
+[Time] [Actor] [Action] [Resource] [Result] [IP/source]
+
+2026-06-19 10:41  Luca  Changed pool size  db-prod-2  Success
+  Before: 20
+  After:  40
+  Reason: Handle expected event traffic
+```
+
+Rules:
+
+- Use exact timestamps with timezone.
+- Preserve immutable identifiers even if display names change.
+- Show before/after values where safe.
+- Redact secrets rather than omitting the existence of the change.
+- Exports SHOULD carry the active filters and timezone.
+
+### 7.10 Responsive behavior
+Admin dashboards are often desktop-primary, but this does not justify unusable smaller-screen behavior.
+
+At narrow widths:
+
+- Preserve status, identity, primary action, and urgent queue items first.
+- Stack summary cards in priority order.
+- Replace side-by-side primary-detail with list → full-screen detail navigation.
+- Allow tables to expose priority columns and move secondary fields into row detail.
+- Do not shrink charts until labels become unreadable; switch to a simpler representation.
+- Keep touch targets large enough and separated.
+- Avoid horizontal scrolling for the whole page. A deliberately scrollable data grid MAY be appropriate.
+
+---

--- a/plugins/design/skills/dashboard-design/references/metrics-status-and-charts.md
+++ b/plugins/design/skills/dashboard-design/references/metrics-status-and-charts.md
@@ -1,0 +1,234 @@
+# Metrics, Status, and Charts
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 8. Metrics, status, and data trust
+
+### 8.1 Metric contract
+Every metric used in a product SHOULD have a contract:
+
+```yaml
+metric:
+  id: support.first_response_time.p50
+  label: Median first response time
+  definition: >
+    Median elapsed business time from conversation creation to the first
+    human or qualifying automated response.
+  unit: minutes
+  aggregation: p50
+  window: rolling_24_hours
+  comparison: previous_equivalent_period
+  filters:
+    - inbox
+    - channel
+    - priority
+  exclusions:
+    - spam
+    - test_conversations
+  source: support_warehouse
+  expected_lag: 15_minutes
+  owner: support_analytics
+```
+
+Without a definition, users will infer one. Different teams often infer different ones.
+
+### 8.2 KPI card anatomy
+A useful KPI card may contain:
+
+```text
+Metric label                    Status or info
+Current value + unit
+Delta + comparison basis
+Small trend or target progress
+Window · scope · freshness
+```
+
+MUST:
+
+- show the unit;
+- state the comparison basis for a delta;
+- identify the time window;
+- distinguish zero from missing;
+- expose a definition;
+- link to detail when the number can be investigated.
+
+SHOULD:
+
+- show target or threshold when one exists;
+- show directionality only when “higher” or “lower” is truly better;
+- avoid presenting excessive precision;
+- use consistent formatting for the same metric across the product.
+
+Avoid:
+
+- a percentage with no denominator or definition;
+- a green upward arrow when an increase is actually bad;
+- “+12%” with no baseline;
+- a sparkline with no time window;
+- a large number chosen because it looks impressive rather than because it changes a decision.
+
+### 8.3 Status model
+Use a small, documented vocabulary. A useful operational set is:
+
+|State|Meaning|Expected treatment|
+|---|---|---|
+|**Healthy**|Operating within expected bounds|Neutral-positive; no urgent action|
+|**Degraded**|Service continues with reduced quality or elevated risk|Explain impact and next step|
+|**Critical**|Active or imminent severe impact|Prominent, actionable, owned|
+|**Maintenance**|Intentional service change or limited availability|Show window and owner|
+|**Paused / disabled**|Deliberately not operating|Do not classify as healthy|
+|**Unknown**|No trustworthy current signal|Show missing/stale reason|
+
+Status indicators help users notice changes and prioritized issues, but they must be chosen for context and communicated consistently.[^carbon-status]
+
+MUST:
+
+- include a text label;
+- not rely on red/green alone;
+- define how the state is calculated;
+- display unknown or stale states honestly;
+- align aggregate status with child states according to a documented rule.
+
+### 8.4 Freshness and staleness
+Every live or near-live surface SHOULD expose:
+
+- last successful update;
+- expected update cadence;
+- current refresh or streaming state;
+- stale threshold;
+- partial-source warnings;
+- timezone.
+
+Do not replace stale values with zero. Retain the last known value, mark it stale, and explain what is unavailable.
+
+### 8.5 Data quality states
+A metric may be:
+
+- current;
+- delayed;
+- partial;
+- sampled;
+- estimated;
+- backfilled;
+- unavailable;
+- invalid due to configuration;
+- inaccessible due to permissions.
+
+These states SHOULD be represented explicitly. A generic “No data” message hides operationally important distinctions.
+
+### 8.6 Aggregation and scope
+Always clarify:
+
+- average versus percentile;
+- sum versus rate;
+- point-in-time versus cumulative;
+- event time versus ingestion time;
+- local versus global scope;
+- timezone and business-hours behavior;
+- whether retries, bots, tests, or internal traffic are included.
+
+---
+
+## 9. Charts and data visualization
+A dashboard is not improved by maximizing chart variety. Nielsen Norman Group recommends basic charts—especially bars, lines, and scatterplots—for most UX contexts because chart choice should serve the question.[^nng-chart-types]
+
+### 9.1 Chart-selection matrix
+|User question|Preferred representation|Notes|
+|---|---|---|
+|What is the current value?|Number + context|Add target, window, and freshness|
+|How has it changed over time?|Line chart|Use consistent interval and annotate events|
+|Which category is larger?|Horizontal bar chart|Sort meaningfully; start quantitative bars at zero|
+|How do two periods compare?|Paired bars or two lines|State exact comparison periods|
+|How is a total composed?|Stacked bar|Use a table when precise values matter|
+|What is the distribution?|Histogram, box plot, percentile table|Avoid reducing skewed data to an average|
+|Are two variables related?|Scatterplot|Include units and sample size|
+|Where are values geographically located?|Map only when location matters|Provide a table/list alternative|
+|What is the state across many resources?|Status table, heatmap, matrix|Text labels and accessible detail required|
+|What is the sequence of events?|Timeline|Preserve exact timestamps|
+|What is the hierarchy?|Tree, indented list, sunburst only for expert analysis|Prefer navigable structures over decorative treemaps|
+|Which records need action?|Table or queue|Do not turn actionable records into a chart|
+
+### 9.2 Chart anatomy
+A chart SHOULD include the elements necessary to interpret it:[^carbon-chart]
+
+- clear title that states the measure;
+- optional subtitle with scope or question;
+- axes and units;
+- legend when direct labels are not possible;
+- tooltip or accessible detail;
+- time range;
+- source/freshness when relevant;
+- annotation for deployments, incidents, campaigns, policy changes, or other causal candidates.
+
+### 9.3 Visual hierarchy
+Use visual prominence for:
+
+1. urgent exceptions;
+2. the primary outcome;
+3. meaningful comparisons;
+4. supporting context.
+
+Do not make every chart equal-sized. Equal size suggests equal importance.
+
+### 9.4 Color
+Use color to communicate a defined semantic or to distinguish a small number of series.
+
+MUST:
+
+- pair status color with text, icon, pattern, or position;
+- maintain sufficient contrast;
+- use the same semantic color for the same meaning;
+- include hover, focus, selected, disabled, and high-contrast states;
+- avoid a rainbow palette for ordered data.
+
+SHOULD:
+
+- reserve strong status colors for status;
+- use neutral colors for context;
+- direct-label series where possible;
+- provide a non-chart table or textual summary for critical data.
+
+### 9.5 Scales and baselines
+- Bar charts SHOULD generally start at zero because length encodes value.
+- Line charts MAY use a non-zero baseline when the range is made explicit and the design is not misleading.
+- Log scales MUST be labeled clearly.
+- Dual axes SHOULD be avoided unless the relationship is essential and unmistakable.
+- Threshold bands MUST explain who set the threshold and what it means.
+- Percentages SHOULD state the denominator when ambiguity is possible.
+
+### 9.6 Missing and partial data
+Do not draw a continuous line across a period with missing data unless interpolation is deliberate and disclosed.
+
+Use:
+
+- gaps;
+- dashed estimated segments;
+- shaded incomplete windows;
+- explicit “data delayed” annotation;
+- coverage percentage.
+
+### 9.7 Chart interaction
+Interactions MAY include:
+
+- hover and keyboard-focus details;
+- click-to-filter;
+- click-to-drill down;
+- brushing a time window;
+- zoom;
+- compare mode;
+- event overlays;
+- open raw records.
+
+Every interaction SHOULD have a visible affordance. Hover-only behavior is insufficient for touch and keyboard users.
+
+### 9.8 Avoid these visualization choices
+- 3D charts;
+- gauges used for ordinary percentages;
+- many small donuts;
+- pie charts with many slices;
+- treemaps chosen for visual novelty;
+- unlabeled sparklines used as evidence;
+- red/green-only heatmaps;
+- charts where a sorted table would answer the question faster;
+- animated transitions that delay urgent understanding.
+
+---

--- a/plugins/design/skills/dashboard-design/references/research-basis.md
+++ b/plugins/design/skills/dashboard-design/references/research-basis.md
@@ -1,0 +1,97 @@
+# Research Basis and References
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 26. Research basis and references
+This playbook combines established dashboard, enterprise-application, design-system, accessibility, observability, database, support, and security guidance. The sources below are starting points rather than substitutes for user research in the target product.
+
+[^nng-dashboard]: Nielsen Norman Group, [Dashboards: Making Charts and Graphs Easier to Understand](https://www.nngroup.com/articles/dashboards-preattentive/).
+
+[^powerbi-dashboard]: Microsoft Learn, [Introduction to dashboards for Power BI designers](https://learn.microsoft.com/en-us/power-bi/create-reports/service-dashboards).
+
+[^powerbi-design]: Microsoft Learn, [Tips for designing a great Power BI dashboard](https://learn.microsoft.com/en-us/power-bi/create-reports/service-dashboards-design-tips).
+
+[^qlik-types]: Qlik, [Dashboard Design: Best Practices and Dashboard Types](https://www.qlik.com/us/dashboard-examples/dashboard-design).
+
+[^nng-chart-types]: Nielsen Norman Group, [Choosing Chart Types: Consider Context](https://www.nngroup.com/articles/choosing-chart-types/).
+
+[^nng-tables]: Nielsen Norman Group, [Data Tables: Four Major User Tasks](https://www.nngroup.com/articles/data-tables/).
+
+[^carbon-chart]: IBM Carbon Design System, [Chart anatomy](https://v10.carbondesignsystem.com/data-visualization/chart-anatomy/).
+
+[^carbon-status]: IBM Carbon Design System, [Status indicators](https://carbondesignsystem.com/patterns/status-indicator-pattern/).
+
+[^carbon-empty]: IBM Carbon Design System, [Empty states](https://carbondesignsystem.com/patterns/empty-states-pattern/).
+
+[^carbon-forms]: IBM Carbon Design System, [Forms pattern](https://v10.carbondesignsystem.com/patterns/forms-pattern/).
+
+[^patternfly-forms]: Red Hat PatternFly, [Form design guidelines](https://www.patternfly.org/components/forms/form/design-guidelines).
+
+[^patternfly-primary-detail]: Red Hat PatternFly, [Primary-detail design guidelines](https://www.patternfly.org/patterns/primary-detail/design-guidelines).
+
+[^patternfly-data-list]: Red Hat PatternFly, [Data list design guidelines](https://www.patternfly.org/components/data-list/design-guidelines).
+
+[^govuk-question]: GOV.UK Design System, [Question pages](https://design-system.service.gov.uk/patterns/question-pages/).
+
+[^govuk-check]: GOV.UK Design System, [Check answers](https://design-system.service.gov.uk/patterns/check-answers/).
+
+[^wcag22]: W3C Web Accessibility Initiative, [Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG22/).
+
+[^wcag-forms]: W3C WAI, [Understanding error identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html) and [labels or instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html).
+
+[^wcag-target]: W3C WAI, [Understanding Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
+
+[^wcag-redundant]: W3C WAI, [Understanding Redundant Entry](https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html).
+
+[^wcag-error-prevention]: W3C WAI, [Understanding Error Prevention (All)](https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-all.html).
+
+[^grafana-best-practices]: Grafana Labs, [Grafana dashboard best practices](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/best-practices/).
+
+[^grafana-data-links]: Grafana Labs, [Configure data links and actions](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/configure-data-links/).
+
+[^otel-signals]: OpenTelemetry, [Signals](https://opentelemetry.io/docs/concepts/signals/).
+
+[^otel-traces]: OpenTelemetry, [Traces](https://opentelemetry.io/docs/concepts/signals/traces/).
+
+[^otel-context]: OpenTelemetry, [Context propagation](https://opentelemetry.io/docs/concepts/context-propagation/).
+
+[^google-sre-monitoring]: Google, [Site Reliability Engineering — Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/).
+
+[^postgres-monitoring]: PostgreSQL Global Development Group, [Monitoring Database Activity](https://www.postgresql.org/docs/current/monitoring.html).
+
+[^postgres-maintenance]: PostgreSQL Global Development Group, [Routine Database Maintenance Tasks](https://www.postgresql.org/docs/current/maintenance.html).
+
+[^aws-rds-monitoring]: Amazon Web Services, [Monitoring metrics in an Amazon RDS instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Monitoring.html).
+
+[^aws-fleet]: Amazon Web Services, [Viewing the Fleet Health Dashboard for CloudWatch Database Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Database-Insights-Fleet-Health-Dashboard.html).
+
+[^zendesk-dashboard]: Zendesk, [Overview of the Zendesk Support dashboard](https://support.zendesk.com/hc/en-us/articles/4408835985434-Overview-of-the-Zendesk-Support-dashboard).
+
+[^intercom-dashboard]: Intercom, [Real-time Dashboard](https://www.intercom.com/help/en/articles/5784131-real-time-dashboard) and [Monitoring team workload and capacity](https://www.intercom.com/help/en/articles/6560699-monitoring-your-team-s-workload-and-capacity).
+
+[^owasp-authz]: OWASP Cheat Sheet Series, [Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html).
+
+---
+
+## Compact rule set for an agent prompt
+```text
+Design the dashboard as a decision-and-action system, not a chart gallery.
+
+1. Identify the primary user, recurring job, decision horizon, risk, scope,
+   and successful next action.
+2. Choose one primary archetype: monitor, queue/workbench, fleet,
+   resource detail, investigation, configuration, wizard, scorecard, or audit.
+3. Put identity, environment, status, urgent exceptions, and primary action
+   before secondary analytics.
+4. Give every metric a definition, unit, time window, comparison, scope,
+   freshness, and missing-data behavior.
+5. Use basic charts selected by the question; use tables for actionable records.
+6. Preserve scope, time, filters, and list position across drill-downs.
+7. Map forms to complexity, context, and risk. Use persistent labels,
+   grouped sections, clear units, recovery-oriented errors, and explicit save behavior.
+8. For high-risk actions, show target, impact, dependencies, reversibility,
+   permission, review, confirmation, progress, and audit result.
+9. Specify loading, empty, filtered-empty, stale, partial, permission,
+   error, saving, conflict, success, and partial-success states.
+10. Meet WCAG 2.2 AA, support keyboard and narrow screens, never rely on
+    color alone, and never present missing telemetry as healthy.
+```

--- a/plugins/design/skills/dashboard-design/references/review-checklist.md
+++ b/plugins/design/skills/dashboard-design/references/review-checklist.md
@@ -1,0 +1,80 @@
+# Dashboard Review Checklist
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 24. Review checklist
+
+### 24.1 Purpose and architecture
+- [ ] The primary user and job are explicit.
+- [ ] The decision horizon is explicit.
+- [ ] The page has one primary archetype.
+- [ ] A dashboard is actually the right surface.
+- [ ] Global scope is visually distinct from local filters.
+- [ ] Drill-downs preserve valid scope, time, and filters.
+- [ ] Navigation reflects the user’s domain model.
+
+### 24.2 Information hierarchy
+- [ ] Urgent exceptions appear before lower-priority detail.
+- [ ] The primary action is obvious.
+- [ ] Metrics have definitions, units, windows, and comparisons.
+- [ ] Status includes text and handles unknown/stale data.
+- [ ] Data freshness is visible.
+- [ ] No panel exists only to fill space.
+
+### 24.3 Charts
+- [ ] Each chart answers a stated question.
+- [ ] Chart type matches the comparison.
+- [ ] Axes, units, scope, and time are clear.
+- [ ] Missing/partial data is not disguised.
+- [ ] Color is not the only encoding.
+- [ ] Critical data has a textual or tabular alternative.
+- [ ] Events are annotated where they help diagnosis.
+
+### 24.4 Tables and queues
+- [ ] Default sort matches urgency or task.
+- [ ] Identity, status, and primary comparison fields are visible.
+- [ ] Row navigation and checkbox selection are distinct.
+- [ ] Bulk actions show count, scope, and partial results.
+- [ ] Filters are visible and clearable.
+- [ ] Empty states distinguish no data, no match, no access, and error.
+- [ ] Live updates do not destabilize user interaction.
+
+### 24.5 Forms
+- [ ] The form container matches complexity, context, and risk.
+- [ ] Labels are persistent and specific.
+- [ ] Fields are grouped by user concept.
+- [ ] Defaults are safe and transparent.
+- [ ] Units and valid ranges are visible.
+- [ ] Errors explain how to recover and preserve input.
+- [ ] Save behavior is consistent.
+- [ ] Unsaved changes and conflicts are handled.
+- [ ] Consequential actions have review and appropriate confirmation.
+- [ ] Secrets are never repopulated or exposed.
+
+### 24.6 Actions and jobs
+- [ ] Action labels state the result.
+- [ ] Permission is enforced server-side.
+- [ ] Production target and environment are repeated for risky actions.
+- [ ] Long-running actions have durable job status.
+- [ ] Partial success is represented honestly.
+- [ ] Retry and cancellation semantics are defined.
+- [ ] Audit events contain actor, target, time, result, and safe diff.
+
+### 24.7 Accessibility and responsive behavior
+- [ ] Keyboard order and focus behavior are specified.
+- [ ] Targets meet minimum size/spacing requirements.
+- [ ] Forms have labels, instructions, and text errors.
+- [ ] Status does not depend only on color.
+- [ ] Tables and charts have accessible alternatives.
+- [ ] Narrow-screen priority is explicit.
+- [ ] Primary-detail becomes a usable single-pane flow on mobile.
+- [ ] Timezone, locale, and long translated labels are supported.
+
+### 24.8 Trust and safety
+- [ ] Unknown data is not shown as healthy or zero.
+- [ ] Estimates and forecasts are labeled.
+- [ ] Sensitive data is redacted by role and context.
+- [ ] Destructive actions expose impact and recovery options.
+- [ ] Impersonation/support access is persistent and audited.
+- [ ] High-risk changes support approval or reauthentication where required.
+
+---

--- a/plugins/design/skills/dashboard-design/references/tables-lists-and-queues.md
+++ b/plugins/design/skills/dashboard-design/references/tables-lists-and-queues.md
@@ -1,0 +1,145 @@
+# Tables, Lists, and Queues
+Source: Dashboard UX Playbook for Product-Building Agents, version 1.0, June 2026.
+
+## 10. Tables, lists, queues, and grids
+Tables are often the most important component in operational products. They support four common tasks: finding records, comparing them, viewing or editing one record, and taking action on records.[^nng-tables]
+
+### 10.1 Table versus data list versus cards
+Use a **table** when:
+
+- rows share consistent fields;
+- column comparison matters;
+- sorting and filtering matter;
+- values are compact.
+
+Use a **data list** when:
+
+- row content varies;
+- each item has richer text or media;
+- a strict column model would be awkward;
+- responsive flexibility matters.
+
+Use **cards** when:
+
+- the set is small;
+- visual identity matters;
+- each item has a few high-level facts;
+- comparison precision is secondary.
+
+PatternFly similarly recommends data lists for flexible, non-tabular rich rows and tables for clearly columnar data.[^patternfly-data-list]
+
+### 10.2 Column design
+Order columns by task:
+
+1. identity;
+2. actionable status;
+3. primary comparison values;
+4. ownership or scope;
+5. recency;
+6. secondary metadata;
+7. actions.
+
+Rules:
+
+- Keep the primary identifier visible when horizontally scrolling.
+- Align numeric values for comparison.
+- Put units in headers when every value shares the unit.
+- Use exact timestamps in detail and human-readable relative time in overview, with exact time available.
+- Avoid a separate column for every rare attribute; use row detail or customizable columns.
+- Truncated content MUST have an accessible way to reveal the full value.
+
+### 10.3 Sorting
+- Indicate the current sort and direction.
+- Use a useful default: urgency for queues, status/impact for fleets, recency for events.
+- Preserve stable ordering when live data updates.
+- Explain composite priority when it is algorithmic.
+- Avoid ambiguous “Status” sorting unless the status order is defined.
+
+### 10.4 Filtering and search
+A table toolbar SHOULD provide only relevant controls:
+
+```text
+[Search] [Status] [Owner] [Region] [More filters] [Saved view]
+                                              [Columns] [Export]
+```
+
+- Show active filters as removable chips or a clear summary.
+- Show result count.
+- Provide “Clear all.”
+- Distinguish a local table search from global product search.
+- Do not hide high-frequency filters in an advanced drawer.
+
+### 10.5 Row actions
+Use one visible primary row action only when it is frequent and unambiguous. Put secondary actions in an overflow menu.
+
+Do not:
+
+- reveal critical actions only on hover;
+- use icon-only actions without accessible names and tooltips where needed;
+- place destructive and harmless actions adjacent without separation;
+- let clicking an action also trigger row navigation.
+
+### 10.6 Selection and bulk actions
+Checkbox selection and row navigation are distinct states.
+
+When items are selected:
+
+```text
+12 selected   [Assign] [Change status] [Export] [More]
+```
+
+Bulk actions MUST:
+
+- state the count;
+- show mixed-value behavior;
+- explain unsupported items;
+- provide an impact preview for risky operations;
+- handle partial success with per-item results;
+- retain a downloadable result for large jobs.
+
+### 10.7 Pagination, infinite scroll, and virtualization
+Use **pagination** when:
+
+- users need stable pages or shareable positions;
+- the dataset is large;
+- selection across pages is meaningful;
+- exact counts matter.
+
+Use **infinite scroll** sparingly, mainly for chronological feeds where position is less important.
+
+Use **virtualization** for performance in dense expert grids, but preserve:
+
+- keyboard navigation;
+- screen-reader semantics as far as technically possible;
+- stable focus;
+- reliable selection;
+- export for the full dataset.
+
+### 10.8 Inline editing
+Inline editing works for small, independent, low-risk values such as a label, owner, or priority.
+
+Use a form or drawer when:
+
+- fields depend on one another;
+- validation is complex;
+- the change has broad impact;
+- users need explanatory context;
+- multiple values must be reviewed together.
+
+Inline edit MUST show saving, success, error, and conflict states. It SHOULD support cancel and keyboard operation.
+
+### 10.9 Queue-specific details
+A queue item SHOULD make priority understandable through a combination of:
+
+- SLA or due time;
+- severity or customer impact;
+- age;
+- assignment;
+- status;
+- customer or resource identity;
+- channel/source;
+- last meaningful update.
+
+Do not rely on an unexplained opaque priority score. If machine ranking is used, expose the major reasons and allow a sensible manual sort.
+
+---


### PR DESCRIPTION
## Summary

- Add `design:dashboard-design` with a compact `SKILL.md` workflow for decision-first dashboard, admin console, workbench, and internal-tool UX.
- Split the dashboard UX playbook into focused references for briefs, taxonomy, IA, layouts, metrics, charts, tables, filters, forms, actions, states, safety, accessibility, domain blueprints, output specs, review checklists, anti-patterns, and research notes.
- Register the skill in the design plugin and regenerate generated design plugin artifacts.

## Validation

- `python3 /Users/luca/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/design/skills/dashboard-design`
- `bun run marketplace:write`
- `bun run marketplace`
- `bun run check:fix`
- `git diff --check`
- `bun run ci`

## Notes

- `bun run ci` passes with existing informational warnings about long files in other skills and missing optional Cursor plugin hooks/MCP files.