### PR TITLE
feat(design): add web design skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -49,7 +49,7 @@
 			"category": "Design",
 			"interface": {
 				"displayName": "Design",
-				"shortDescription": "Product and system design"
+				"shortDescription": "Product, web, and system design"
 			}
 		},
 		{

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,7 +58,7 @@
 		{
 			"name": "design",
 			"source": "./plugins/design",
-			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+			"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
 			"version": "2.0.0",
 			"author": {
 				"name": "Luca Silverentand",
@@ -74,6 +74,8 @@
 				"hig",
 				"ui",
 				"ux",
+				"web",
+				"website",
 				"adr",
 				"c4"
 			]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -24,7 +24,7 @@
 		{
 			"name": "design",
 			"source": "design",
-			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews."
+			"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews."
 		},
 		{
 			"name": "development",

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -42,10 +42,10 @@
 		{
 			"name": "design",
 			"displayName": "Design",
-			"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
-			"shortDescription": "Product and system design",
+			"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+			"shortDescription": "Product, web, and system design",
 			"category": "Design",
-			"keywords": ["design", "architecture", "api", "database", "apple", "hig", "ui", "ux", "adr", "c4"],
+			"keywords": ["design", "architecture", "api", "database", "apple", "hig", "ui", "ux", "web", "website", "adr", "c4"],
 			"skills": [
 				"api-design",
 				"architecture",
@@ -59,6 +59,7 @@
 				"foundations",
 				"platforms",
 				"services",
+				"web-design",
 				"write-adr",
 				"write-design-doc"
 			],

--- a/plugins/design/.claude-plugin/plugin.json
+++ b/plugins/design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "design",
-	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+	"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
 	"version": "2.0.0",
 	"skills": [
 		"./skills/api-design",
@@ -15,6 +15,7 @@
 		"./skills/foundations",
 		"./skills/platforms",
 		"./skills/services",
+		"./skills/web-design",
 		"./skills/write-adr",
 		"./skills/write-design-doc"
 	],
@@ -34,6 +35,8 @@
 		"hig",
 		"ui",
 		"ux",
+		"web",
+		"website",
 		"adr",
 		"c4"
 	]

--- a/plugins/design/.codex-plugin/plugin.json
+++ b/plugins/design/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "design",
 	"version": "2.0.0",
-	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+	"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
@@ -18,14 +18,16 @@
 		"hig",
 		"ui",
 		"ux",
+		"web",
+		"website",
 		"adr",
 		"c4"
 	],
 	"skills": "./skills/",
 	"interface": {
 		"displayName": "Design",
-		"shortDescription": "Product and system design",
-		"longDescription": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+		"shortDescription": "Product, web, and system design",
+		"longDescription": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
 		"developerName": "Luca Silverentand",
 		"category": "Design",
 		"capabilities": [

--- a/plugins/design/.cursor-plugin/plugin.json
+++ b/plugins/design/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
 	"name": "design",
 	"displayName": "Design",
 	"version": "2.0.0",
-	"description": "Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
+	"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",
 	"author": {
 		"name": "Luca Silverentand",
 		"email": "dev@lucasilverentand.com"
@@ -17,6 +17,8 @@
 		"hig",
 		"ui",
 		"ux",
+		"web",
+		"website",
 		"adr",
 		"c4"
 	]

--- a/plugins/design/README.md
+++ b/plugins/design/README.md
@@ -1,5 +1,5 @@
 # Design
-Design and architecture skills for product UI, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.
+Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.
 
 ## Skills
 - `design:api-design`
@@ -14,6 +14,7 @@ Design and architecture skills for product UI, Apple platforms, system architect
 - `design:foundations`
 - `design:platforms`
 - `design:services`
+- `design:web-design`
 - `design:write-adr`
 - `design:write-design-doc`
 

--- a/plugins/design/skills/web-design/SKILL.md
+++ b/plugins/design/skills/web-design/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: web-design
+description: Designs, reviews, and implements modern public-facing websites with strong content, hierarchy, conversion, accessibility, performance, and visual quality. Use for marketing sites, campaign landing pages, homepages, pricing pages, product pages, portfolio sites, editorial sites, ecommerce/catalog pages, service websites, nonprofit/government/healthcare/education sites, event pages, hospitality/restaurant pages, personal brand sites, and similar website content surfaces. Trigger when the user asks for web design, landing page design, marketing website UX, homepage structure, website copy hierarchy, responsive site layout, conversion-focused page design, website audit, or modern website visual direction.
+---
+
+# Web Design
+Use this skill for content-led website design: public pages that need to explain, persuade, build trust, help visitors navigate, and convert without sacrificing usability, accessibility, or performance.
+
+For dashboard-like products, admin consoles, operational tools, or dense internal UI, prefer `$dashboard-design` unless the task is specifically about public website presentation.
+
+## Core Workflow
+1. Identify the site's job, audience, decision cost, proof needs, and primary conversion or comprehension goal.
+2. Read the relevant strategy, page-pattern, website-type, and visual-system references before proposing structure or UI.
+3. Start with content hierarchy and information architecture. Do not begin with decoration, trends, component libraries, or generic hero sections.
+4. Choose the page sequence, navigation model, proof placement, calls to action, trust signals, responsive behavior, and non-happy-path states.
+5. Load technical-quality and implementation references before building or reviewing code.
+6. Review the result against the launch checklist and 100-point audit when finishing substantial website work.
+
+## Reference Routing
+|Need|Read|
+|---|---|
+|Handbook scope, table of contents, and source map|`references/00-handbook-map.md`|
+|Site strategy, audience, jobs to be done, content hierarchy, IA, visual composition|`references/01-strategy-content-ia.md`|
+|Layout, grids, typography, color, imagery, icons, depth, brand distinctiveness|`references/02-visual-system.md`|
+|Navigation, search, forms, CTAs, states, motion, data, trust, ethical conversion|`references/03-interaction-conversion.md`|
+|Responsive design and accessibility|`references/04-responsive-accessibility.md`|
+|Performance, SEO, localization, privacy, security, resilience, and consent|`references/05-performance-discoverability-privacy.md`|
+|Design tokens, components, CSS architecture, CMS/content models, handoff, QA|`references/06-systems-implementation.md`|
+|SaaS/AI, enterprise/B2B, ecommerce, marketplace, portfolio, creative studio, editorial, and documentation sites|`references/07-website-types-technology-commerce.md`|
+|Dashboard/product, community, nonprofit, government, healthcare, education, finance, and travel sites|`references/08-website-types-sectors.md`|
+|Restaurant, event, real estate, local service, media, entertainment, personal brand, membership, campaign, luxury/fashion, legal, and utility sites|`references/09-website-types-local-campaigns.md`|
+|Page patterns for homepages, landing pages, pricing, product detail, listings, articles, about, case studies, contact, checkout, help, and error/offline pages|`references/10-page-pattern-playbooks.md`|
+|Current 2026 aesthetic directions, trend filters, and anti-patterns|`references/11-aesthetic-directions-antipatterns.md`|
+|Semantic page shell, CSS foundations, skip links, layout utilities, buttons, forms, dialogs, disclosures, and responsive images|`references/12-cookbook-page-components.md`|
+|Fonts, theming, motion, reveal, status announcements, tables, media, async stability, decorative atmosphere, feature detection, focus, 3D, structured data, security, print, and component readiness|`references/13-cookbook-interaction-quality.md`|
+|Launch checklists|`references/14-launch-checklists.md`|
+|100-point quality audit, reference library, and closing principle|`references/15-quality-audit-reference-library.md`|
+
+## Website Defaults
+- Treat content as the design foundation. Establish message hierarchy, proof, scanning structure, and conversion logic before styling.
+- Make the first viewport identify the offer, audience relevance, and next action without hiding all downstream context.
+- Use visual ambition deliberately: a site can be expressive, but every image, animation, layout move, and trend should support the page's job.
+- Prefer clear navigation, plain labels, strong information scent, real product or subject matter imagery, and proof near the claims it supports.
+- Design for scanning and depth: headlines carry meaning, sections have clear jobs, and visitors can skim or inspect without losing orientation.
+- Keep conversion ethical. Avoid false urgency, hidden costs, manipulative defaults, inaccessible forms, and proof that cannot be verified.
+- Preserve technical quality as part of design: responsive behavior, accessibility, performance, SEO, localization, privacy, and resilience are acceptance criteria.
+
+## Expected Outputs
+For advisory work, return the website brief, recommended page structure, key content hierarchy, proof and CTA strategy, visual direction, open questions, and next decision.
+
+For design or implementation work, produce or build:
+
+1. Audience, job, success measure, and page/site goal.
+2. Information architecture and page sequence.
+3. Content hierarchy, section-by-section message, proof, and CTA plan.
+4. Visual system choices for layout, type, color, imagery, motion, and brand distinctiveness.
+5. Responsive, accessibility, performance, SEO, privacy, and localization requirements.
+6. State handling for forms, loading, errors, empty/no-results pages, offline/degraded behavior, and consent.
+7. Launch or audit findings when reviewing an existing site.

--- a/plugins/design/skills/web-design/agents/openai.yaml
+++ b/plugins/design/skills/web-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Web Design"
+  short_description: "Design modern marketing websites"
+  default_prompt: "Use $web-design to plan, review, or build a modern marketing website."

--- a/plugins/design/skills/web-design/references/00-handbook-map.md
+++ b/plugins/design/skills/web-design/references/00-handbook-map.md
@@ -1,0 +1,129 @@
+# Handbook Map and Usage
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Modern, Visually Stunning, Functional Web Design
+## A practical mega-handbook for websites and web applications
+**Edition:** June 2026
+**Audience:** Designers, front-end engineers, product designers, creative developers, founders, content strategists, and teams shipping production websites.
+**Goal:** Help you create sites that look distinctive, communicate clearly, work for real people, load quickly, remain accessible, and survive contact with actual content.
+
+---
+
+## How to use this handbook
+This is not a catalog of fashionable effects. It is a decision system.
+
+Use it in four ways:
+
+1. **Before design:** read Parts I–III to set strategy, content, hierarchy, and visual direction.
+2. **During design and implementation:** use Parts IV–VII as design-system and engineering guidance.
+3. **For a specific project:** jump to the website-type and page-type playbooks.
+4. **Before launch:** run the accessibility, performance, responsive, content, and 100-point audit checklists.
+
+Statements marked **standard** come from formal standards or established platform guidance. Statements marked **heuristic** are useful defaults, not universal laws. Statements marked **direction** describe a current visual tendency that should be adapted rather than copied.
+
+---
+
+## Table of contents
+
+### Part I — What good modern web design actually is
+1. [The central model](#1-the-central-model)
+2. [A hierarchy of design obligations](#2-a-hierarchy-of-design-obligations)
+3. [Strategy, audience, and jobs to be done](#3-strategy-audience-and-jobs-to-be-done)
+4. [Content before decoration](#4-content-before-decoration)
+5. [Information architecture](#5-information-architecture)
+6. [Visual hierarchy and composition](#6-visual-hierarchy-and-composition)
+
+### Part II — Building the visual system
+7. [Layout, grids, spacing, and density](#7-layout-grids-spacing-and-density)
+8. [Typography](#8-typography)
+9. [Color systems and themes](#9-color-systems-and-themes)
+10. [Images, illustration, video, and art direction](#10-images-illustration-video-and-art-direction)
+11. [Iconography](#11-iconography)
+12. [Shape, borders, shadows, texture, and depth](#12-shape-borders-shadows-texture-and-depth)
+13. [Brand distinctiveness without visual chaos](#13-brand-distinctiveness-without-visual-chaos)
+
+### Part III — Interaction and product behavior
+14. [Navigation](#14-navigation)
+15. [Search, filtering, sorting, and discovery](#15-search-filtering-sorting-and-discovery)
+16. [Buttons, links, cards, and calls to action](#16-buttons-links-cards-and-calls-to-action)
+17. [Forms](#17-forms)
+18. [System status, loading, errors, and empty states](#18-system-status-loading-errors-and-empty-states)
+19. [Motion, transitions, scrolling, and 3D](#19-motion-transitions-scrolling-and-3d)
+20. [Tables, dashboards, and data visualization](#20-tables-dashboards-and-data-visualization)
+21. [Trust, persuasion, and ethical conversion](#21-trust-persuasion-and-ethical-conversion)
+
+### Part IV — Technical quality
+22. [Responsive and adaptive design](#22-responsive-and-adaptive-design)
+23. [Accessibility and inclusive design](#23-accessibility-and-inclusive-design)
+24. [Performance and Core Web Vitals](#24-performance-and-core-web-vitals)
+25. [SEO, structured data, and discoverability](#25-seo-structured-data-and-discoverability)
+26. [Internationalization and localization](#26-internationalization-and-localization)
+27. [Privacy, security, resilience, and consent](#27-privacy-security-resilience-and-consent)
+
+### Part V — Systems and implementation
+28. [Design tokens](#28-design-tokens)
+29. [Component architecture](#29-component-architecture)
+30. [CSS architecture and modern platform capabilities](#30-css-architecture-and-modern-platform-capabilities)
+31. [Content models and CMS design](#31-content-models-and-cms-design)
+32. [Design-to-development workflow](#32-design-to-development-workflow)
+33. [Testing and quality assurance](#33-testing-and-quality-assurance)
+
+### Part VI — Website-type playbooks
+34. [SaaS and AI product marketing](#34-saas-and-ai-product-marketing)
+35. [Enterprise and B2B](#35-enterprise-and-b2b)
+36. [E-commerce](#36-e-commerce)
+37. [Marketplace](#37-marketplace)
+38. [Portfolio](#38-portfolio)
+39. [Creative agency and studio](#39-creative-agency-and-studio)
+40. [Editorial, magazine, news, and blog](#40-editorial-magazine-news-and-blog)
+41. [Documentation and developer portal](#41-documentation-and-developer-portal)
+42. [Dashboard, admin, and analytics product](#42-dashboard-admin-and-analytics-product)
+43. [Community, forum, and social product](#43-community-forum-and-social-product)
+44. [Nonprofit and charity](#44-nonprofit-and-charity)
+45. [Government and public service](#45-government-and-public-service)
+46. [Healthcare and clinic](#46-healthcare-and-clinic)
+47. [Education and course platform](#47-education-and-course-platform)
+48. [Finance, banking, and fintech](#48-finance-banking-and-fintech)
+49. [Travel, hotel, and hospitality](#49-travel-hotel-and-hospitality)
+50. [Restaurant, café, and food service](#50-restaurant-café-and-food-service)
+51. [Event, conference, and festival](#51-event-conference-and-festival)
+52. [Real estate and property](#52-real-estate-and-property)
+53. [Local services and trades](#53-local-services-and-trades)
+54. [Media, music, and streaming](#54-media-music-and-streaming)
+55. [Gaming and entertainment](#55-gaming-and-entertainment)
+56. [Personal brand and résumé](#56-personal-brand-and-résumé)
+57. [Membership and subscription](#57-membership-and-subscription)
+58. [Crowdfunding and campaign](#58-crowdfunding-and-campaign)
+59. [Luxury, fashion, and beauty](#59-luxury-fashion-and-beauty)
+60. [Legal and professional services](#60-legal-and-professional-services)
+61. [Progressive web app and utility](#61-progressive-web-app-and-utility)
+
+### Part VII — Page-pattern playbooks
+62. [Homepage](#62-homepage)
+63. [Campaign landing page](#63-campaign-landing-page)
+64. [Pricing page](#64-pricing-page)
+65. [Product detail page](#65-product-detail-page)
+66. [Category or listing page](#66-category-or-listing-page)
+67. [Article page](#67-article-page)
+68. [About page](#68-about-page)
+69. [Case study](#69-case-study)
+70. [Contact page](#70-contact-page)
+71. [Signup, login, and onboarding](#71-signup-login-and-onboarding)
+72. [Checkout](#72-checkout)
+73. [Dashboard](#73-dashboard)
+74. [Search results](#74-search-results)
+75. [Help center and documentation](#75-help-center-and-documentation)
+76. [Error, offline, empty, and maintenance pages](#76-error-offline-empty-and-maintenance-pages)
+
+### Part VIII — Current aesthetic directions
+77. [What feels current in 2026](#77-what-feels-current-in-2026)
+78. [Trend translation matrix](#78-trend-translation-matrix)
+79. [Anti-patterns](#79-anti-patterns)
+
+### Part IX — Practical tools
+80. [Implementation cookbook](#80-implementation-cookbook)
+81. [Launch checklists](#81-launch-checklists)
+82. [100-point quality audit](#82-100-point-quality-audit)
+83. [Reference library](#83-reference-library)
+
+---

--- a/plugins/design/skills/web-design/references/01-strategy-content-ia.md
+++ b/plugins/design/skills/web-design/references/01-strategy-content-ia.md
@@ -1,0 +1,389 @@
+# Strategy, Content, IA, and Composition
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part I — What good modern web design actually is
+
+## 1. The central model
+A strong modern website sits at the intersection of six qualities:
+
+|Quality|The question it answers|Failure mode when absent|
+|---|---|---|
+|**Useful**|Does this help someone complete a real task?|Beautiful irrelevance|
+|**Clear**|Can people understand the offer, structure, and next step?|Cognitive fog|
+|**Distinctive**|Is it recognizable and ownable?|Template sameness|
+|**Inclusive**|Can people with varied abilities, devices, and contexts use it?|Exclusion and legal risk|
+|**Fast**|Does it respond quickly and remain stable?|Abandonment and distrust|
+|**Maintainable**|Can the team evolve it without breaking consistency?|Design entropy|
+
+Visual quality is not a seventh, isolated layer. It is the visible expression of these six qualities. A beautiful hierarchy makes content clear. Good typography makes reading effortless. Carefully directed motion makes state changes legible. A disciplined component system makes refinement repeatable.
+
+### A compact design equation
+> **Perceived quality = clarity × craft × coherence × speed × trust**
+
+The multiplication matters. One near-zero factor can spoil the whole experience. A cinematic landing page that takes twelve seconds to become interactive feels broken. A fast application with weak hierarchy feels cheap. A gorgeous shop with ambiguous shipping and returns feels risky.
+
+### “Stunning” does not mean “busy”
+A visually memorable design usually has:
+
+- one dominant idea;
+- one or two signature devices;
+- excellent typography;
+- purposeful imagery;
+- careful rhythm and whitespace;
+- consistent detail;
+- restraint everywhere else.
+
+A page with five competing visual ideas often has no visual idea.
+
+### The two-layer model
+Build every experience in two layers:
+
+1. **The durable layer:** semantic structure, content, hierarchy, navigation, accessibility, responsive behavior, and performance.
+2. **The expressive layer:** art direction, motion, texture, depth, interactive flourishes, 3D, and unusual composition.
+
+The expressive layer may fail, be reduced, or be unavailable. The durable layer must still work.
+
+---
+
+## 2. A hierarchy of design obligations
+When design goals conflict, resolve them in this order:
+
+1. **Safety and legality**
+2. **Task completion**
+3. **Accessibility**
+4. **Comprehension**
+5. **Performance and resilience**
+6. **Trust**
+7. **Brand expression**
+8. **Novelty**
+
+This prevents common mistakes such as hiding required controls to preserve a minimalist composition, using low-contrast type to maintain a palette, or blocking a critical interaction behind a complex animation.
+
+### Hard constraints versus soft preferences
+Define hard constraints at kickoff:
+
+- supported browsers and devices;
+- accessibility conformance target;
+- content-management needs;
+- localization;
+- legal and consent requirements;
+- performance budget;
+- authentication and security rules;
+- analytics;
+- launch deadline.
+
+Then define soft preferences:
+
+- mood;
+- visual references;
+- motion intensity;
+- density;
+- desired brand traits;
+- appetite for experimentation.
+
+Never solve a soft preference by breaking a hard constraint.
+
+### Three levels of visual ambition
+**Level 1 — Polished utility**
+Best for public services, healthcare workflows, internal tools, high-frequency utilities, and early products. Use strong type, spacing, color, and subtle motion.
+
+**Level 2 — Branded product**
+Best for most commercial sites and mature products. Add distinctive art direction, branded iconography, custom illustration, and selected interaction signatures.
+
+**Level 3 — Experiential showcase**
+Best for campaigns, entertainment, fashion, cultural work, portfolios, and launches. Use cinematic motion, unusual composition, immersive media, and WebGL selectively. Preserve a direct route to the core task.
+
+A site may mix levels. A luxury brand homepage can be experiential while checkout remains polished utility.
+
+---
+
+## 3. Strategy, audience, and jobs to be done
+Do not start with a style. Start with evidence.
+
+### Define the site’s job
+Complete this sentence:
+
+> For **[specific audience]**, this site helps them **[complete a task or make a decision]** by providing **[specific value]**, unlike **[current alternative]**.
+
+Then identify:
+
+- the primary visitor;
+- their entry context;
+- what they already know;
+- what they fear;
+- what proof they need;
+- the most valuable action;
+- the smallest useful action;
+- the reason to return.
+
+### Useful research inputs
+Use a mix of:
+
+- stakeholder interviews;
+- customer interviews;
+- support tickets;
+- sales calls;
+- search queries;
+- analytics;
+- session recordings, with privacy safeguards;
+- competitor and adjacent-category analysis;
+- content inventory;
+- accessibility review;
+- performance baseline.
+
+Analytics show what happened. Interviews often reveal why. Neither replaces the other.
+
+### Jobs, questions, and proof
+For every major audience, map:
+
+|Stage|Visitor question|Needed content|Needed proof|Desired action|
+|---|---|---|---|---|
+|Orientation|“What is this?”|Plain-language proposition|Familiar cues|Continue|
+|Relevance|“Is it for me?”|Use cases and audience fit|Examples|Explore|
+|Evaluation|“Does it work?”|Features, process, limitations|Demo, case study, evidence|Compare|
+|Risk|“Can I trust it?”|Security, policies, team, terms|Certification, review, guarantees|Commit|
+|Action|“What happens next?”|Clear CTA and expectations|Confirmation|Convert|
+|Retention|“How do I succeed?”|Guidance and support|Progress/status|Return|
+
+### Competitive analysis without imitation
+Audit competitors along dimensions, not screenshots:
+
+- information architecture;
+- positioning;
+- proof;
+- tone;
+- visual codes;
+- interaction model;
+- performance;
+- accessibility;
+- conversion path;
+- neglected audience needs.
+
+Look outside the category for interaction and art-direction inspiration. A B2B dashboard may learn density management from professional audio software. A museum site may learn browsing from streaming services. Borrow principles, not costumes.
+
+### Define success before visual design
+Choose a small metric set:
+
+- task completion rate;
+- qualified conversion rate;
+- activation;
+- completion time;
+- error rate;
+- retention;
+- support-contact rate;
+- search success;
+- accessibility defects;
+- Core Web Vitals pass rate.
+
+Avoid optimizing an easy proxy at the expense of the real outcome. More clicks on a CTA are not valuable if users later abandon a misleading flow.
+
+---
+
+## 4. Content before decoration
+Good design clarifies content. It cannot rescue weak content indefinitely.
+
+### Start with a message hierarchy
+For each page, define:
+
+1. The one thing a visitor should understand.
+2. The one action they should be able to take.
+3. The three to five supporting ideas.
+4. The proof required.
+5. The detail that can be deferred.
+
+This hierarchy should survive as unstyled text. If it does not, layout experiments will conceal rather than solve the problem.
+
+### Write for scanning and depth
+People alternate between scanning and reading. Support both:
+
+- descriptive headings;
+- short opening summaries;
+- strong first sentences;
+- concrete labels;
+- lists for actual sets;
+- tables for comparisons;
+- progressive disclosure for detail;
+- links with meaningful text;
+- visual anchors that correspond to content.
+
+The classic F-shaped scanning pattern describes a symptom of weakly formatted pages, not a design target. Create deliberate landmarks so scanning becomes more efficient.
+
+### Front-load meaning
+Prefer:
+
+- “Export invoices as CSV” over “A smarter way to do more”
+- “Open until 23:00” over “Plan your visit”
+- “Plans from €12/month” over “Pricing that grows with you”
+- “No credit card required” near the signup action rather than in a FAQ
+
+### Match copy to decision cost
+Low-cost action: concise copy, immediate CTA.
+High-cost action: more explanation, proof, objections, process detail, and reversibility.
+
+A €12 purchase and a six-figure enterprise contract should not have the same page density.
+
+### Use plain language without flattening personality
+Plain language means recognizable words and direct syntax. It does not require a bland voice. Personality can come through rhythm, metaphor, examples, microcopy, photography, and art direction.
+
+### Content design rules
+- One concept per paragraph.
+- Put conditions before the action when conditions affect the decision.
+- Use verbs for actions.
+- Avoid labels such as “Learn more” when a destination can be named.
+- Explain consequences before destructive actions.
+- State units, dates, currencies, and time zones.
+- Do not make legal text visually illegible.
+- Write empty states and errors during initial design, not at the end.
+- Treat alt text, captions, metadata, and transcripts as content.
+
+---
+
+## 5. Information architecture
+Information architecture is the structure users infer from navigation, labels, page relationships, and content order.
+
+### Build around mental models
+A company may organize itself by departments. Customers usually organize their needs by tasks. Prefer the customer model.
+
+For example, a university may internally have faculties, offices, and programs. A prospective student may think in terms of “What can I study?”, “Can I afford it?”, “How do I apply?”, and “What is life there like?”
+
+### Core IA methods
+- **Content inventory:** list pages, owners, freshness, quality, and purpose.
+- **Content model:** define reusable content types and relationships.
+- **Card sorting:** discover how audiences group concepts.
+- **Tree testing:** test whether labels and hierarchy support finding.
+- **Search-log analysis:** reveal vocabulary and missing paths.
+- **Top-task analysis:** identify disproportionately important tasks.
+- **URL planning:** make stable, legible, hierarchical paths.
+
+### Navigation depth
+There is no universal “three-click rule.” Optimize for:
+
+- obvious choices;
+- low ambiguity;
+- useful scent;
+- manageable option counts;
+- continuity of context.
+
+Four clear steps are better than two confusing steps.
+
+### Page families
+Most sites contain a few page families:
+
+- orientation pages;
+- category or hub pages;
+- detail pages;
+- task pages;
+- editorial pages;
+- account pages;
+- system pages.
+
+Design templates around these families instead of making every page unique.
+
+### Labeling principles
+A label should be:
+
+- familiar to the audience;
+- specific enough to predict the destination;
+- consistent across the site;
+- distinct from sibling labels;
+- translatable;
+- concise without becoming cryptic.
+
+Avoid internal product names in primary navigation unless the audience already knows them.
+
+### URLs and breadcrumbs
+Use readable URLs that can survive redesigns. Breadcrumbs help on deep, hierarchical sites but should not replace clear navigation. On small sites, they may add noise.
+
+### Site search
+Search becomes essential when:
+
+- the catalog is large;
+- the audience knows what it wants;
+- content is technical;
+- naming varies;
+- users return frequently;
+- browsing alone is too slow.
+
+Search should handle synonyms, typos, abbreviations, and domain vocabulary where feasible.
+
+---
+
+## 6. Visual hierarchy and composition
+Visual hierarchy determines what is seen first, what is grouped, and what appears actionable.
+
+### Hierarchy controls
+The main controls are:
+
+- size;
+- weight;
+- contrast;
+- color;
+- position;
+- whitespace;
+- alignment;
+- repetition;
+- motion;
+- depth;
+- image salience.
+
+Use fewer controls more deliberately. Making an element bigger, brighter, bolder, animated, and elevated at once may overwhelm rather than clarify.
+
+### Establish a focal path
+A strong page usually provides:
+
+1. a primary focal point;
+2. a nearby explanatory element;
+3. an obvious next action;
+4. supporting evidence;
+5. deeper content.
+
+Test by blurring the page or viewing it at thumbnail size. The large-scale hierarchy should remain visible.
+
+### Composition models
+**Editorial column**
+Strong for reading, portfolios, journalism, and thought leadership. Uses asymmetry, typographic contrast, captions, and varied image scale.
+
+**Centered conversion stack**
+Strong for landing pages and simple products. Uses a clear proposition, CTA, proof, benefits, objections, and final CTA.
+
+**Split composition**
+Strong when copy and visual demonstration deserve equal weight. Ensure reading order remains logical on narrow screens.
+
+**Modular grid or bento**
+Strong for varied features and dashboards. Use modules to communicate real grouping; avoid arbitrary boxes around everything.
+
+**Full-bleed cinematic**
+Strong for art, entertainment, fashion, launches, and place-based storytelling. Maintain readable overlays and an accessible non-cinematic path.
+
+**Dense workspace**
+Strong for professional applications. Hierarchy comes from grouping, alignment, persistent tools, and predictable states rather than generous whitespace.
+
+### Alignment creates confidence
+Repeated edges make complex pages feel intentional. Establish a few alignment lines and reuse them. Random offsets can look expressive in a static mockup but chaotic with real content.
+
+### Whitespace is relational
+Whitespace does not simply mean “large empty areas.” It expresses grouping. Space inside a group should generally be smaller than space between groups. Dense products can still use excellent whitespace through disciplined micro-spacing.
+
+### Contrast of scale
+A memorable composition often combines:
+
+- one very large element;
+- ordinary body text;
+- small metadata;
+- a controlled amount of medium-scale UI.
+
+When everything is large, nothing is large.
+
+### Asymmetry with anchors
+Asymmetry feels intentional when anchored by a grid, repeated edge, baseline, or counterweight. Unanchored asymmetry feels accidental.
+
+### The squint test
+At key breakpoints:
+
+- squint or blur the screen;
+- identify the first three regions perceived;
+- verify they match the content priority;
+- ensure the primary action is visible but not coercive;
+- verify decorative elements do not become the focal point.
+
+---

--- a/plugins/design/skills/web-design/references/02-visual-system.md
+++ b/plugins/design/skills/web-design/references/02-visual-system.md
@@ -1,0 +1,676 @@
+# Visual System
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part II — Building the visual system
+
+## 7. Layout, grids, spacing, and density
+A grid is a decision framework, not a visible cage.
+
+### Layout primitives
+Use a small set of primitives:
+
+- full-bleed region;
+- centered content container;
+- narrow reading measure;
+- split layout;
+- auto-fit card grid;
+- sidebar shell;
+- cluster for inline items;
+- stack for vertical rhythm;
+- switcher that wraps based on available space;
+- frame for media aspect ratio;
+- cover for viewport-height composition.
+
+These primitives reduce one-off CSS and make responsive behavior predictable.
+
+### Container strategy
+Define several max-widths by purpose:
+
+```css
+:root {
+  --measure-reading: 68ch;
+  --container-narrow: 48rem;
+  --container-content: 72rem;
+  --container-wide: 90rem;
+}
+```
+
+Do not use a single width for every page. Long-form text, application tables, and cinematic media have different needs.
+
+### Gutters
+Use fluid gutters with a lower and upper bound:
+
+```css
+.page-shell {
+  padding-inline: clamp(1rem, 3vw, 3rem);
+}
+```
+
+This avoids abrupt breakpoint jumps.
+
+### Grid choices
+- Use **CSS Grid** for two-dimensional page and component layout.
+- Use **Flexbox** for one-dimensional distribution and alignment.
+- Use normal flow whenever it already solves the problem.
+- Use absolute positioning for overlays and decoration, not primary content structure.
+- Use **subgrid** when nested components need to align with parent tracks.
+- Use **container queries** when a component should respond to its own available space.
+
+### Spacing scales
+A useful scale is intentionally limited. Example:
+
+```text
+0, 2, 4, 8, 12, 16, 24, 32, 48, 64, 96, 128
+```
+
+A strict mathematical scale is less important than semantic consistency.
+
+Map raw values to roles:
+
+```css
+:root {
+  --space-control-gap: 0.5rem;
+  --space-card-padding: 1.25rem;
+  --space-section: clamp(4rem, 9vw, 8rem);
+  --space-page-gutter: clamp(1rem, 4vw, 4rem);
+}
+```
+
+### Density modes
+Consider compact, comfortable, and spacious density for products used in different contexts. Density changes should affect:
+
+- row height;
+- control height;
+- card padding;
+- typography;
+- icon size;
+- whitespace;
+- amount of visible metadata.
+
+Do not simply scale the whole interface.
+
+### Card discipline
+A card is appropriate when content:
+
+- forms a meaningful unit;
+- can move or repeat independently;
+- has a clear boundary;
+- benefits from a contained action area.
+
+Avoid cards for every paragraph. Excessive containers create “box soup,” weaken hierarchy, and waste space.
+
+### Responsive grid heuristic
+A practical marketing grid:
+
+- small: 4 conceptual columns;
+- medium: 8 conceptual columns;
+- large: 12 conceptual columns.
+
+In CSS, the actual implementation can be more fluid. The conceptual grid helps design alignment.
+
+### Intrinsic responsiveness
+Prefer components that adapt without page-level breakpoint knowledge:
+
+```css
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: clamp(1rem, 2vw, 2rem);
+}
+```
+
+### Avoid breakpoint archaeology
+Do not add a breakpoint for every device or visual glitch. First ask:
+
+- Is a fixed width causing the problem?
+- Should content wrap naturally?
+- Can `min()`, `max()`, or `clamp()` solve it?
+- Should the component use a container query?
+- Is there too much content for the pattern?
+
+---
+
+## 8. Typography
+Typography carries most of the interface. Spend design effort accordingly.
+
+### Choose type by function
+Evaluate a typeface for:
+
+- body-text readability;
+- character distinction;
+- x-height;
+- punctuation;
+- numeral styles;
+- language support;
+- variable axes;
+- loading cost;
+- licensing;
+- tone;
+- behavior at small sizes;
+- behavior at very large display sizes.
+
+A fashionable display face can be paired with a conservative text face. Do not force one face to perform every role if it is weak in one.
+
+### A practical type system
+Define semantic roles, not page-specific sizes:
+
+- display;
+- page title;
+- section title;
+- subsection title;
+- body large;
+- body;
+- body small;
+- label;
+- caption;
+- code;
+- numeric/data.
+
+Example:
+
+```css
+:root {
+  --step--2: clamp(0.75rem, 0.72rem + 0.12vw, 0.82rem);
+  --step--1: clamp(0.875rem, 0.83rem + 0.18vw, 1rem);
+  --step-0: clamp(1rem, 0.95rem + 0.24vw, 1.125rem);
+  --step-1: clamp(1.25rem, 1.12rem + 0.62vw, 1.6rem);
+  --step-2: clamp(1.56rem, 1.32rem + 1.18vw, 2.25rem);
+  --step-3: clamp(1.95rem, 1.52rem + 2.14vw, 3.2rem);
+  --step-4: clamp(2.44rem, 1.68rem + 3.8vw, 4.8rem);
+  --step-5: clamp(3.05rem, 1.83rem + 6.1vw, 7rem);
+}
+```
+
+Use `rem` in fluid type formulas so user font preferences and zoom remain meaningful. Avoid viewport-only sizing.
+
+### Reading measure
+**Heuristic:** long-form body text often reads well around 45–90 characters per line, with roughly 60–75 as a useful center. Interface copy can be shorter; data tables may be wider.
+
+Use `ch` as a starting point, then test the actual font:
+
+```css
+.prose {
+  max-inline-size: 68ch;
+}
+```
+
+### Line height
+**Heuristic:** body copy typically needs around 1.45–1.7 line height depending on typeface, size, and line length. Display type can be tighter. Small text often needs more relative leading.
+
+```css
+body { line-height: 1.55; }
+h1, h2, h3 { line-height: 1.05; }
+```
+
+WCAG requires text to remain usable when users increase line, paragraph, word, and letter spacing under its text-spacing criterion. Avoid clipping containers.
+
+### Weight and contrast
+Do not use ultra-light text for long reading or low-contrast “premium” aesthetics. Thin strokes deteriorate on lower-quality screens, under zoom, and for low-vision readers.
+
+### Letter spacing
+- Large display text may benefit from slight negative tracking.
+- Uppercase labels usually need positive tracking.
+- Body copy rarely benefits from aggressive tracking.
+- Do not use all caps for paragraphs.
+- Test accented characters and non-Latin scripts.
+
+### Optical sizing and variable fonts
+Variable fonts can reduce requests and expose axes such as weight, width, slant, and optical size. They can also be larger than a carefully subset static font. Measure the actual file.
+
+Use optical sizing when supported by the font:
+
+```css
+body {
+  font-optical-sizing: auto;
+}
+```
+
+### Font loading
+- Prefer system fonts when brand requirements allow.
+- Self-host when it improves privacy and control.
+- Subset by language and glyph coverage carefully.
+- Preload only fonts needed immediately.
+- Use `font-display` intentionally.
+- Provide metrics-compatible fallbacks to reduce layout shift.
+- Avoid loading many weights when a variable font or fewer styles suffice.
+
+### Typographic hierarchy checklist
+- Does the page title look different from a card title?
+- Can metadata be distinguished without becoming illegible?
+- Are links identifiable without relying only on color?
+- Do numbers align where comparison matters?
+- Are headings meaningful in document order?
+- Does the system work with twice as much text?
+- Does it survive localization?
+- Are orphaned one-word lines in large headlines acceptable?
+- Are code, quotations, captions, and annotations styled for their function?
+
+### Expressive type
+Large, unusual, or kinetic typography is effective when:
+
+- the words themselves carry the brand;
+- the display line is short;
+- resizing does not obscure content;
+- animation respects reduced-motion settings;
+- a plain-text equivalent remains in the accessibility tree;
+- performance remains acceptable.
+
+Never turn essential text into an inaccessible image merely to preserve exact composition.
+
+---
+
+## 9. Color systems and themes
+Color should carry meaning, hierarchy, and identity without becoming the only carrier of information.
+
+### Build color by roles
+Define semantic roles:
+
+- canvas;
+- surface;
+- elevated surface;
+- primary text;
+- secondary text;
+- subtle text;
+- border;
+- strong border;
+- accent;
+- accent-hover;
+- accent-contrast;
+- success;
+- warning;
+- danger;
+- info;
+- focus;
+- selection;
+- data-series colors.
+
+Then map brand primitives to these roles. Components should consume roles, not raw palette values.
+
+### Contrast requirements
+**WCAG 2.2 standard:**
+
+- normal text: at least **4.5:1** contrast;
+- large text: at least **3:1**;
+- essential non-text UI graphics and component boundaries: generally at least **3:1** against adjacent colors under the applicable criterion.
+
+Large text is approximately 18pt regular or 14pt bold, commonly mapped near 24 CSS px and 18.5 CSS px, though font rendering matters.
+
+Treat these as minimums, not aesthetic targets. Body text often benefits from higher contrast.
+
+### Perceptual color spaces
+Modern CSS supports perceptual color models such as OKLCH. They can make lightness and chroma adjustments more predictable than RGB/HSL.
+
+```css
+:root {
+  --brand: oklch(62% 0.19 258);
+  --brand-hover: oklch(56% 0.19 258);
+  --brand-soft: color-mix(in oklch, var(--brand) 15%, white);
+}
+```
+
+Always test contrast after mixing. Perceptual uniformity does not guarantee accessibility.
+
+### Dark mode is a redesign, not an inversion
+Dark themes need:
+
+- controlled contrast;
+- reduced glare;
+- adjusted shadows and elevation;
+- restrained saturation;
+- corrected image treatment;
+- visible borders;
+- tested states;
+- appropriate code and chart palettes.
+
+Pure white on pure black can be harsh. Use near-black surfaces and slightly softened text where contrast still passes.
+
+```css
+:root {
+  color-scheme: light dark;
+  --canvas: light-dark(oklch(98% 0.01 260), oklch(18% 0.015 260));
+  --text: light-dark(oklch(20% 0.02 260), oklch(94% 0.01 260));
+}
+```
+
+Provide explicit user choice when theme preference matters, and store it. System preference is a useful default, not always the final decision.
+
+### Color hierarchy
+A coherent page often uses:
+
+- one dominant neutral field;
+- one primary text family;
+- one signature accent;
+- semantic colors only where needed;
+- occasional secondary accent for illustration or data.
+
+A full brand color system can still appear rich through tonal variation, imagery, and gradients rather than many unrelated hues.
+
+### Gradients
+Use gradients to:
+
+- establish atmosphere;
+- create depth;
+- connect regions;
+- visualize a spectrum;
+- soften transitions.
+
+Avoid placing critical text over unpredictable gradients unless a stable overlay guarantees contrast.
+
+### Data color
+For charts:
+
+- choose palettes with distinct lightness as well as hue;
+- do not rely on red/green alone;
+- add labels, patterns, symbols, or line styles;
+- keep semantic colors consistent;
+- reserve saturated colors for meaningful emphasis;
+- verify dark theme separately.
+
+### Forced colors and high contrast
+Test in forced-colors modes. Do not suppress system colors casually. Custom visuals may disappear or collapse; ensure focus, boundaries, icons, and selected states remain understandable.
+
+---
+
+## 10. Images, illustration, video, and art direction
+Imagery can establish meaning faster than decoration, but it is often the largest performance cost on a page.
+
+### Give every image a job
+An image may:
+
+- demonstrate a product;
+- show a person, place, or outcome;
+- provide evidence;
+- create emotional context;
+- explain a process;
+- establish brand texture;
+- support navigation.
+
+Remove imagery that only fills a hole in the layout.
+
+### Photography direction
+Define:
+
+- subject distance;
+- camera perspective;
+- lighting;
+- color treatment;
+- depth of field;
+- movement;
+- casting;
+- environment;
+- crop behavior;
+- relation between subject and text.
+
+A coherent photographic system is more distinctive than a collection of individually attractive stock images.
+
+### Product imagery
+For physical products, include:
+
+- multiple angles;
+- scale reference;
+- close detail;
+- context of use;
+- color variants;
+- zoom;
+- video where motion matters;
+- clear indication when imagery is illustrative or digitally rendered.
+
+### Art direction across breakpoints
+Responsive images are not only about file size. A wide desktop image may need a tighter mobile crop.
+
+```html
+<picture>
+  <source
+    media="(min-width: 60rem)"
+    srcset="/img/hero-wide.avif 1x, /img/hero-wide@2x.avif 2x"
+    type="image/avif">
+  <source
+    srcset="/img/hero-portrait.webp"
+    type="image/webp">
+  <img
+    src="/img/hero-portrait.jpg"
+    alt="A marine biologist examining coral samples"
+    width="900"
+    height="1200"
+    fetchpriority="high">
+</picture>
+```
+
+Set intrinsic dimensions to prevent layout shift.
+
+### Image format strategy
+- **AVIF/WebP:** photographic and complex imagery where supported and advantageous.
+- **JPEG:** broad fallback for photographs.
+- **PNG:** transparency or lossless raster detail when modern formats are unsuitable.
+- **SVG:** logos, icons, diagrams, and scalable vector illustration.
+- **Animated formats/video:** short loops, demonstrations, or atmosphere; consider video for better compression and control.
+
+Compare real output. Format choice alone does not ensure a small file.
+
+### Alternative text
+Write alt text according to purpose:
+
+- informative image: communicate the relevant information;
+- functional image: describe the action or destination;
+- decorative image: empty alt (`alt=""`) so it can be ignored;
+- complex chart: concise alt plus nearby detailed data or description;
+- repeated caption: avoid redundant wording.
+
+Do not begin every alt with “Image of.” Screen readers already convey image semantics.
+
+### Background images
+Do not place essential content only in CSS backgrounds. Backgrounds may be disabled, cropped, or absent from accessibility semantics.
+
+### Video
+Provide:
+
+- captions;
+- transcript when useful;
+- audio description or equivalent for essential visual information;
+- visible controls;
+- volume control;
+- pause;
+- poster image;
+- no unexpected audio;
+- restrained autoplay;
+- reduced-data consideration.
+
+Autoplaying silent background video should not be the only way to understand the proposition.
+
+### Illustration systems
+Define:
+
+- perspective;
+- stroke;
+- corner treatment;
+- palette;
+- texture;
+- human representation;
+- level of abstraction;
+- motion behavior;
+- use cases.
+
+A consistent illustration grammar allows many artists or generators to produce coherent work.
+
+### Generative imagery
+When using generated imagery:
+
+- disclose it where trust or context requires;
+- review anatomy, text, symbols, bias, and cultural representation;
+- retain licensing and provenance records;
+- avoid synthetic “customer” imagery that implies false evidence;
+- art-direct outputs rather than accepting generic prompt aesthetics.
+
+---
+
+## 11. Iconography
+Icons compress familiar ideas. They do not magically make unfamiliar ideas understandable.
+
+### Use icons when
+- the action is conventional;
+- space is constrained;
+- repeated scanning benefits;
+- the icon supports a text label;
+- status needs a compact cue.
+
+### Use text when
+- the meaning is domain-specific;
+- the cost of misunderstanding is high;
+- the audience is infrequent;
+- several icons look similar;
+- localization can be accommodated.
+
+### Icon system decisions
+Define:
+
+- stroke or fill;
+- optical size;
+- grid;
+- line cap and joins;
+- corner character;
+- default sizes;
+- alignment box;
+- color behavior;
+- selected state;
+- animation rules.
+
+Icons of equal nominal dimensions often need optical correction.
+
+### Accessibility
+- Decorative icons: hide from assistive technology.
+- Icon-only buttons: provide an accessible name.
+- Status icon: include text or another redundant signal.
+- SVG: ensure focus behavior and titles are handled intentionally.
+- Do not put important text inside an SVG without an accessible equivalent.
+
+### Common ambiguity
+Icons such as star, heart, bookmark, flag, and pin can mean save, favorite, feature, rate, report, or location. Pair them with labels until the context is learned.
+
+---
+
+## 12. Shape, borders, shadows, texture, and depth
+These properties establish the material character of a design.
+
+### Corner radius
+Use a limited radius system:
+
+- small controls;
+- standard cards;
+- large panels;
+- pill shape for tags or compact actions.
+
+Do not use a pill shape for every rectangle. Shape should support grouping and affordance.
+
+### Borders
+Borders are useful for:
+
+- separating dense content;
+- defining controls;
+- preserving hierarchy in high-contrast environments;
+- reducing reliance on shadows.
+
+Use subtle borders for surfaces and stronger borders for interactive or focused states. Ensure essential boundaries remain visible.
+
+### Shadows
+A shadow should communicate:
+
+- elevation;
+- overlap;
+- focus;
+- interaction;
+- atmosphere.
+
+Keep elevation levels few and consistent. A giant soft shadow on every card creates visual haze and rendering cost.
+
+### Blur and glass
+Glass effects can look refined when:
+
+- the background has controlled contrast;
+- text remains readable;
+- the blur is not required for comprehension;
+- fallback surfaces are defined;
+- the number and area of backdrop filters are limited.
+
+Avoid glassmorphism over busy images for long text or forms.
+
+### Texture and grain
+Subtle grain can counter sterile digital surfaces, unify imagery, and create a tactile identity. Apply it as a lightweight decorative layer, not a high-resolution full-page asset. Ensure it does not reduce text contrast.
+
+### Depth cues
+Depth can come from:
+
+- overlap;
+- scale;
+- parallax;
+- blur;
+- light;
+- shadow;
+- color temperature;
+- perspective;
+- occlusion.
+
+Choose one or two cues. Combining all of them often looks theatrical and harms clarity.
+
+### Decorative pseudo-elements
+Prefer CSS gradients, masks, and pseudo-elements for simple decoration. Keep them out of the accessibility tree and prevent them from intercepting pointer events.
+
+---
+
+## 13. Brand distinctiveness without visual chaos
+Distinctiveness comes from a coherent combination, not constant novelty.
+
+### Ownable ingredients
+A brand system can be distinguished through:
+
+- type pairing;
+- signature color relationship;
+- photographic point of view;
+- illustration grammar;
+- composition;
+- motion behavior;
+- icon shape;
+- tone of voice;
+- border and radius character;
+- recurring motif;
+- sound, in appropriate contexts.
+
+Choose two or three ingredients to emphasize.
+
+### The signature-device rule
+A page should generally have one dominant signature device, such as:
+
+- oversized editorial type;
+- a kinetic product demo;
+- a spatial 3D object;
+- a distinctive modular grid;
+- a strong photographic crop system;
+- a hand-drawn annotation layer;
+- a bold monochrome palette.
+
+Supporting components should be calmer.
+
+### Avoid aesthetic cargo cults
+Do not use:
+
+- bento boxes without meaningful grouping;
+- glass panels without depth context;
+- brutalism without intentional typography and accessibility;
+- 3D objects that do not explain or embody the product;
+- horizontal scroll because an awards site used it;
+- tiny gray type as a proxy for sophistication;
+- gratuitous grain, glow, and chromatic aberration;
+- generic AI gradients as a substitute for identity.
+
+### Brand consistency versus monotony
+Consistency means stable rules. Variation can happen within them. Define what can flex:
+
+- image crop;
+- layout composition;
+- accent color;
+- type scale;
+- motion intensity;
+- illustration density.
+
+Templates should guide, not fossilize.
+
+---

--- a/plugins/design/skills/web-design/references/03-interaction-conversion.md
+++ b/plugins/design/skills/web-design/references/03-interaction-conversion.md
@@ -1,0 +1,759 @@
+# Interaction, Product Behavior, and Conversion
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part III — Interaction and product behavior
+
+## 14. Navigation
+Navigation should answer:
+
+- Where am I?
+- What can I do here?
+- Where else can I go?
+- How do I return?
+- What is most important?
+
+### Primary navigation
+Keep top-level choices conceptually distinct. Group utilities such as account, language, support, and search separately from the main content hierarchy.
+
+A large desktop menu does not need to collapse into a hamburger. Preserve visible navigation where space allows.
+
+### Mobile navigation
+Prioritize:
+
+- clear menu trigger and state;
+- immediate access to top tasks;
+- logical nesting;
+- visible back behavior;
+- no accidental page scroll behind overlays;
+- keyboard and screen-reader support;
+- preserved context when closed.
+
+A full-screen menu is a page state, not merely a visual overlay. Manage focus and escape behavior.
+
+### Dropdowns and mega menus
+Use a mega menu when categories require grouping and explanation. Do not use it to expose the entire sitemap indiscriminately.
+
+Good behavior includes:
+
+- click support, not hover only;
+- predictable opening;
+- sufficient pointer tolerance;
+- keyboard navigation;
+- escape to close;
+- visible focus;
+- no surprise activation while crossing the menu;
+- touch compatibility.
+
+### Sticky navigation
+Sticky headers help frequent navigation but consume valuable viewport space. Keep them compact and avoid dramatic hide/reveal behavior that causes layout confusion. On small screens, consider a task-specific sticky action instead.
+
+### Tabs
+Tabs switch between related views in the same context. They are not a replacement for page navigation when each view deserves its own URL, history, sharing, or SEO.
+
+### Side navigation
+Side navigation suits deep documentation, settings, and complex products. It can support more items and nested hierarchy than a horizontal bar. Provide collapse behavior carefully; icons alone may not be understandable.
+
+### Current location
+Use visible current-page states, meaningful page titles, breadcrumbs where useful, and persistent selected states. Do not rely only on color.
+
+### Footer
+A useful footer can provide:
+
+- secondary navigation;
+- legal and policy links;
+- contact;
+- language/region;
+- social channels;
+- newsletter;
+- status;
+- accessibility statement;
+- company details.
+
+Do not make the footer a landfill for unresolved IA.
+
+---
+
+## 15. Search, filtering, sorting, and discovery
+
+### Search box
+Use a visible search field when search is a primary task. A lone magnifying-glass icon adds friction and may be overlooked.
+
+Include:
+
+- clear placeholder or label;
+- submit behavior;
+- recent or suggested queries where useful;
+- keyboard access;
+- clear button;
+- loading state;
+- typo tolerance;
+- useful no-results state.
+
+A persistent label is more accessible than placeholder-only identification.
+
+### Results hierarchy
+A result should clearly expose:
+
+- title;
+- content type;
+- relevant excerpt;
+- metadata;
+- matched terms, when helpful;
+- destination context;
+- status or availability.
+
+### Filters
+Good filters:
+
+- match the vocabulary users know;
+- show selected state clearly;
+- reveal result counts when affordable;
+- support clearing one or all;
+- retain selections during navigation;
+- produce shareable URLs where appropriate;
+- work without drag-only controls;
+- avoid overwhelming users with rarely used facets.
+
+On mobile, a filter sheet can work well. Show the number of active filters outside the sheet.
+
+### Sorting
+Use user-centered labels:
+
+- Price: low to high
+- Newest
+- Best rated
+- Most relevant
+
+Explain “recommended” or “featured” when commercial ranking or personalization affects order.
+
+### No results
+Offer:
+
+- spelling correction;
+- broadened scope;
+- removed filters;
+- related categories;
+- popular alternatives;
+- a support path;
+- the original query retained for editing.
+
+Do not show a dead end.
+
+### Discovery modes
+Not all discovery is search:
+
+- curated collections;
+- related content;
+- recently viewed;
+- personalized recommendations;
+- guided quiz;
+- map;
+- timeline;
+- topic graph;
+- editorial pathways.
+
+Be transparent when recommendations are personalized, sponsored, or algorithmically ranked.
+
+---
+
+## 16. Buttons, links, cards, and calls to action
+
+### Buttons versus links
+- A **button** changes application state, submits, opens a dialog, or performs an action.
+- A **link** navigates to a new resource or location.
+
+Style can vary, but semantics should remain correct.
+
+### Button hierarchy
+A useful system includes:
+
+- primary;
+- secondary;
+- tertiary or ghost;
+- destructive;
+- icon-only;
+- loading;
+- disabled or unavailable.
+
+Most regions need at most one primary action. Multiple bright primaries destroy prioritization.
+
+### Labels
+Use verb-led, specific labels:
+
+- “Create project”
+- “Download invoice”
+- “Book 19:30 table”
+- “Continue to payment”
+
+Avoid “Submit” when the action can be named.
+
+### Target size
+**WCAG 2.2 AA standard:** pointer targets should generally be at least **24 × 24 CSS pixels**, or have sufficient spacing, with listed exceptions. A more comfortable product heuristic is around **44 × 44 CSS pixels** for common touch controls, especially high-frequency or consequential actions.
+
+The visible icon can be smaller than the hit area.
+
+### Disabled buttons
+Disabled controls can conceal requirements and are often skipped by keyboard navigation. Prefer an enabled action with clear validation when feasible, or explain why the action is unavailable adjacent to it.
+
+### Links
+- Make links visually identifiable.
+- Use underlines for inline content links unless another strong, consistent convention exists.
+- Preserve visited state in content-heavy sites where revisiting matters.
+- Do not remove focus styles.
+- Indicate external or download behavior when consequential.
+- Write destination-specific text.
+
+### Cards
+Decide whether:
+
+- the whole card is clickable;
+- only the title is linked;
+- multiple independent actions exist.
+
+Avoid nested interactive elements that create invalid or confusing behavior. A stretched-link technique must preserve independent controls and focus clarity.
+
+### CTA systems
+A CTA needs four ingredients:
+
+1. clear action;
+2. clear value;
+3. expected consequence;
+4. nearby risk reducer.
+
+Example:
+
+> **Start free workspace**
+> No card required. Invite your team after setup.
+
+Do not manufacture urgency or use deceptive scarcity.
+
+---
+
+## 17. Forms
+Forms are conversations with constraints.
+
+### Minimize work
+Ask only for information required now. Defer profile enrichment. Infer safely when possible. Let users edit inferred values.
+
+### Layout
+A single vertical column usually supports scanning and error recovery. Multi-column forms can work for short, strongly related fields such as city and postal code, but often become awkward on small screens.
+
+### Labels
+- Use persistent visible labels.
+- Place labels close to controls.
+- Do not rely on placeholder text as the label.
+- Mark optional fields when most are required, or required fields when most are optional.
+- Explain format before input when unusual.
+- Keep help text adjacent and programmatically associated.
+
+### Input type and autocomplete
+Use semantic types and autocomplete tokens:
+
+```html
+<label for="email">Email address</label>
+<input
+  id="email"
+  name="email"
+  type="email"
+  inputmode="email"
+  autocomplete="email"
+  required>
+```
+
+This improves keyboard choice, autofill, and assistive technology.
+
+### Validation
+Use layers:
+
+1. HTML constraints for basic correctness;
+2. client validation for immediate guidance;
+3. server validation as authority.
+
+Validation messages should:
+
+- identify the field;
+- explain the issue;
+- suggest a fix;
+- preserve entered data;
+- be announced to assistive technology;
+- not rely only on color.
+
+Do not validate aggressively while a person is still typing. Validate on blur or submission for many fields, with exceptions for useful live checks such as password requirements.
+
+### Error summary
+For long or important forms, provide an error summary at the top with links to each invalid field. Move focus appropriately after failed submission.
+
+### Passwords and authentication
+- Allow paste.
+- Support password managers.
+- Provide reveal password.
+- State requirements before input.
+- Avoid arbitrary composition rules when better security policy is possible.
+- Offer passkeys where appropriate.
+- Do not require memory tests or block autofill.
+- Provide recovery that does not depend on inaccessible puzzles.
+
+WCAG 2.2’s accessible-authentication guidance explicitly guards against cognitive-function tests without alternatives or assistance.
+
+### Address and payment
+- Use a single name field unless separate parts are genuinely required.
+- Design for international addresses.
+- Do not assume postal code format.
+- Use autocomplete.
+- Keep billing address reuse obvious.
+- Show total cost before commitment.
+- Preserve cart and form state.
+- Explain declines without exposing sensitive detail.
+
+### Long forms
+Break into steps when:
+
+- sections have a meaningful sequence;
+- later questions depend on earlier answers;
+- completion takes time;
+- users need progress and save/resume;
+- one-question-per-page reduces complexity.
+
+Do not split a short form merely to inflate perceived simplicity.
+
+### File upload
+Provide:
+
+- accepted formats;
+- maximum size;
+- upload progress;
+- preview;
+- remove/replace;
+- error recovery;
+- keyboard operation;
+- non-drag alternative.
+
+### Form checklist
+- Logical tab order
+- Visible focus
+- Labels and descriptions
+- Appropriate autocomplete
+- Mobile keyboard types
+- No data loss on error
+- Inline and summary errors
+- Accessible status announcements
+- Clear submit state
+- Duplicate submission prevention
+- Success confirmation
+- Privacy explanation near sensitive fields
+
+---
+
+## 18. System status, loading, errors, and empty states
+A polished interface explains what is happening.
+
+### State inventory
+Every interactive component may need:
+
+- default;
+- hover;
+- active/pressed;
+- focus;
+- selected;
+- disabled/unavailable;
+- loading;
+- success;
+- warning;
+- error;
+- empty;
+- offline;
+- permission-limited;
+- stale;
+- partial;
+- skeleton;
+- read-only.
+
+Design states before implementation.
+
+### Loading
+Use:
+
+- immediate response to input;
+- skeletons when page structure is known;
+- progress indicators for indeterminate work;
+- percentage or step progress for measurable work;
+- optimistic UI only when rollback is safe;
+- background completion notification for long tasks;
+- cancellation where meaningful.
+
+Avoid fake precision. A progress bar stuck at 99% damages trust.
+
+### Skeletons
+Skeletons should approximate the final layout closely enough to prevent perceived jumping. Do not animate large shimmering regions indefinitely. Respect reduced-motion preferences.
+
+### Empty states
+Differentiate:
+
+- first use;
+- no results;
+- filtered to zero;
+- deleted content;
+- permission restriction;
+- error;
+- offline.
+
+A useful empty state explains what the area is, why it is empty, and the next action. It does not always need illustration.
+
+### Errors
+An error message should answer:
+
+1. What happened?
+2. What was affected?
+3. Was anything saved?
+4. What can the user do?
+5. Where can they get help?
+
+Use a stable error identifier for support in complex systems, but do not expose internals or security-sensitive traces.
+
+### Toasts
+Toasts suit brief, non-critical confirmation. They are poor for:
+
+- information users must act on;
+- destructive failure;
+- long text;
+- irreversible consequences;
+- messages requiring comparison.
+
+Do not make toasts disappear before people can read them. Pause on hover/focus where applicable and announce status accessibly.
+
+### Undo
+For reversible destructive actions, an immediate undo often works better than a confirmation dialog. Use confirmation when consequences are severe, broad, costly, or irreversible.
+
+### Offline and degraded modes
+Explain:
+
+- current connectivity;
+- which data is available;
+- whether edits are queued;
+- when synchronization occurs;
+- conflict behavior;
+- how to retry.
+
+Resilience is part of the experience.
+
+---
+
+## 19. Motion, transitions, scrolling, and 3D
+Motion should explain space, causality, state, or hierarchy. Decoration is secondary.
+
+### Good reasons to animate
+- connect an action to a result;
+- preserve object continuity;
+- reveal hierarchy;
+- orient during navigation;
+- indicate progress;
+- draw attention to a meaningful change;
+- express brand personality during low-risk moments.
+
+### Motion hierarchy
+Define motion tokens for:
+
+- instant feedback;
+- small control transition;
+- component entrance/exit;
+- page transition;
+- ambient loop;
+- celebratory moment.
+
+Example starting points:
+
+```css
+:root {
+  --duration-instant: 80ms;
+  --duration-fast: 140ms;
+  --duration-medium: 240ms;
+  --duration-slow: 420ms;
+  --ease-standard: cubic-bezier(.2, .8, .2, 1);
+  --ease-enter: cubic-bezier(.16, 1, .3, 1);
+  --ease-exit: cubic-bezier(.7, 0, .84, 0);
+}
+```
+
+These are heuristics. Perceived speed depends on distance, size, and context.
+
+### Performance-friendly properties
+Prefer animating `transform` and `opacity` when possible. Layout-changing properties can trigger more work. Measure rather than assuming, and avoid blanket `will-change`; excessive promotion consumes memory.
+
+### Reduced motion
+Provide a meaningful reduced-motion mode:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+A global kill switch is a useful fallback, but a refined product can replace spatial transitions with fades and preserve essential progress indicators.
+
+### Scroll-linked animation
+Use scroll-linked effects when the content genuinely benefits from temporal sequencing. Risks include:
+
+- loss of user control;
+- motion sickness;
+- obscured scroll position;
+- poor keyboard behavior;
+- pinned sections that trap content;
+- mobile jank;
+- inaccessible reading order;
+- overlong narratives.
+
+Ensure the page remains understandable without the effect. Modern CSS scroll-driven animation APIs exist, but support varies by feature; use progressive enhancement.
+
+### Parallax
+Keep depth small and slow. Large opposing movement is visually aggressive. Disable or simplify for reduced motion and small devices.
+
+### Page transitions
+Page transitions can preserve continuity, especially in galleries, product flows, and apps. Do not delay navigation to showcase an animation. Maintain focus, scroll, history, and reduced-motion behavior.
+
+### 3D and WebGL
+Use 3D when it:
+
+- demonstrates a physical product;
+- reveals spatial relationships;
+- supports exploration;
+- embodies the brand idea;
+- creates a memorable but optional hero.
+
+Guardrails:
+
+- static poster fallback;
+- lazy initialization;
+- quality tiers;
+- reduced motion;
+- pause when off-screen;
+- no essential text inside the scene;
+- keyboard-accessible alternative;
+- capped texture size and draw calls;
+- thermal and battery testing;
+- mobile fallback;
+- context-loss handling.
+
+### Cursor effects
+Custom cursors can harm usability and platform familiarity. Use them only as a small enhancement in expressive contexts. Preserve actual pointer affordances, text selection, accessibility, and touch behavior.
+
+### Autoplay and ambient motion
+Ambient loops should pause when off-screen, when the tab is hidden, and under reduced-motion/data conditions where appropriate. Avoid multiple independent loops competing for attention.
+
+### Motion review questions
+- What does this motion explain?
+- Is it interruptible?
+- Does it delay the task?
+- Is the direction spatially coherent?
+- Does focus move correctly?
+- Does it work at 200% zoom?
+- Is there a reduced version?
+- What happens on a low-end phone?
+- What happens when frames drop?
+- Does it survive content length changes?
+
+---
+
+## 20. Tables, dashboards, and data visualization
+Data interfaces should optimize interpretation, comparison, and action.
+
+### Dashboard strategy
+A dashboard is not a wall of charts. Define:
+
+- audience;
+- decisions;
+- monitoring frequency;
+- time horizon;
+- thresholds;
+- actions;
+- data freshness;
+- uncertainty.
+
+Put decision-critical information first.
+
+### Information layers
+A strong dashboard often has:
+
+1. current status;
+2. change over time;
+3. explanation or drivers;
+4. breakdown;
+5. action;
+6. detailed records.
+
+### Metric cards
+A metric card should state:
+
+- metric name;
+- current value;
+- comparison basis;
+- direction;
+- time period;
+- units;
+- freshness;
+- definition or tooltip where ambiguous.
+
+A green arrow is meaningless without knowing whether an increase is good.
+
+### Chart selection
+- **Line:** continuous trend over time.
+- **Bar:** compare discrete categories.
+- **Stacked bar/area:** composition plus total, with caution.
+- **Scatter:** relationship between two measures.
+- **Histogram:** distribution.
+- **Box plot:** distribution summary for expert audiences.
+- **Map:** spatial pattern, not decoration.
+- **Table:** exact values, many dimensions, lookup, or auditing.
+- **Pie/donut:** a few simple parts of a whole; often a bar is easier to compare.
+- **Gauge:** rare; use when a meaningful bounded threshold matters.
+
+### Chart rules
+- Start quantitative axes at zero for bars unless there is a compelling, disclosed reason.
+- Label directly when possible.
+- Limit series.
+- Use annotation for important events.
+- Avoid 3D chart distortion.
+- Show uncertainty and missing data.
+- Make time zones and aggregation explicit.
+- Provide data table or accessible summary.
+- Do not use color alone.
+- Keep interactions keyboard-operable where interactive charts are essential.
+
+### Tables
+Tables need:
+
+- meaningful headers;
+- alignment by data type;
+- sensible column order;
+- sticky headers for long tables;
+- responsive strategy;
+- sorting indication;
+- filtering;
+- pagination or virtualization;
+- row actions;
+- selection model;
+- loading and empty states;
+- accessible captions;
+- scope relationships;
+- no loss of context during horizontal scroll.
+
+Numbers usually align right; text usually aligns left. Use tabular numerals where useful.
+
+### Responsive tables
+Choose based on task:
+
+- horizontal scroll with frozen key column;
+- priority columns;
+- card transformation for simple records;
+- expandable detail;
+- alternate compact view;
+- dedicated mobile workflow.
+
+Do not collapse complex financial tables into unlabeled card piles.
+
+### Data density
+Professional users may value density. Do not impose consumer-style whitespace on workflows requiring comparison. Offer density settings when audiences vary.
+
+### Real-time data
+Show:
+
+- connection status;
+- last updated time;
+- paused state;
+- stale state;
+- sampling interval;
+- alert thresholds;
+- whether values are provisional.
+
+Avoid animating every numerical update.
+
+---
+
+## 21. Trust, persuasion, and ethical conversion
+Trust is built through coherence, evidence, transparency, and respectful behavior.
+
+### Trust signals by context
+- real contact details;
+- clear ownership;
+- understandable policies;
+- secure payment indicators where relevant;
+- independent reviews;
+- named customers with permission;
+- quantified case studies;
+- professional photography;
+- transparent pricing;
+- accessible support;
+- status page;
+- security documentation;
+- certifications with scope and validity;
+- clear returns or cancellation;
+- accurate availability.
+
+### Evidence hierarchy
+Strongest to weakest:
+
+1. verifiable independent evidence;
+2. specific measured outcomes with context;
+3. detailed customer account;
+4. named testimonial;
+5. anonymous testimonial;
+6. unsupported superlative.
+
+Do not invent precision.
+
+### Social proof placement
+Place proof near the claim it supports:
+
+- reliability claim → uptime/status/security;
+- quality claim → detailed review or demonstration;
+- speed claim → measured workflow;
+- fit claim → recognizable use case;
+- enterprise claim → procurement/security material.
+
+A giant logo wall is not a complete trust strategy.
+
+### Pricing honesty
+Show:
+
+- currency;
+- billing period;
+- taxes when knowable;
+- minimum term;
+- usage limits;
+- overages;
+- renewal behavior;
+- cancellation;
+- refund policy;
+- what changes by plan.
+
+Do not hide mandatory fees until the final step.
+
+### Ethical urgency
+Legitimate urgency can be based on:
+
+- real event date;
+- actual inventory;
+- application deadline;
+- genuine capacity;
+- temporary price with stated end.
+
+Do not reset timers, fake viewers, preselect paid add-ons, or make rejection harder than acceptance.
+
+### Consent
+Consent should be:
+
+- informed;
+- specific;
+- freely given;
+- reversible;
+- as easy to decline as accept where required;
+- separated from unrelated terms;
+- recorded appropriately.
+
+Design cookie and privacy controls as real interfaces, not compliance theater.

--- a/plugins/design/skills/web-design/references/04-responsive-accessibility.md
+++ b/plugins/design/skills/web-design/references/04-responsive-accessibility.md
@@ -1,0 +1,405 @@
+# Responsive and Accessible Design
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part IV — Technical quality
+
+## 22. Responsive and adaptive design
+Responsive design is not shrinking a desktop composition. It is deciding what the interface should do at every amount of available space and under varied input, zoom, orientation, and content conditions.
+
+### Design from content pressure
+Choose breakpoints where the design stops working, not from a list of popular devices.
+
+Common pressure points:
+
+- navigation no longer fits;
+- line length becomes uncomfortable;
+- cards become too narrow;
+- controls wrap badly;
+- sidebars squeeze the main task;
+- data loses context;
+- a visual crop stops communicating;
+- fixed actions cover content.
+
+### Start narrow, not “mobile-only”
+A narrow-first implementation often produces cleaner source order and progressive enhancement. Still, design wide states deliberately. A desktop interface is not merely a stretched phone.
+
+### Responsive dimensions beyond width
+Test:
+
+- height;
+- landscape orientation;
+- zoom;
+- text enlargement;
+- pointer precision;
+- hover availability;
+- reduced motion;
+- reduced data;
+- color scheme;
+- contrast preferences;
+- safe-area insets;
+- on-screen keyboard;
+- foldable or split-screen panes;
+- embedded/container contexts.
+
+### Media queries and capability queries
+Use width queries for page-level composition. Use capability queries for interaction assumptions:
+
+```css
+@media (hover: hover) and (pointer: fine) {
+  .card:hover { transform: translateY(-0.125rem); }
+}
+```
+
+Do not hide essential functionality behind hover.
+
+### Container queries
+A component should often respond to its container instead of the viewport:
+
+```css
+.feature {
+  container-type: inline-size;
+}
+
+.feature__inner {
+  display: grid;
+  gap: 1rem;
+}
+
+@container (min-width: 38rem) {
+  .feature__inner {
+    grid-template-columns: 1fr 1.4fr;
+    align-items: center;
+  }
+}
+```
+
+This makes components portable across pages, sidebars, modals, and CMS layouts.
+
+### Responsive ordering
+Visual reordering must not create a confusing reading or focus order. Prefer source order that works linearly, then use layout to enhance it. Avoid using CSS `order` to create a visual sequence radically different from the DOM.
+
+### Viewport units
+Dynamic viewport units help with mobile browser chrome:
+
+- `svh`: small viewport;
+- `lvh`: large viewport;
+- `dvh`: dynamic viewport.
+
+Use them carefully:
+
+```css
+.hero {
+  min-block-size: min(48rem, 100svh);
+}
+```
+
+A hero does not always need to fill the viewport. On short screens, full-height compositions can push all proof below the fold.
+
+### Safe areas
+For full-screen interfaces:
+
+```css
+.app-bar {
+  padding-block-start: max(1rem, env(safe-area-inset-top));
+  padding-inline:
+    max(1rem, env(safe-area-inset-left))
+    max(1rem, env(safe-area-inset-right));
+}
+```
+
+### Responsive images and media
+- provide source dimensions;
+- use `srcset` and `sizes`;
+- art-direct with `<picture>`;
+- lazy-load below-the-fold media;
+- avoid lazy-loading likely LCP content;
+- provide poster frames;
+- cap media width;
+- test crop at every content breakpoint.
+
+### Responsive typography
+Fluid type should have minimum and maximum values. Never use unbounded `vw`.
+
+```css
+.hero-title {
+  font-size: clamp(2.75rem, 1.4rem + 6vw, 7.5rem);
+}
+```
+
+Test at 200% browser zoom and with enlarged default font size.
+
+### Mobile interaction
+- keep primary controls within comfortable reach where appropriate;
+- prevent sticky elements from covering focused fields;
+- ensure the keyboard does not hide submission;
+- provide sufficient touch targets;
+- avoid precision gestures;
+- include non-swipe alternatives;
+- keep back behavior predictable;
+- preserve scroll position after navigation.
+
+### Desktop interaction
+Use available space to improve:
+
+- comparison;
+- preview;
+- multi-selection;
+- context panels;
+- persistent navigation;
+- keyboard shortcuts;
+- drag-and-drop, with alternatives;
+- information density.
+
+Do not inflate every element just because the viewport is wide.
+
+### Responsive test matrix
+At minimum, test:
+
+|Dimension|Cases|
+|---|---|
+|Width|320, 375, 768, 1024, 1280, 1440, very wide|
+|Height|short laptop, landscape phone, tall desktop|
+|Zoom|100%, 200%, 400% where applicable|
+|Text|default, enlarged, long localization|
+|Input|touch, mouse, keyboard, screen reader|
+|Theme|light, dark, forced colors|
+|Motion|normal, reduced|
+|Network|fast, slow, offline/reconnect|
+|Content|empty, typical, extreme, error|
+
+---
+
+## 23. Accessibility and inclusive design
+Accessibility is product quality. Build to **WCAG 2.2 AA** as a practical baseline unless a stricter legal or organizational target applies.
+
+Automated tools catch only a subset of issues. Combine automated checks, keyboard testing, screen-reader testing, zoom/reflow testing, and human evaluation.
+
+### Semantic foundation
+Start with native HTML:
+
+- headings in meaningful order;
+- landmarks such as `header`, `nav`, `main`, `aside`, and `footer`;
+- buttons for actions;
+- links for navigation;
+- lists for lists;
+- tables for tabular data;
+- labels for inputs;
+- `details`/`summary` where suitable;
+- dialogs implemented with correct semantics and focus behavior.
+
+ARIA can communicate missing semantics. It does not repair an interaction model that does not behave like the announced role. Follow the WAI-ARIA Authoring Practices for custom widgets.
+
+### Page structure
+Every page should have:
+
+- a unique, descriptive title;
+- one clear main region;
+- a logical heading outline;
+- meaningful landmarks;
+- a skip link when repeated navigation precedes content;
+- consistent navigation;
+- a declared document language;
+- language changes identified where relevant.
+
+### Keyboard access
+All functionality must be available from a keyboard without requiring a mouse, touch, or drag gesture.
+
+Test:
+
+- logical Tab and Shift+Tab order;
+- visible focus;
+- activation with expected keys;
+- Escape behavior;
+- arrow-key behavior for composite widgets;
+- focus restoration after dialogs;
+- no keyboard traps;
+- access to hidden/revealed controls;
+- no content revealed only on hover.
+
+Do not add positive `tabindex` values to force order. Fix DOM order.
+
+### Focus appearance
+WCAG 2.2 adds stronger focus guidance. A practical target is a clearly visible indicator roughly equivalent to a two-CSS-pixel perimeter with sufficient contrast against adjacent colors.
+
+```css
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+```
+
+Never remove the browser outline without a replacement. Check focus against every surface, not only white.
+
+### Focus management
+Move focus when context changes substantially:
+
+- opening a modal → focus inside, usually heading or first meaningful control;
+- closing a modal → return to trigger;
+- failed long form → error summary;
+- client-side route change → appropriate page start/heading;
+- added content → announce or move focus only when the user's task requires it.
+
+Unexpected focus movement is disruptive. Use it sparingly.
+
+### Target size and spacing
+WCAG 2.2 AA defines a 24 × 24 CSS-pixel minimum target-size rule with exceptions, including equivalent spacing. Treat 24 as a floor. Use larger targets for touch, mobility limitations, destructive actions, and high-frequency controls.
+
+### Contrast
+Test all states:
+
+- default;
+- hover;
+- active;
+- focus;
+- selected;
+- disabled;
+- validation;
+- placeholder;
+- text over media;
+- dark mode;
+- forced colors.
+
+Do not use opacity so low that required text fails contrast. Disabled text is treated differently by WCAG, but it should still be understandable whenever users need to know why something is unavailable.
+
+### Color independence
+Never communicate status only with color. Add:
+
+- text;
+- icon;
+- shape;
+- pattern;
+- position;
+- line style.
+
+Examples: required fields need more than a red border; chart series need more than hue; errors need a message and association.
+
+### Text resizing and reflow
+WCAG requires text to resize to 200% without loss of content or functionality. Reflow criteria also address narrow equivalent viewport widths. Avoid:
+
+- fixed-height text containers;
+- clipped labels;
+- overlays that cannot scroll;
+- two-dimensional page scrolling for ordinary content;
+- sticky elements that consume most of a zoomed viewport.
+
+### Spacing overrides
+Users may override line height, paragraph spacing, letter spacing, and word spacing. Do not use fixed containers or positioning that clips text under these changes.
+
+### Images and media
+- appropriate alt text;
+- empty alt for decorative images;
+- captions for prerecorded speech;
+- transcript where needed;
+- audio description or equivalent for essential visuals;
+- pause/stop/hide for moving content;
+- no content flashing at dangerous frequencies;
+- accessible media controls;
+- no autoplay audio.
+
+### Forms
+- visible labels;
+- programmatic associations;
+- clear instructions;
+- errors in text;
+- suggestions for correction;
+- error summary for complex flows;
+- no loss of data;
+- accessible authentication;
+- status announcements;
+- sufficient time or adjustable limits.
+
+### Hover and focus content
+Tooltips, popovers, and submenus triggered by hover or focus need to be:
+
+- dismissible;
+- hoverable when pointer movement is needed;
+- persistent until dismissed, invalidated, or no longer relevant;
+- keyboard accessible.
+
+Do not put essential instructions only in a tooltip.
+
+### Dragging
+WCAG 2.2 requires a non-drag alternative for functionality that uses dragging, unless dragging is essential. Provide buttons, menus, inputs, or keyboard operations.
+
+### Motion and vestibular safety
+Respect `prefers-reduced-motion`. Avoid:
+
+- large parallax;
+- rapid zoom;
+- automatic panning;
+- scroll hijacking;
+- persistent background movement;
+- flashing;
+- motion tied tightly to every scroll pixel without an alternative.
+
+### Cognitive accessibility
+Support comprehension through:
+
+- consistent patterns;
+- plain labels;
+- visible progress;
+- chunked tasks;
+- recognition over recall;
+- forgiving input;
+- save and resume;
+- clear time limits;
+- predictable help;
+- no memory puzzles;
+- confirmation of consequences.
+
+### Screen-reader testing
+Test at least one common screen reader/browser combination per target platform. Inspect:
+
+- landmark navigation;
+- headings;
+- names, roles, values;
+- reading order;
+- live regions;
+- table navigation;
+- dialog behavior;
+- error announcements;
+- icon-only controls;
+- custom widgets.
+
+Do not interpret “it reads something” as success. The interaction must be understandable and efficient.
+
+### Forced colors and high contrast
+Use system colors where appropriate. Test:
+
+- focus rings;
+- selected states;
+- SVG icons;
+- borders;
+- custom checkboxes/radios;
+- charts;
+- disabled controls;
+- decorative background dependencies.
+
+### Accessibility acceptance checklist
+- [ ] Unique page titles
+- [ ] Correct language
+- [ ] Logical headings
+- [ ] Landmarks and skip link
+- [ ] Native controls where possible
+- [ ] Full keyboard operation
+- [ ] Visible focus
+- [ ] Dialog focus trap and restoration
+- [ ] Text contrast passes
+- [ ] Non-text contrast passes
+- [ ] Information not color-only
+- [ ] Target sizes and spacing
+- [ ] Text zoom and reflow
+- [ ] Reduced motion
+- [ ] Captions/transcripts
+- [ ] Correct alternative text
+- [ ] Labeled forms
+- [ ] Useful error recovery
+- [ ] Drag alternative
+- [ ] Accessible authentication
+- [ ] Automated scan reviewed
+- [ ] Manual screen-reader pass
+- [ ] Accessibility statement and feedback route where appropriate
+
+**Primary references:** [WCAG 2.2](https://www.w3.org/TR/WCAG22/), [WCAG quick reference](https://www.w3.org/WAI/WCAG22/quickref/), and [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/).
+
+---

--- a/plugins/design/skills/web-design/references/05-performance-discoverability-privacy.md
+++ b/plugins/design/skills/web-design/references/05-performance-discoverability-privacy.md
@@ -1,0 +1,526 @@
+# Performance, SEO, Localization, Privacy, and Resilience
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+## 24. Performance and Core Web Vitals
+Performance changes perception, conversion, accessibility, energy use, and product quality. Treat it as a design constraint from the first art-direction decision.
+
+### Current Core Web Vitals targets
+At the 75th percentile of page loads, separately for mobile and desktop, the “good” thresholds are:
+
+|Metric|What it represents|Good threshold|
+|---|---|---:|
+|**LCP**|loading of the largest visible content element|**≤ 2.5 s**|
+|**INP**|responsiveness across interactions|**≤ 200 ms**|
+|**CLS**|unexpected visual instability|**≤ 0.1**|
+
+These thresholds are documented by web.dev. Field data matters because lab tests cannot reproduce every real device, network, cache state, and interaction.
+
+### Set performance budgets
+Create budgets before implementation:
+
+- initial HTML;
+- critical CSS;
+- total CSS;
+- initial JavaScript;
+- total page JavaScript;
+- font bytes and requests;
+- hero media;
+- total image weight;
+- third-party scripts;
+- long tasks;
+- LCP;
+- INP;
+- CLS.
+
+A budget should have an owner and enforcement in CI where possible.
+
+### Loading priorities
+Prioritize:
+
+1. HTML and critical render path;
+2. primary CSS;
+3. LCP media;
+4. essential fonts;
+5. above-the-fold interaction;
+6. below-the-fold content;
+7. analytics and optional enhancements.
+
+Do not lazy-load the likely LCP image. Consider `fetchpriority="high"` for the true hero image, but do not overuse priority hints.
+
+### LCP improvement
+Common LCP work:
+
+- improve server response;
+- cache HTML safely;
+- use a CDN;
+- reduce redirects;
+- render meaningful content server-side or statically;
+- discover the hero asset in initial HTML;
+- avoid loading the hero through late JavaScript;
+- compress and size the hero;
+- preload selectively;
+- reduce render-blocking CSS;
+- load fonts efficiently.
+
+### INP improvement
+Common INP work:
+
+- reduce JavaScript execution;
+- break up long tasks;
+- avoid expensive synchronous handlers;
+- update only affected DOM;
+- virtualize large lists;
+- defer noncritical hydration;
+- use web workers for suitable computation;
+- provide immediate visual feedback;
+- minimize third-party code;
+- profile actual interactions.
+
+An animation that begins instantly but blocks the final result is not responsive.
+
+### CLS prevention
+Reserve space for:
+
+- images;
+- video;
+- ads;
+- embeds;
+- banners;
+- cookie UI;
+- async widgets;
+- web fonts;
+- dynamic notices.
+
+Set `width` and `height` or `aspect-ratio`. Insert new content in predictable places. Avoid pushing the current reading position unexpectedly.
+
+### JavaScript strategy
+Ask of every dependency:
+
+- Is it required?
+- Can the platform do it?
+- Can it load later?
+- Can it run only on relevant pages?
+- Can it be replaced with a smaller module?
+- Does it add main-thread work?
+- What happens when it fails?
+
+Use code splitting by route and behavior. Avoid shipping an entire animation, chart, date, or utility library for one small effect.
+
+### Rendering strategy
+Choose based on content and interaction:
+
+- static generation for stable public content;
+- server rendering for dynamic, indexable pages;
+- streaming for progressive delivery;
+- client rendering for app-like private surfaces where justified;
+- islands or partial hydration for mostly static pages with isolated interaction.
+
+Framework choice does not determine performance; implementation does.
+
+### CSS strategy
+- remove unused CSS;
+- avoid giant global bundles;
+- use cascade layers intentionally;
+- keep selectors understandable;
+- inline only genuinely critical CSS;
+- prevent layout thrash;
+- avoid expensive paint effects over large areas;
+- limit blur, filters, and large fixed backgrounds.
+
+### Font performance
+- limit families and styles;
+- subset carefully;
+- use modern compression;
+- preload only immediate files;
+- choose fallback metrics;
+- use `font-display`;
+- consider system UI fonts for product surfaces;
+- test the visual cost of late swaps.
+
+### Image performance
+- send dimensions appropriate to display;
+- use responsive source selection;
+- compress based on visual tolerance;
+- lazy-load below the fold;
+- decode asynchronously where helpful;
+- remove metadata when appropriate;
+- use content-aware art direction;
+- avoid huge images merely scaled by CSS.
+
+### Third parties
+Third-party scripts can dominate performance and privacy risk. Inventory:
+
+- analytics;
+- tag managers;
+- chat;
+- A/B testing;
+- ads;
+- social embeds;
+- consent managers;
+- personalization;
+- video players.
+
+Load on consent and intent where appropriate. Set budgets and remove tools that no longer earn their cost.
+
+### Performance measurement stack
+Use:
+
+- field Core Web Vitals/RUM;
+- Chrome User Experience Report where available;
+- Lighthouse for repeatable lab diagnostics;
+- browser performance profiles;
+- network waterfall;
+- coverage tools;
+- bundle analysis;
+- synthetic tests on representative devices;
+- real low-end hardware;
+- throttled and unstable networks.
+
+### Performance and visual ambition
+Rich visuals are possible when orchestrated:
+
+- render a static first frame immediately;
+- progressively initialize;
+- use lower fidelity on constrained devices;
+- suspend off-screen work;
+- pause hidden tabs;
+- preload only likely assets;
+- make immersion optional;
+- preserve navigation and content before effects.
+
+### Practical budgets by project style
+These are heuristics, not standards:
+
+|Project|Initial experience priority|
+|---|---|
+|Editorial/content|HTML and text extremely early; minimal JS|
+|E-commerce|fast product imagery, filters, cart stability|
+|SaaS marketing|strong hero with restrained script|
+|Dashboard|interaction latency and incremental data|
+|Portfolio/showcase|static poster first, progressive effects|
+|Campaign|bounded experience with explicit fallback|
+
+---
+
+## 25. SEO, structured data, and discoverability
+SEO starts with useful content, crawlable structure, stable URLs, and good page experience. Visual design should strengthen these properties.
+
+### Technical foundation
+- indexable HTML for public content;
+- unique title and meta description;
+- canonical URLs;
+- correct status codes;
+- crawlable links;
+- XML sitemap where useful;
+- robots controls used deliberately;
+- mobile parity;
+- HTTPS;
+- no essential content available only after fragile interaction;
+- accessible heading structure;
+- fast, stable pages.
+
+### Mobile-first indexing
+Google primarily uses the mobile version of content for indexing. Ensure mobile has:
+
+- equivalent primary content;
+- equivalent meaningful alt text;
+- equivalent structured data;
+- crawlable media;
+- no blocked critical resources;
+- sensible lazy loading;
+- the same metadata intent.
+
+Do not remove substantive content from mobile solely to make the layout sparse. Collapse it carefully when appropriate, but keep it available.
+
+### On-page content
+A page should have:
+
+- a clear topic;
+- descriptive title;
+- one main heading;
+- useful subheadings;
+- direct answer or proposition;
+- supporting detail;
+- contextual internal links;
+- meaningful media;
+- authorship and freshness where relevant.
+
+Write for people who arrive with a specific need. Keyword repetition is not a design strategy.
+
+### Structured data
+Use structured data that matches visible page content and a supported type, such as:
+
+- Product;
+- Article;
+- Event;
+- Organization;
+- LocalBusiness;
+- BreadcrumbList;
+- Recipe;
+- JobPosting;
+- Course;
+- VideoObject.
+
+Validate it and keep it synchronized with displayed information. Structured data can make content eligible for enhanced search appearances; it does not guarantee them.
+
+### Internal linking
+Design links into:
+
+- topic hubs;
+- related content;
+- breadcrumbs;
+- navigation;
+- article context;
+- product alternatives;
+- next steps.
+
+Avoid orphaned pages.
+
+### Image and video discoverability
+- descriptive filenames where practical;
+- proper alt text;
+- captions/context;
+- image sitemaps for image-heavy sites when useful;
+- stable media URLs;
+- video metadata and transcripts;
+- poster frames;
+- fast delivery.
+
+### Page experience
+Google’s guidance considers overall page experience, but no single visual or performance score guarantees ranking. Optimize for real usability: Core Web Vitals, mobile experience, secure delivery, non-intrusive overlays, and accessible content.
+
+### AI-assisted search and answer systems
+The durable strategy remains:
+
+- publish original, useful material;
+- make entities and relationships clear;
+- provide direct summaries;
+- expose evidence;
+- use structured headings;
+- keep crawlable text;
+- identify authors and sources;
+- update stale content;
+- avoid mass-produced generic pages.
+
+Answer-first summaries can help both people and retrieval systems, especially on technical, support, and informational pages.
+
+### Avoid SEO-driven UX damage
+Do not:
+
+- create giant introductory blocks that bury the task;
+- repeat near-identical copy across categories;
+- add FAQ accordions with no user need;
+- use misleading headings;
+- interrupt immediately with overlays;
+- create location pages without genuine local value;
+- hide content through inaccessible widgets.
+
+---
+
+## 26. Internationalization and localization
+Internationalization is an architecture concern, not a final translation step.
+
+### Design for expansion
+Translated text may be much longer or shorter. Test:
+
+- buttons;
+- navigation;
+- tabs;
+- cards;
+- forms;
+- dialogs;
+- tables;
+- charts;
+- captions;
+- badges;
+- empty states.
+
+Avoid fixed widths and single-line assumptions.
+
+### Writing and content
+- avoid idioms in critical instructions;
+- keep sentences structurally clear;
+- separate text from code;
+- use placeholders rather than concatenating fragments;
+- provide translator context;
+- allow grammatical variation;
+- localize images containing text;
+- use real locale data.
+
+### Dates and time
+Display:
+
+- local date order;
+- month names where ambiguity matters;
+- 12/24-hour conventions;
+- time zone for remote events;
+- daylight-saving behavior;
+- relative time with an exact value available.
+
+“Tomorrow at 9” can be dangerously ambiguous across zones.
+
+### Numbers and currency
+Use locale-aware formatting. Clarify:
+
+- decimal separator;
+- grouping;
+- currency symbol/code;
+- tax inclusion;
+- conversion;
+- measurement units;
+- rounding.
+
+Do not assume currency from language alone.
+
+### Names and addresses
+- avoid forcing first/last-name models unnecessarily;
+- permit diacritics and non-Latin scripts;
+- handle variable address structures;
+- do not assume postal codes exist;
+- do not require state/province universally;
+- support local phone formats;
+- validate flexibly.
+
+### Right-to-left design
+For Arabic, Hebrew, and other RTL contexts:
+
+- mirror layout flow where appropriate;
+- keep media controls and universally directional symbols logical;
+- use CSS logical properties;
+- test mixed-direction content;
+- inspect icons such as arrows and progress;
+- support bidi isolation for user-generated text.
+
+```css
+.card {
+  margin-inline-start: 1rem;
+  padding-inline: 1.25rem;
+  border-inline-start: 3px solid var(--accent);
+}
+```
+
+### Font coverage
+Select fonts with required scripts or plan compatible fallbacks. Matching weight, proportions, and tone across scripts requires art direction, not merely glyph availability.
+
+### Locale selection
+- use a recognizable language/region control;
+- name languages in their own language where useful;
+- preserve current page when switching;
+- do not rely only on flags;
+- remember preference;
+- allow users to override automatic detection.
+
+### Cultural adaptation
+Review:
+
+- imagery;
+- gesture;
+- color connotations;
+- icons;
+- examples;
+- humor;
+- formality;
+- reading conventions;
+- regulatory text;
+- payment methods;
+- address and fulfillment expectations.
+
+Localization may require content and flow changes, not word substitution.
+
+---
+
+## 27. Privacy, security, resilience, and consent
+Security and privacy affect interface design directly.
+
+### Secure interaction principles
+- explain why sensitive data is requested;
+- minimize collection;
+- mask only where useful;
+- let users verify critical values;
+- show secure context without theatrical padlocks;
+- preserve password-manager compatibility;
+- provide session-expiry warning;
+- make device/session management understandable;
+- avoid exposing account existence unnecessarily;
+- protect destructive actions;
+- log important account changes visibly.
+
+### Authentication UX
+Offer suitable options:
+
+- passkeys;
+- password manager–friendly passwords;
+- magic links where risk allows;
+- authenticator apps;
+- recovery codes;
+- federated sign-in with clear consequences.
+
+Do not use email or SMS one-time codes without handling delays, autofill, resend timing, and changed contact details.
+
+### Permissions
+Ask permissions in context, after explaining value. Do not request camera, location, notifications, clipboard, or contacts on first load without a clear need.
+
+### Consent interface
+A consent choice should not use:
+
+- a bright “accept” and hidden “reject”;
+- preselected optional categories;
+- confusing double negatives;
+- repeated nagging after a valid refusal;
+- bundled unrelated purposes;
+- inaccessible modal behavior.
+
+### Privacy by default
+Default to the least data necessary. Make retention, deletion, export, and communication preferences findable.
+
+### Resilience
+Design for:
+
+- slow APIs;
+- partial failures;
+- stale cache;
+- offline mode;
+- authentication expiry;
+- duplicate actions;
+- retries;
+- rate limits;
+- service degradation;
+- conflict resolution.
+
+### Destructive actions
+Use escalating friction:
+
+|Consequence|Pattern|
+|---|---|
+|easily reversible|action + undo|
+|moderate and localized|concise confirmation|
+|broad or costly|detailed confirmation with impact|
+|irreversible/high risk|reauthentication, explicit item name, delay or recovery window|
+
+Typed confirmation should be reserved for serious consequences; overuse becomes ritual.
+
+### User-generated content
+Plan:
+
+- reporting;
+- blocking;
+- moderation state;
+- content warnings;
+- appeals;
+- rate limiting;
+- privacy controls;
+- identity visibility;
+- deletion and archival;
+- accessible moderation tools.
+
+### Security messages
+Be specific enough to help, but do not reveal exploitable detail. Provide:
+
+- affected action;
+- current state;
+- safe next step;
+- support route;
+- timestamp;
+- device/location context for account events.
+
+---

--- a/plugins/design/skills/web-design/references/06-systems-implementation.md
+++ b/plugins/design/skills/web-design/references/06-systems-implementation.md
@@ -1,0 +1,671 @@
+# Systems and Implementation
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part V — Systems and implementation
+
+## 28. Design tokens
+Tokens encode decisions so they can be reused across design and code.
+
+### Token layers
+A mature token system often has three layers:
+
+1. **Primitive:** raw values such as blue-600, space-4, radius-8.
+2. **Semantic:** roles such as text-primary, action-primary, surface-raised.
+3. **Component:** local decisions such as button-primary-background.
+
+Prefer semantic tokens in application code. Primitive names leak implementation and make themes harder.
+
+### Token categories
+- color;
+- typography;
+- spacing;
+- size;
+- radius;
+- border;
+- shadow/elevation;
+- opacity;
+- z-index;
+- motion duration;
+- easing;
+- breakpoint/container;
+- data visualization;
+- focus;
+- density.
+
+### Example
+```css
+@layer tokens {
+  :root {
+    --color-neutral-0: oklch(100% 0 0);
+    --color-neutral-950: oklch(16% 0.02 260);
+    --color-brand-600: oklch(56% 0.2 260);
+
+    --color-canvas: var(--color-neutral-0);
+    --color-text: var(--color-neutral-950);
+    --color-action: var(--color-brand-600);
+    --color-focus: oklch(72% 0.18 90);
+
+    --radius-control: 0.625rem;
+    --radius-surface: 1rem;
+    --shadow-raised: 0 0.5rem 2rem rgb(0 0 0 / 0.12);
+  }
+
+  [data-theme="dark"] {
+    --color-canvas: var(--color-neutral-950);
+    --color-text: var(--color-neutral-0);
+  }
+}
+```
+
+### Naming
+Names should describe intent and state:
+
+```text
+color.action.primary.default
+color.action.primary.hover
+color.text.muted
+space.component.card
+motion.duration.fast
+```
+
+Avoid names such as `pretty-blue`, `homepage-gap`, or `gray-3` in component APIs.
+
+### Governance
+For each token change:
+
+- document rationale;
+- preview affected components;
+- test themes and contrast;
+- version breaking changes;
+- provide migration;
+- avoid creating a token for every one-off value.
+
+Tokens are not useful if teams routinely bypass them.
+
+### Cross-platform tokens
+Store platform-neutral source data and transform it for CSS, native platforms, design tools, and documentation. Watch for units and capabilities that do not map exactly.
+
+---
+
+## 29. Component architecture
+A component is a reusable behavioral and visual contract.
+
+### Good component boundaries
+A component should have:
+
+- a coherent responsibility;
+- a stable API;
+- defined states;
+- accessibility behavior;
+- content constraints;
+- responsive behavior;
+- theme support;
+- test coverage.
+
+Do not abstract a pattern after seeing it once. Abstract when repetition and variation are understood.
+
+### Composition over giant variants
+Prefer small composable parts:
+
+```jsx
+<Card>
+  <Card.Media />
+  <Card.Header>
+    <Card.Eyebrow />
+    <Card.Title />
+  </Card.Header>
+  <Card.Body />
+  <Card.Actions />
+</Card>
+```
+
+Avoid a single component with dozens of Boolean props that create impossible combinations.
+
+### State model
+Document state explicitly. For a button:
+
+```ts
+type ButtonState =
+  | { kind: "idle" }
+  | { kind: "loading"; label: string }
+  | { kind: "success"; label: string }
+  | { kind: "error"; message: string };
+```
+
+State machines are useful for complex components such as uploads, checkout, authentication, and async workflows.
+
+### Controlled flexibility
+Define safe extension points:
+
+- slots;
+- variants;
+- size;
+- density;
+- semantic color;
+- media;
+- actions;
+- layout mode.
+
+Do not expose every CSS property through props.
+
+### Component documentation
+Include:
+
+- purpose;
+- anatomy;
+- variants;
+- content rules;
+- interaction;
+- accessibility;
+- responsive behavior;
+- do/don’t examples;
+- code;
+- status;
+- owner;
+- related patterns;
+- change log.
+
+### Headless and styled layers
+A headless behavior layer can separate semantics/state from visual styling. This works well when multiple brands need the same accessible interactions. Ensure the styling layer cannot accidentally omit required states or structure.
+
+### Native first
+Before building a custom select, date picker, menu, dialog, or disclosure, assess whether native HTML meets the need. Custom controls carry a large accessibility and maintenance obligation.
+
+### CMS components
+CMS blocks need stricter constraints than developer components:
+
+- bounded options;
+- content previews;
+- validation;
+- meaningful names;
+- safe defaults;
+- responsive behavior;
+- no arbitrary layout controls that allow editors to break hierarchy.
+
+### Component acceptance template
+```markdown
+## Component: [name]
+
+Purpose:
+Anatomy:
+Required content:
+Optional content:
+Variants:
+States:
+Keyboard behavior:
+Screen-reader behavior:
+Responsive behavior:
+Motion:
+Performance constraints:
+Localization constraints:
+Analytics:
+Tests:
+Owner:
+```
+
+---
+
+## 30. CSS architecture and modern platform capabilities
+Modern CSS can replace substantial JavaScript and reduce coupling when used progressively.
+
+### Cascade layers
+Define precedence intentionally:
+
+```css
+@layer reset, tokens, base, components, utilities, overrides;
+```
+
+This makes specificity less accidental.
+
+### Nesting
+Native nesting can improve locality, but deep nesting recreates the same complexity as preprocessors.
+
+```css
+.card {
+  border: 1px solid var(--border);
+
+  & > header {
+    display: flex;
+  }
+
+  &:has(input:focus-visible) {
+    border-color: var(--focus);
+  }
+}
+```
+
+Keep nesting shallow and readable.
+
+### Logical properties
+Use logical properties for writing-mode resilience:
+
+- `margin-inline`;
+- `padding-block`;
+- `inset-inline-start`;
+- `border-block-end`;
+- `inline-size`;
+- `block-size`.
+
+### Container queries
+Use them for component adaptation, not as a replacement for every media query. Name containers where nested contexts need clarity.
+
+### Subgrid
+Subgrid helps repeated card content align across rows:
+
+```css
+.card {
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 4;
+}
+```
+
+Use a fallback if your support matrix requires it.
+
+### Relational selectors
+`:has()` can express parent state without JavaScript:
+
+```css
+.field:has(:invalid:not(:placeholder-shown)) {
+  --field-border: var(--danger);
+}
+```
+
+Be careful with validation timing and selector scope.
+
+### View transitions
+View Transition APIs can animate between states or documents where supported. Treat cross-document transitions as progressive enhancement because support varies. Preserve reduced-motion behavior, focus, history, and immediate navigation.
+
+### Color capabilities
+Use modern color functions behind tested fallbacks when your browser matrix requires it:
+
+```css
+.button {
+  background: #405cf5;
+  background: oklch(58% 0.22 265);
+}
+```
+
+### CSS architecture choices
+Common approaches include:
+
+- global semantic CSS;
+- BEM-style naming;
+- CSS Modules;
+- scoped component styles;
+- utility classes;
+- CSS-in-JS;
+- generated atomic CSS.
+
+Choose based on team, runtime, theming, extraction, and product lifetime. Evaluate:
+
+- output size;
+- caching;
+- server rendering;
+- runtime cost;
+- token integration;
+- developer ergonomics;
+- debugging;
+- ownership;
+- portability.
+
+No naming methodology substitutes for good component boundaries.
+
+### Progressive enhancement
+Build:
+
+1. semantic content and form submission;
+2. CSS layout;
+3. modest interaction;
+4. rich enhancement.
+
+A product does not need to work identically without JavaScript, but critical content, navigation, and recovery should degrade deliberately.
+
+### Feature support
+Use:
+
+```css
+@supports (container-type: inline-size) {
+  /* enhancement */
+}
+```
+
+Check current browser support through authoritative compatibility data. “Baseline” status can help distinguish widely available features from newly interoperable or limited ones.
+
+### Avoid CSS performance folklore
+Measure actual bottlenecks. Selector micro-optimization is rarely more important than:
+
+- huge DOM;
+- layout thrashing;
+- expensive paint;
+- large blurred layers;
+- frequent style invalidation;
+- animation of layout-heavy properties;
+- unbounded content;
+- unused bundles.
+
+---
+
+## 31. Content models and CMS design
+A CMS should store meaning, not screenshots of layouts.
+
+### Model content semantically
+Prefer fields such as:
+
+- title;
+- summary;
+- body;
+- author;
+- date;
+- category;
+- media;
+- caption;
+- CTA label/destination;
+- product data;
+- testimonial source;
+- legal qualifier.
+
+Avoid one giant rich-text field for the entire page when content needs reuse, search, personalization, or structured display.
+
+### Structured content versus blocks
+Use structured content for stable entities and relationships. Use bounded page blocks for editorial composition. Combine them carefully.
+
+Example:
+
+- `CaseStudy` entity with client, challenge, outcomes, services, quotes, media;
+- page builder that can reference case studies in a featured grid.
+
+### Content constraints
+Set:
+
+- character guidance;
+- required fields;
+- image aspect ratios;
+- alternative text;
+- link validation;
+- publication state;
+- ownership;
+- review date;
+- localization status.
+
+Character counts should guide, not force awkward copy. Design must survive realistic variance.
+
+### Preview
+Preview should include:
+
+- representative breakpoints;
+- dark/light theme if applicable;
+- draft state;
+- localization;
+- missing/long content;
+- scheduled content.
+
+### Editorial workflow
+Define:
+
+- draft;
+- review;
+- legal/compliance;
+- accessibility check;
+- scheduled;
+- published;
+- expired;
+- archived.
+
+A page without an owner becomes stale.
+
+### Content debt
+Track:
+
+- duplicate pages;
+- broken links;
+- stale claims;
+- outdated screenshots;
+- missing alt text;
+- orphaned content;
+- inconsistent terminology;
+- unowned pages.
+
+Treat content debt like code debt.
+
+---
+
+## 32. Design-to-development workflow
+High visual quality comes from iteration between design and implementation, not a one-way handoff.
+
+### Recommended sequence
+1. brief and constraints;
+2. content and IA;
+3. low-fidelity flows;
+4. visual territories;
+5. selected direction;
+6. tokens and primitives;
+7. responsive prototypes;
+8. component states;
+9. implementation;
+10. joint review in browser;
+11. accessibility/performance hardening;
+12. launch and measurement.
+
+### Visual territories
+Create two or three meaningfully different directions, not minor color variations. Each should explain:
+
+- brand traits;
+- typography;
+- color logic;
+- imagery;
+- composition;
+- motion;
+- suitability;
+- risks;
+- cost.
+
+### Prototype the risky thing first
+Risk may be:
+
+- 3D hero;
+- complex data table;
+- localization;
+- checkout;
+- scroll narrative;
+- collaborative editor;
+- unusual navigation;
+- large media catalog.
+
+Do not spend weeks polishing ordinary cards before proving the risky core.
+
+### Browser as design material
+Inspect actual:
+
+- font rendering;
+- line breaks;
+- browser controls;
+- touch behavior;
+- sticky positioning;
+- loading sequence;
+- animation timing;
+- input autofill;
+- focus;
+- real content;
+- low-end performance.
+
+A static canvas cannot show these accurately.
+
+### Handoff specification
+Provide:
+
+- tokens;
+- component anatomy;
+- states;
+- responsive rules;
+- content constraints;
+- motion timing;
+- asset exports;
+- image crops;
+- accessibility requirements;
+- interaction notes;
+- empty/error/loading states;
+- test cases.
+
+Avoid redline documents that freeze pixels without explaining behavior.
+
+### Design QA
+Designers should review the implementation in the browser across breakpoints and states. Engineers should participate before visual decisions are fixed. Use one issue system with screenshots, expected behavior, severity, and ownership.
+
+### Definition of done
+A component is not done when the default state matches a mockup. It is done when:
+
+- all states work;
+- keyboard behavior works;
+- responsive behavior works;
+- localization works;
+- content extremes work;
+- tests pass;
+- performance cost is acceptable;
+- documentation exists;
+- analytics and privacy needs are met.
+
+---
+
+## 33. Testing and quality assurance
+Test the experience as a system.
+
+### Test pyramid for interfaces
+**Static and automated**
+
+- linting;
+- type checks;
+- unit tests;
+- accessibility rules;
+- component tests;
+- visual regression;
+- bundle budgets;
+- broken-link scans;
+- HTML validation;
+- structured-data validation.
+
+**Integration**
+
+- form flows;
+- authentication;
+- search/filter;
+- cart/checkout;
+- permissions;
+- error handling;
+- analytics events;
+- localization;
+- API failure states.
+
+**Human evaluation**
+
+- keyboard;
+- screen reader;
+- zoom/reflow;
+- touch;
+- usability;
+- content review;
+- visual craft;
+- low-end performance;
+- assistive technology;
+- real-user research.
+
+### Content stress tests
+Use:
+
+- empty content;
+- one item;
+- hundreds of items;
+- long names;
+- long translated strings;
+- missing image;
+- broken image;
+- very tall image;
+- unexpected markup;
+- user-generated text;
+- huge number;
+- negative number;
+- zero;
+- unknown value;
+- old date;
+- future date.
+
+### Visual regression
+Capture:
+
+- key breakpoints;
+- themes;
+- states;
+- focus;
+- validation;
+- loading;
+- empty;
+- modal;
+- menus;
+- long content.
+
+Do not approve snapshots blindly. A stable wrong screenshot is still wrong.
+
+### Browser/device strategy
+Choose from actual audience data, then include:
+
+- current major engines;
+- iOS Safari;
+- Android Chrome;
+- keyboard desktop;
+- low-end Android where relevant;
+- high-DPI and ordinary screens;
+- touch laptop/tablet if used;
+- embedded webviews if part of the product.
+
+### Network and failure tests
+- slow 3G/4G simulation;
+- high latency;
+- request timeout;
+- partial response;
+- failed image;
+- failed analytics;
+- expired token;
+- server error;
+- offline then reconnect;
+- duplicated submission;
+- stale data.
+
+### Accessibility QA sequence
+1. inspect semantics;
+2. run automated tools;
+3. keyboard-only pass;
+4. zoom/reflow;
+5. forced colors;
+6. reduced motion;
+7. screen-reader flows;
+8. test errors and dynamic content;
+9. test with disabled users where possible;
+10. document residual issues and owners.
+
+### Performance QA sequence
+1. establish field baseline;
+2. test representative page templates;
+3. inspect waterfall;
+4. identify LCP element;
+5. profile interactions;
+6. review long tasks;
+7. test CLS during full lifecycle;
+8. inspect fonts/media;
+9. audit third parties;
+10. enforce budgets.
+
+### Release gates
+Block release for:
+
+- inaccessible core task;
+- data loss;
+- severe security/privacy defect;
+- broken checkout or authentication;
+- keyboard trap;
+- unreadable contrast in critical content;
+- catastrophic performance regression;
+- legal misinformation;
+- crash loop;
+- unhandled destructive action.
+
+Log lower-severity craft defects with owners rather than accepting permanent “later.”

--- a/plugins/design/skills/web-design/references/07-website-types-technology-commerce.md
+++ b/plugins/design/skills/web-design/references/07-website-types-technology-commerce.md
@@ -1,0 +1,399 @@
+# Website Type Playbooks: Technology, Commerce, Editorial, and Documentation
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part VI — Website-type playbooks
+Each playbook is a starting model, not a template. Blend them when a product crosses categories. A marketplace for healthcare appointments, for example, inherits obligations from marketplace, healthcare, and public-service patterns.
+
+## 34. SaaS and AI product marketing
+
+### Primary job
+Turn a partially informed visitor into an activated trial, qualified lead, or confident buyer by making an unfamiliar product concrete.
+
+### Audiences
+End users evaluating personal fit, team leads evaluating workflow fit, technical reviewers, procurement, and executives. Each needs a different depth of explanation.
+
+### Recommended information architecture
+- A plain-language proposition that names the audience, task, and outcome.
+- An immediate product view: real interface, short guided demo, or credible workflow animation.
+- Three to five outcome-led capabilities rather than an exhaustive feature grid.
+- Use-case paths for distinct roles or industries.
+- Evidence: customer outcomes, integrations, security, reliability, and implementation detail.
+- Pricing or a clear route to pricing; enterprise paths should state what happens after contact.
+- FAQ focused on objections, limitations, migration, support, and data handling.
+- A low-friction activation CTA repeated after sufficient proof.
+
+### Visual direction
+Use product-led art direction: sharp interface crops, purposeful motion, strong diagrams, and a restrained brand field. Generative-AI products should avoid interchangeable violet gradients and floating sparkles unless those are genuinely owned brand assets.
+
+### Essential components
+- Interactive demo with a skip and static fallback
+- Use-case switcher with URL-addressable states
+- Integration gallery and technical architecture diagram
+- Comparison table
+- Security and privacy summary
+- Transparent trial/signup module
+
+### Trust and inclusion
+- Show real outputs, including boundaries and failure cases.
+- State whether data trains models, how content is retained, and which controls exist.
+- Name metrics, sample size, and time period in case studies.
+- For AI, identify generated content, confidence, review requirements, and human override.
+
+### Avoid
+- An abstract hero that never says what the product does
+- Endless feature cards with no workflow
+- Fabricated chat conversations
+- Autoplay demos that steal scroll or keyboard focus
+- Calling every capability “AI-powered” without practical meaning
+- Hiding pricing behind a sales form for ordinary self-serve plans
+
+### Useful measures
+Qualified conversion, trial activation, time to first value, demo engagement, signup completion, sales-qualified lead rate, and support questions before purchase.
+
+---
+
+## 35. Enterprise and B2B
+
+### Primary job
+Help a buying group establish fit, business value, technical viability, and organizational safety.
+
+### Audiences
+Champions, operators, IT, security, legal, finance, procurement, and senior decision-makers. Expect multiple visits and shared links.
+
+### Recommended information architecture
+- Specific proposition by operational problem or industry.
+- Role-based and industry-based paths without duplicating generic pages.
+- Business outcomes supported by credible case studies.
+- Product architecture, integrations, deployment, administration, and migration.
+- Security, privacy, compliance, accessibility, and procurement material.
+- Implementation process, support model, and service expectations.
+- Pricing logic or at least buying model and qualification criteria.
+- Contact path that sets expectations for response and discovery.
+
+### Visual direction
+Calm authority works better than “corporate blue plus stock handshake.” Use distinctive editorial typography, precise diagrams, real customer environments, and structured white space. Dense information can still feel premium through alignment and hierarchy.
+
+### Essential components
+- Solution map by role and industry
+- Case-study library with measurable outcomes
+- Security/trust center
+- Architecture and integration diagrams
+- ROI model with transparent assumptions
+- Resource center and downloadable procurement pack
+- Account-based but privacy-respectful personalization
+
+### Trust and inclusion
+- Name legal entities and contact routes.
+- Keep certifications current and describe scope.
+- Provide status, subprocessors, data residency, accessibility conformance, and incident practices.
+- Use customer logos only with permission and pair them with actual evidence.
+
+### Avoid
+- Vague transformation language
+- Stock photography that misrepresents customers
+- Dozens of near-identical SEO solution pages
+- Lead forms that ask for budget and phone before providing value
+- Security claims with no documentation
+- Animated diagrams that cannot be paused or read
+
+### Useful measures
+Qualified pipeline, content-assisted opportunity rate, security-document self-service, form completion, sales-cycle length, return visits by account, and influenced revenue.
+
+---
+
+## 36. E-commerce
+
+### Primary job
+Help shoppers find, evaluate, purchase, receive, and potentially return the right product with minimal uncertainty.
+
+### Audiences
+Known-item shoppers, browsers, comparison shoppers, gift buyers, repeat customers, and support-seeking customers.
+
+### Recommended information architecture
+- Search and category navigation grounded in how customers describe products.
+- Category pages with useful filters, sorting, availability, and comparison.
+- Product pages with strong media, price, variants, delivery, returns, and proof.
+- Persistent but non-coercive cart access.
+- Checkout with the fewest necessary fields, guest purchase, autofill, and clear totals.
+- Order confirmation, tracking, changes, returns, and support.
+- Account features that improve repeat purchase without making an account mandatory.
+
+### Visual direction
+Let products dominate. Build a visual system around image ratios, crop rules, typography, and merchandising modules. Use editorial moments selectively; keep filters, variants, cart, and checkout conventional and fast.
+
+### Essential components
+- Predictive search with useful categories
+- Filter system with active-filter summary
+- Variant selector with unavailable-state clarity
+- Image gallery with zoom and video
+- Delivery/collection estimator
+- Review distribution and verified-detail views
+- Cart drawer plus full cart
+- Address and payment forms with autocomplete
+
+### Trust and inclusion
+- Show total cost, shipping, taxes, return terms, stock, and delivery before commitment where possible.
+- Use honest reviews and explain moderation.
+- Keep product imagery consistent with delivered goods.
+- Provide accessible customer service and clear company identity.
+
+### Avoid
+- Surprise fees
+- Forced account creation
+- Preselected add-ons
+- Fake scarcity or resetting countdowns
+- Variant selection through color swatches alone
+- Low-resolution or misleading product media
+- Blocking the screen with discount popups on arrival
+- Removing cart items after navigation without clear reason
+
+### Useful measures
+Product-findability, product-page add-to-cart, checkout completion, field error rate, search success, return rate, support contact, repeat purchase, and Core Web Vitals by template.
+
+---
+
+## 37. Marketplace
+
+### Primary job
+Create enough liquidity and trust for two or more participant groups to discover, transact, and resolve problems.
+
+### Audiences
+Buyers, sellers/providers, moderators, and sometimes advertisers, logistics partners, or institutions.
+
+### Recommended information architecture
+- Clear explanation of inventory, coverage, fees, and participant responsibilities.
+- Search/browse with location, availability, category, price, reputation, and other relevant filters.
+- Rich listing profiles with comparable attributes.
+- Transparent reputation and review systems.
+- Messaging, offer, booking, or purchase flow.
+- Payment, escrow, cancellation, dispute, and safety information.
+- Seller/provider onboarding and inventory management.
+- Reporting, moderation, and support.
+
+### Visual direction
+Use the marketplace’s inventory as the visual language. Standardize listing photography and structured facts enough for comparison, while preserving seller identity. Maps, availability, and reputation should be legible, not decorative.
+
+### Essential components
+- Location-aware search with manual override
+- Listing cards with normalized key facts
+- Saved search and alerts
+- Availability calendar
+- Messaging with safety boundaries
+- Review breakdown and response
+- Identity or credential verification
+- Dispute and report flows
+
+### Trust and inclusion
+- Explain what verification does and does not prove.
+- Separate platform guarantees from seller claims.
+- Show fees before commitment.
+- Design visible moderation states and appeal routes.
+- Protect personal contact and exact location until appropriate.
+
+### Avoid
+- Ranking that hides sponsorship
+- Dark patterns that pressure off-platform communication or add-on purchase
+- Reviews with no context
+- Unclear cancellation responsibility
+- Map-only discovery
+- Allowing listings to omit essential comparable information
+
+### Useful measures
+Search-to-contact/purchase, inventory activation, match rate, time to first transaction, cancellation, dispute rate, repeat participation, safety reports, and marketplace balance.
+
+---
+
+## 38. Portfolio
+
+### Primary job
+Make a creator’s judgment, process, range, and fit memorable enough to start a relevant conversation.
+
+### Audiences
+Clients, hiring managers, collaborators, curators, press, and peers. Many will scan quickly before opening one or two projects.
+
+### Recommended information architecture
+- A concise identity and specialty statement.
+- A tightly edited project selection.
+- Case-study pages with role, constraints, process, decisions, and outcome.
+- About and capabilities.
+- Recognizable contact route and availability context.
+- Optional archive for breadth without weakening the featured set.
+
+### Visual direction
+The work should lead, but the portfolio itself demonstrates taste. Use a strong typographic voice, purposeful project sequencing, generous media, and one signature interaction. Photographers and filmmakers should optimize image quality and pacing without turning every page into a heavy slideshow.
+
+### Essential components
+- Project index with multiple useful views
+- Media viewer that preserves browser controls and URLs
+- Credits and role metadata
+- Before/after or process comparison
+- Case-study chapter navigation
+- Contact CTA tied to project type
+
+### Trust and inclusion
+- State your exact contribution on collaborative work.
+- Credit collaborators.
+- Distinguish shipped work from concepts.
+- Use real outcomes where available and protect confidential details honestly.
+
+### Avoid
+- Mystery navigation
+- Loading gates before any work appears
+- Every project autoplaying simultaneously
+- Tiny type and invisible cursor experiments
+- Case studies that are only final images
+- Thirty mediocre projects instead of eight strong ones
+- Contact details available only through a social platform
+
+### Useful measures
+Relevant inquiries, project-depth viewed, case-study completion, contact conversion, returning visitors, downloads where intended, and media performance.
+
+---
+
+## 39. Creative agency and studio
+
+### Primary job
+Demonstrate a distinctive point of view and credible delivery capability while attracting the right projects and talent.
+
+### Audiences
+Prospective clients, procurement, creative collaborators, recruits, press, and award/research audiences.
+
+### Recommended information architecture
+- Point of view and category of work.
+- Selected cases with business and creative context.
+- Capabilities expressed through outcomes and methods.
+- Client proof and working model.
+- Team, culture, and geography.
+- Contact route with project-fit guidance.
+- Optional journal, experiments, or process material.
+
+### Visual direction
+A studio site can be experimental, but the experiment should embody its practice. Use a controlled art system, unusual transitions, variable project layouts, and strong media. Keep core navigation and contact stable.
+
+### Essential components
+- Featured-case reel with manual control
+- Project taxonomy by discipline or sector
+- Case-study narrative modules
+- Credits and partner network
+- Capabilities matrix
+- Careers and studio-life content
+- Plain HTML fallback or low-motion mode for immersive work
+
+### Trust and inclusion
+- Show the team doing the work, not only awards.
+- Clarify scope and role in cases.
+- Pair aesthetic acclaim with evidence of outcomes and delivery.
+- Make accessibility and performance part of the craft claim.
+
+### Avoid
+- An inscrutable homepage whose only goal is surprise
+- Showreels with no project names or context
+- Excessive scroll capture
+- Desktop-only interactions
+- Generic service buzzwords
+- Outdated team and client lists
+
+### Useful measures
+Qualified briefs, project-fit ratio, case-study engagement, talent applications, press referrals, and performance on media-heavy templates.
+
+---
+
+## 40. Editorial, magazine, news, and blog
+
+### Primary job
+Help readers discover, understand, trust, and return to a body of published work.
+
+### Audiences
+Direct readers, search visitors, subscribers, researchers, casual browsers, and members.
+
+### Recommended information architecture
+- Clear publication identity and topic navigation.
+- Homepage or section fronts with deliberate editorial priority.
+- Article pages optimized for reading and evidence.
+- Author, date, update, correction, and source context.
+- Related pathways that are relevant rather than endless.
+- Search, archive, and topic pages.
+- Subscription/membership proposition placed with restraint.
+
+### Visual direction
+Use an editorial grid, expressive type, controlled image crops, and meaningful density variation. Let major stories breathe while preserving a rapid scan of the broader issue. Build a dark theme only if reading quality is equally tested.
+
+### Essential components
+- Headline packages with hierarchy
+- Article deck, byline, timestamp, and share tools
+- Sticky or in-page article outline for long work
+- Footnotes, citations, figures, and pull quotes
+- Live-update module
+- Corrections and update history
+- Reading list or save
+- Accessible paywall and subscription controls
+
+### Trust and inclusion
+- Make authorship, ownership, funding, correction policy, and AI use visible.
+- Distinguish reporting, analysis, opinion, advertising, and sponsored content.
+- Preserve URLs and publish dates.
+- Link primary sources whenever practical.
+
+### Avoid
+- Intrusive interstitials
+- Layout shift from ads
+- Headline hierarchy based only on image size
+- Infinite scroll that destroys article URLs and history
+- Ambiguous sponsored content
+- Auto-playing video with sound
+- Thin gray body type or extremely wide lines
+
+### Useful measures
+Engaged reading, return frequency, subscription conversion, search success, recirculation quality, correction rate, accessibility, and ad-induced performance impact.
+
+---
+
+## 41. Documentation and developer portal
+
+### Primary job
+Get a user from question or goal to a correct implementation quickly, while supporting deep reference work.
+
+### Audiences
+First-time learners, task-focused implementers, expert reference users, evaluators, and support teams.
+
+### Recommended information architecture
+- Orientation and quick start.
+- Tutorials for learning.
+- How-to guides for tasks.
+- Reference for exact facts.
+- Explanation for concepts and architecture.
+- Search, versioning, changelog, status, and support.
+- Runnable examples and clear prerequisites.
+
+### Visual direction
+Prioritize legibility and navigation. A distinctive brand can appear through typography, syntax theme, diagrams, examples, and restrained illustrations. Avoid marketing-page motion in high-frequency reading and code-copy workflows.
+
+### Essential components
+- Persistent hierarchical side navigation
+- Fast scoped search
+- Version and language switcher
+- Copyable code blocks with accessible feedback
+- Tabs for platform variants with deep links
+- API reference tables
+- On-page table of contents
+- Feedback and edit-this-page links
+
+### Trust and inclusion
+- Show version, last update, ownership, deprecation, and compatibility.
+- Test examples.
+- Separate conceptual explanation from normative reference.
+- Do not hide limitations or error cases.
+
+### Avoid
+- Search that prioritizes marketing over docs
+- Code embedded as images
+- Broken deep links when versions change
+- Horizontal code overflow that traps the page
+- Client-side rendering that leaves blank docs on failure
+- Tutorials that assume unstated setup
+- Unlabeled generated answers
+
+### Useful measures
+Search success, time to successful implementation, copy/run success, support deflection, feedback sentiment, stale-page rate, and reference latency.
+
+---

--- a/plugins/design/skills/web-design/references/08-website-types-sectors.md
+++ b/plugins/design/skills/web-design/references/08-website-types-sectors.md
@@ -1,0 +1,404 @@
+# Website Type Playbooks: Product, Community, Public Service, Education, Finance, and Travel
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+## 42. Dashboard, admin, and analytics product
+
+### Primary job
+Support repeated monitoring, investigation, decision-making, and action with minimal friction.
+
+### Audiences
+Operators, analysts, managers, administrators, and occasional executives; expertise and frequency may vary sharply.
+
+### Recommended information architecture
+- Global context: account, workspace, date range, permissions, and freshness.
+- Task-oriented navigation.
+- Status and exceptions before vanity metrics.
+- Drill-down from summary to detail.
+- Tables and records for exact work.
+- Actions near the evidence that motivates them.
+- Saved views, exports, alerts, and audit history where appropriate.
+
+### Visual direction
+Use disciplined density, strong alignment, restrained color, and excellent type. Visual distinction can come from branded data palettes, spatial organization, and subtle motion rather than giant decorative surfaces.
+
+### Essential components
+- Filter bar with shareable state
+- Metric cards with comparison context
+- Accessible chart system
+- Data table with sorting, selection, and column control
+- Command palette and keyboard shortcuts
+- Activity/audit log
+- Permission-aware actions
+- Customizable but recoverable layout
+
+### Trust and inclusion
+- Show data freshness, source, units, uncertainty, and permissions.
+- Keep destructive actions auditable.
+- Explain derived metrics.
+- Distinguish empty data from loading, error, and no permission.
+
+### Avoid
+- A dashboard made entirely of cards
+- Rainbow chart palettes
+- Truncated values with no access to full data
+- Refresh animations on every update
+- Hidden filters
+- Icon-only navigation for unfamiliar modules
+- Desktop assumptions that make mobile emergency tasks impossible
+
+### Useful measures
+Task completion time, interaction latency, error rate, saved-view use, alert action rate, support tickets, data interpretation accuracy, and weekly active qualified users.
+
+---
+
+## 43. Community, forum, and social product
+
+### Primary job
+Enable valuable participation, relationships, discovery, and moderation without allowing noise or abuse to dominate.
+
+### Audiences
+Readers, new contributors, established members, moderators, organizers, and administrators.
+
+### Recommended information architecture
+- Readable feed or topic structure.
+- Clear community norms.
+- Low-risk onboarding and identity choices.
+- Posting, replying, reacting, saving, and following.
+- Discovery by topic, person, time, and relevance.
+- Reporting, blocking, muting, and moderation.
+- Notification and privacy controls.
+- Member reputation that does not become a simplistic popularity score.
+
+### Visual direction
+Let people and content be the visual identity. Use avatars, topic color, editorial curation, and lightweight delight. Preserve calm reading modes and strong content boundaries in dense feeds.
+
+### Essential components
+- Composer with draft preservation
+- Threaded conversation with clear depth limits
+- Content warnings and sensitive-media controls
+- Notification inbox with grouping
+- Moderation queue and reason codes
+- Report/block/mute flows
+- Profile privacy and audience controls
+- Rate limits and anti-spam feedback
+
+### Trust and inclusion
+- Make moderation policy and enforcement legible.
+- Explain ranking and sponsorship.
+- Protect vulnerable users by default.
+- Provide appeals and evidence preservation.
+- Do not expose private activity through accidental defaults.
+
+### Avoid
+- Engagement metrics that reward provocation
+- Infinite feeds with no stopping cue
+- Publicly shaming moderation
+- Dark patterns in notifications
+- Ambiguous audience selection
+- Removing content without explanation
+- Using color alone for moderation status
+
+### Useful measures
+Healthy contribution rate, reply quality, newcomer retention, report-resolution time, harmful-content exposure, notification opt-outs, and meaningful return visits—not raw time spent alone.
+
+---
+
+## 44. Nonprofit and charity
+
+### Primary job
+Make the mission understandable, prove impact, and let people donate, volunteer, advocate, or receive help safely.
+
+### Audiences
+Donors, beneficiaries, volunteers, partners, funders, press, and staff.
+
+### Recommended information architecture
+- Direct statement of mission and who benefits.
+- Current programs and concrete impact.
+- Donation path with amount, frequency, allocation, and tax context.
+- Ways to help beyond money.
+- Financial transparency and governance.
+- Stories created with dignity and consent.
+- Urgent help route for beneficiaries.
+- Updates and outcomes.
+
+### Visual direction
+Use human, specific imagery and a hopeful but honest tone. Strong color and illustration can create energy, but donation and support flows should remain conventional, calm, and accessible.
+
+### Essential components
+- Donation form with one-time/monthly choice
+- Impact calculator with transparent assumptions
+- Program map or taxonomy
+- Annual report and financial documents
+- Volunteer opportunity filter
+- Emergency banner with expiry
+- Accessible story and media modules
+
+### Trust and inclusion
+- Show registration, leadership, financial statements, fund allocation, and contact.
+- Explain recurring donation cancellation.
+- Do not exploit beneficiaries through decontextualized trauma imagery.
+- Distinguish goals from achieved results.
+
+### Avoid
+- Guilt-driven copy
+- Preselected recurring donations without clarity
+- Hidden processing additions
+- Impact numbers with no method
+- Hero imagery that stereotypes or removes agency
+- Donation popups blocking access to services
+
+### Useful measures
+Donation completion, recurring retention, volunteer application quality, program discovery, beneficiary task success, document access, and trust/support inquiries.
+
+---
+
+## 45. Government and public service
+
+### Primary job
+Let every eligible person understand and complete a public task accurately, regardless of confidence, disability, language, or device.
+
+### Audiences
+The full public, including infrequent users, people under stress, assisted users, professionals, and staff.
+
+### Recommended information architecture
+- Top tasks and service-oriented navigation.
+- Eligibility and prerequisites before a transaction.
+- Step-by-step service flow.
+- Clear legal authority and policy context.
+- Save, resume, print, and assisted-digital routes.
+- Status tracking and expected timelines.
+- Contact and escalation.
+- Accessible documents only when HTML cannot serve the need.
+
+### Visual direction
+Clarity is the aesthetic. Strong typography, generous target sizes, stable patterns, restrained official color, and excellent content can feel authoritative and modern. Original illustration may help explain complex processes but should not trivialize serious matters.
+
+### Essential components
+- One-question-per-page form where complexity warrants
+- Eligibility checker
+- Task list and progress
+- Document upload
+- Application status
+- Appointment booking
+- Service alerts
+- Language and accessibility support
+
+### Trust and inclusion
+- Use official domains and clear agency identity.
+- State what data is collected and why.
+- Show deadlines, processing times, and appeal rights.
+- Provide a reference number and durable receipt.
+
+### Avoid
+- Department-centered navigation
+- PDF-first publishing
+- Complex account creation before basic information
+- Timeout without warning
+- Legal wording as primary instructions
+- CAPTCHAs without accessible alternatives
+- Low-contrast ceremonial branding
+
+### Useful measures
+Task completion, assisted-contact reduction, error and rejection rate, completion time, accessibility defects, language parity, and successful status retrieval.
+
+---
+
+## 46. Healthcare and clinic
+
+### Primary job
+Help people find appropriate care, understand options, schedule, prepare, and manage sensitive information without increasing anxiety.
+
+### Audiences
+Patients, caregivers, clinicians, referrers, insurers, and people seeking urgent guidance.
+
+### Recommended information architecture
+- Immediate route to emergency/urgent care where relevant.
+- Service and symptom-oriented discovery.
+- Clinician profiles and availability.
+- Location, access, insurance, cost, and preparation.
+- Booking and rescheduling.
+- Patient portal with results, messages, prescriptions, and documents.
+- Plain-language health content with authorship and review dates.
+- Privacy and accessibility support.
+
+### Visual direction
+Use calm, legible interfaces and authentic photography. Avoid generic wellness minimalism that obscures practical facts. Color should aid orientation and urgency, not create false reassurance.
+
+### Essential components
+- Urgency triage with explicit limitations
+- Provider and location search
+- Accessible appointment calendar
+- Insurance/cost estimator
+- Preparation checklist
+- Secure messaging
+- Result display with ranges and explanation
+- Proxy/caregiver access
+
+### Trust and inclusion
+- Show clinical authorship, review dates, credentials, privacy practices, and emergency limitations.
+- Never imply automated content is a diagnosis.
+- Explain data sharing and portal notification privacy.
+- Design for emotionally difficult results.
+
+### Avoid
+- Symptom content written as marketing
+- Ambiguous urgent-care language
+- Color-only severity
+- Hidden costs
+- Mandatory app download
+- Session expiry during a long intake without save
+- Overly cheerful error messages in serious contexts
+
+### Useful measures
+Successful booking, no-show reduction, preparation completion, portal task completion, urgent-route accuracy, accessibility, support calls, and privacy incidents.
+
+---
+
+## 47. Education and course platform
+
+### Primary job
+Help learners choose an appropriate path, make progress, practice, receive feedback, and complete meaningful outcomes.
+
+### Audiences
+Prospective learners, active students, instructors, administrators, parents/employers, and accessibility support.
+
+### Recommended information architecture
+- Outcome, prerequisites, level, workload, format, and cost.
+- Curriculum preview and instructor credibility.
+- Enrollment and orientation.
+- Course home with next task and progress.
+- Lessons, practice, assessment, feedback, and discussion.
+- Deadlines and calendar.
+- Certificates or evidence of mastery.
+- Support and accommodations.
+
+### Visual direction
+Make learning material the focus. Use a warm but disciplined visual system, strong diagrams, clear progress, and restrained gamification. Course marketing can be expressive; the learning environment should reduce distraction.
+
+### Essential components
+- Syllabus and sample lesson
+- Progress map
+- Video player with captions/transcript/speed
+- Interactive exercise with keyboard support
+- Quiz feedback
+- Notes/bookmarks
+- Discussion and instructor announcement
+- Deadline and timezone handling
+
+### Trust and inclusion
+- State accreditation, instructor role, completion criteria, refund terms, and accessibility.
+- Distinguish participation certificates from professional credentials.
+- Make grading and AI-use policies explicit.
+
+### Avoid
+- Progress measured only as videos watched
+- Punitive streaks
+- Timed assessments with no accommodation
+- Autoplay lessons
+- Hidden prerequisites
+- Discussion interfaces that expose grades or private activity
+- Decorative animations that compete with instruction
+
+### Useful measures
+Enrollment fit, lesson completion, practice success, retention, assessment validity, support use, accommodation fulfillment, and outcome attainment.
+
+---
+
+## 48. Finance, banking, and fintech
+
+### Primary job
+Let people understand and control money accurately, securely, and with confidence.
+
+### Audiences
+Consumers, businesses, advisors, operators, compliance teams, and support.
+
+### Recommended information architecture
+- Account overview with balances, liabilities, and freshness.
+- Transactions with search, categorization, and detail.
+- Transfer/payment flow with recipient and amount verification.
+- Statements, tax documents, fees, rates, and terms.
+- Alerts and security center.
+- Support, disputes, and fraud reporting.
+- Planning or analysis with transparent assumptions.
+
+### Visual direction
+Use calm precision, strong numerals, clear tables, controlled semantic color, and restrained motion. Premium aesthetics should never reduce contrast or hide terms. Do not mimic trading excitement for ordinary financial decisions.
+
+### Essential components
+- Balance and available-funds distinction
+- Transaction table/timeline
+- Transfer review and confirmation
+- Rate and fee disclosure
+- Card controls
+- Security/session management
+- Scenario calculator
+- Accessible charts with exact data
+
+### Trust and inclusion
+- Show legal entity, regulation, protection scope, timestamps, pending status, and data source.
+- Explain estimates versus settled values.
+- Provide durable receipts and audit trails.
+- Use reauthentication proportionate to risk.
+
+### Avoid
+- Green/red alone for gain/loss
+- Confetti for borrowing or risky trades
+- Preselected investment risk
+- Hidden APR or fee assumptions
+- Truncated transaction names
+- Delayed error disclosure after transfer
+- Dark patterns around cancellation or withdrawal
+
+### Useful measures
+Successful transaction completion, error/reversal, fraud report time, statement access, support contact, trust sentiment, accessibility, and latency on critical actions.
+
+---
+
+## 49. Travel, hotel, and hospitality
+
+### Primary job
+Help travelers imagine, compare, book, prepare, and manage a trip across uncertain dates, prices, and conditions.
+
+### Audiences
+Leisure travelers, business travelers, families, groups, loyalty members, and agents.
+
+### Recommended information architecture
+- Destination/property proposition grounded in location and experience.
+- Date and party search.
+- Availability and price comparison.
+- Room/product detail with total cost, policies, amenities, and accessibility.
+- Booking with traveler details and payment.
+- Confirmation, itinerary, modification, cancellation, and pre-arrival guidance.
+- Local context and support.
+
+### Visual direction
+Use immersive place photography and video, but keep booking controls visible and fast. Editorial storytelling should complement factual room, route, and policy data.
+
+### Essential components
+- Flexible-date calendar
+- Map plus list
+- Room comparison
+- Total-price disclosure
+- Amenity and accessibility filters
+- Itinerary builder
+- Weather/season context with date
+- Booking management
+
+### Trust and inclusion
+- Show exact location context, taxes/fees, cancellation deadlines with timezone, renovation notices, accessibility specifics, and realistic imagery.
+- Label third-party inventory and sponsored rank.
+- Do not imply scarcity without real data.
+
+### Avoid
+- Price shown without mandatory fees
+- Calendar traps
+- Low-resolution room imagery
+- Vague accessibility claims
+- Auto-currency conversion with hidden markup
+- Map pins with no list alternative
+- Urgency banners on every option
+
+### Useful measures
+Search-to-book, total-price comprehension, modification self-service, cancellation errors, filter use, return booking, support contact, and media performance.
+
+---

--- a/plugins/design/skills/web-design/references/09-website-types-local-campaigns.md
+++ b/plugins/design/skills/web-design/references/09-website-types-local-campaigns.md
@@ -1,0 +1,596 @@
+# Website Type Playbooks: Local, Events, Media, Campaigns, Fashion, Legal, and Utilities
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+## 50. Restaurant, café, and food service
+
+### Primary job
+Help someone decide quickly whether the venue fits, then find, book, order, or visit it.
+
+### Audiences
+Nearby diners, planners, tourists, delivery customers, event organizers, and people with dietary/accessibility needs.
+
+### Recommended information architecture
+- Name, cuisine, location, open status, and primary action immediately.
+- Current menu in HTML.
+- Reservation/order/walk-in information.
+- Hours, address, map link, phone, transit, parking, and accessibility.
+- Atmosphere and food photography.
+- Dietary/allergen information with appropriate caution.
+- Events, private dining, or gift cards if relevant.
+
+### Visual direction
+Use sensory photography, expressive type, and a palette drawn from the physical space. Preserve practical information above cinematic storytelling, especially on mobile.
+
+### Essential components
+- Live hours with exact weekly schedule
+- Menu categories and prices
+- Reservation widget with fallback contact
+- Location card
+- Dietary filters or markers plus legend
+- Event/private-booking inquiry
+- Order pickup/delivery handoff
+
+### Trust and inclusion
+- Keep menus, prices, and hours current.
+- State whether allergen requests can be accommodated rather than promising absolute safety casually.
+- Use real venue photography.
+- Explain booking deposits and cancellation.
+
+### Avoid
+- PDF-only menu
+- Music or video autoplay
+- Address hidden below a splash page
+- Food photos that do not represent servings
+- Reservation embed that breaks keyboard access
+- Instagram as the only source of updates
+- Illegible script font for menu text
+
+### Useful measures
+Reservation/order completion, direction/phone actions, menu engagement, failed booking recovery, hours accuracy, dietary information access, and local search conversion.
+
+---
+
+## 51. Event, conference, and festival
+
+### Primary job
+Convert interest into attendance and help attendees plan and navigate a time-sensitive experience.
+
+### Audiences
+Prospective attendees, ticket holders, speakers/artists, sponsors, press, staff, and volunteers.
+
+### Recommended information architecture
+- Event identity, date, place, and ticket status immediately.
+- Program or lineup.
+- Ticket types, total prices, access, refund/transfer rules.
+- Venue, travel, accommodation, accessibility, and safety.
+- Schedule builder and updates.
+- Speaker/artist/session detail.
+- Sponsor and partner context.
+- Post-event recordings, photos, and next edition.
+
+### Visual direction
+Events can support bold, kinetic identities. Use variable typography, poster-like composition, animation, and sound only as optional enhancement. The date, location, lineup, and ticket action must remain instantly legible.
+
+### Essential components
+- Countdown tied to a real deadline
+- Filterable schedule with timezone
+- Personal agenda
+- Ticket status and wallet access
+- Venue map
+- Live alerts
+- Accessible lineup grid
+- Calendar export
+
+### Trust and inclusion
+- Show organizer, terms, refund policy, schedule-change policy, accessibility contact, and official resale route.
+- Timestamp updates.
+- Separate announced, confirmed, postponed, and canceled states.
+
+### Avoid
+- Poster design that turns all text into images
+- Horizontal schedule impossible on mobile
+- Countdown without timezone
+- Hidden fees
+- Color-only tracks
+- Lineup animation that cannot pause
+- Outdated pages left looking current
+
+### Useful measures
+Ticket conversion, schedule use, agenda saves, support contacts, update reach, accessibility inquiries resolved, entry success, and post-event retention.
+
+---
+
+## 52. Real estate and property
+
+### Primary job
+Help people discover, compare, evaluate, and inquire about high-consideration properties with accurate spatial and financial context.
+
+### Audiences
+Buyers, renters, investors, sellers, agents, and property managers.
+
+### Recommended information architecture
+- Location and criteria search.
+- Map/list results with stable filters.
+- Listing detail with price, status, dimensions, rooms, costs, energy, and legal facts.
+- High-quality gallery, floor plan, and area context.
+- Viewing or inquiry flow.
+- Agent/company credibility.
+- Saved properties and alerts.
+- Process and finance education.
+
+### Visual direction
+Use editorial property photography and large maps, balanced by structured fact tables. Premium does not mean hiding dimensions, costs, or controls in tiny text.
+
+### Essential components
+- Map/list synchronization
+- Saved search
+- Image gallery and floor-plan viewer
+- Mortgage/rent calculator with assumptions
+- Viewing calendar
+- Comparable-property table
+- Neighborhood travel-time tools
+- Listing status history
+
+### Trust and inclusion
+- Mark listing freshness, source, agent, fees, floor area definition, energy data, and whether images are staged or rendered.
+- Do not obscure material defects or status.
+- Protect personal details in inquiry flows.
+
+### Avoid
+- Map-only results
+- AI-staged imagery without disclosure
+- Missing floor plans
+- Price-on-request everywhere
+- Lead capture before basic facts
+- Auto-playing virtual tours
+- False “just listed” labels
+
+### Useful measures
+Qualified inquiry, viewing booking, saved search, alert engagement, listing completeness, stale-listing rate, map performance, and inquiry response.
+
+---
+
+## 53. Local services and trades
+
+### Primary job
+Help a nearby customer verify fit and availability, estimate cost, and make contact quickly.
+
+### Audiences
+People with urgent problems, planned projects, recurring-service needs, landlords, and local businesses.
+
+### Recommended information architecture
+- Service, area, availability, and contact immediately.
+- Specific service pages.
+- Credentials, insurance, reviews, and examples.
+- Pricing approach or indicative ranges.
+- Booking/quote request.
+- Emergency versus standard process.
+- Service-area map/list.
+- Frequently asked practical questions.
+
+### Visual direction
+Use authentic work photography, clear typography, and direct actions. A polished local site wins through specificity and responsiveness more than experimental aesthetics.
+
+### Essential components
+- Tap-to-call with operating context
+- Service-area checker
+- Quote form with photo upload
+- Appointment booking
+- Before/after cases
+- Review excerpts linked to sources
+- Emergency banner
+- License/credential detail
+
+### Trust and inclusion
+- Use real company details, team, address/service area, insurance, guarantees, and transparent review sourcing.
+- Explain callout charges and quote validity.
+- Do not imply 24/7 service unless staffed.
+
+### Avoid
+- Generic stock workers
+- Fake local landing pages
+- Phone number that changes or is hard to copy
+- Quote forms asking excessive personal detail
+- Hidden callout fees
+- Review badges with no source
+- Location pages with duplicated text
+
+### Useful measures
+Qualified calls, quote completion, booking conversion, service-area accuracy, response time, no-show rate, and local organic conversion.
+
+---
+
+## 54. Media, music, and streaming
+
+### Primary job
+Help audiences discover, preview, play, collect, follow, and support media while preserving continuity across sessions and devices.
+
+### Audiences
+Casual listeners/viewers, fans, subscribers, creators, curators, and rights holders.
+
+### Recommended information architecture
+- Immediate catalog or featured release.
+- Search, browse, genre/mood/topic, and recommendations.
+- Detail page with credits, metadata, availability, and related work.
+- Persistent player or viewer.
+- Library, queue, history, and downloads where relevant.
+- Subscription or purchase.
+- Creator/artist profiles and support.
+
+### Visual direction
+Artwork is the core visual field. Use dynamic color extraction carefully, cinematic typography, and motion synchronized to playback state—not constant background noise. Keep controls familiar.
+
+### Essential components
+- Persistent accessible player
+- Queue and device handoff
+- Timed transcript/lyrics where licensed
+- Credits and metadata
+- Content warnings and maturity controls
+- Download/offline state
+- Recommendation explanation
+- Share with timestamp
+
+### Trust and inclusion
+- Show availability, quality, subscription limits, rights, credits, and sponsored placement.
+- Make autoplay and recommendation controls visible.
+- Respect listening/viewing privacy.
+
+### Avoid
+- Custom controls with poor keyboard support
+- Art-based text with low contrast
+- Autoplay previews everywhere
+- Unclear shuffle/repeat state
+- Hidden explicit-content controls
+- Recommendations indistinguishable from ads
+- Removing browser history during infinite browsing
+
+### Useful measures
+Successful play, discovery-to-play, completion, library saves, return frequency, subscription conversion, playback errors, and accessibility of controls/captions.
+
+---
+
+## 55. Gaming and entertainment
+
+### Primary job
+Create desire and community while making platform, content, purchase, play, and support requirements unambiguous.
+
+### Audiences
+Prospective players, active players, parents, streamers, press, competitive communities, and support seekers.
+
+### Recommended information architecture
+- Game identity and gameplay quickly.
+- Platforms, release state, age rating, price, and requirements.
+- Trailers/screenshots with player control.
+- Features, modes, world, and updates.
+- Purchase/download links.
+- Community, events, patch notes, and support.
+- Accessibility features and content warnings.
+
+### Visual direction
+Use the game’s art direction boldly: cinematic scenes, spatial layers, sound, particle systems, and dramatic type. Provide a low-motion, low-bandwidth route and keep purchase/support controls stable.
+
+### Essential components
+- Trailer with captions and manual play
+- Platform selector
+- System requirements
+- Edition comparison
+- Patch-note archive
+- Server status
+- Character/world exploration
+- Accessibility feature matrix
+
+### Trust and inclusion
+- Show real gameplay versus cinematic footage, release dates, platform differences, monetization, online requirements, and ratings.
+- Timestamp roadmaps and avoid presenting aspirations as shipped features.
+
+### Avoid
+- Auto-playing sound
+- Heavy 3D before basic content
+- Preorder pressure without terms
+- Editions that are impossible to compare
+- Roadmaps with no status
+- Age-inappropriate tracking or dark patterns
+- Patch notes only on social media
+
+### Useful measures
+Wishlist/purchase, trailer completion, platform selection, support success, patch-note use, community health, and performance by device tier.
+
+---
+
+## 56. Personal brand and résumé
+
+### Primary job
+Make a person’s specialty, evidence, credibility, and contact path understandable in a few minutes.
+
+### Audiences
+Hiring managers, clients, collaborators, event organizers, press, and peers.
+
+### Recommended information architecture
+- Name, role, specialty, and current focus.
+- Selected proof: projects, writing, talks, clients, or outcomes.
+- Short biography.
+- Experience and capabilities.
+- Contact and relevant profiles.
+- Downloadable résumé only as a supplement to HTML.
+- Optional notes, now page, or reading/work log.
+
+### Visual direction
+Use one personal visual signature—type, portraiture, color, or motion—and keep the information easy to scan. The site should feel authored rather than generated from a career template.
+
+### Essential components
+- Featured-work cards
+- Timeline or selected experience
+- Writing/talk archive
+- Availability/status
+- Contact options by purpose
+- Printable résumé style
+- Theme preference if it supports identity
+
+### Trust and inclusion
+- Use real dates, role scope, links, credits, and current contact.
+- Separate client work from employer/team work.
+- Make résumé download accessible and current.
+
+### Avoid
+- Third-person superlatives
+- Skill progress bars
+- An intro animation before a recruiter can read your name
+- Every social profile ever created
+- PDF as the only content
+- Generic headless portraits if your identity matters
+- Contact form with no alternate route
+
+### Useful measures
+Relevant contacts, work-detail views, résumé access, speaking/media requests, and low bounce from direct profile links.
+
+---
+
+## 57. Membership and subscription
+
+### Primary job
+Explain ongoing value, convert appropriate members, and make benefits, billing, renewal, and cancellation easy to manage.
+
+### Audiences
+Prospective members, trial users, active members, lapsed members, and administrators.
+
+### Recommended information architecture
+- Who membership is for and recurring value.
+- Benefit detail with cadence and limitations.
+- Plan comparison and full recurring cost.
+- Preview or sample.
+- Signup and payment.
+- Member home with current benefits and next action.
+- Billing, pause, upgrade/downgrade, and cancellation.
+- Community/support where relevant.
+
+### Visual direction
+Use a sense of belonging through member stories, editorial curation, and branded rituals. Avoid velvet-rope aesthetics that obscure the practical value.
+
+### Essential components
+- Plan comparison
+- Benefit calendar
+- Trial status
+- Member library
+- Referral/gifting
+- Billing controls
+- Pause/cancel flow
+- Renewal reminders
+
+### Trust and inclusion
+- State renewal timing, price changes, cancellation effective date, trial conversion, and benefit limits.
+- Make cancellation at least as straightforward as signup.
+- Do not use fake exclusivity.
+
+### Avoid
+- Annual price displayed without per-term clarity
+- Cancellation through support only
+- Countdown pressure
+- Benefits visible only after payment
+- Hidden geographic restrictions
+- Obscure renewal notices
+- Gamified streaks that penalize healthy disengagement
+
+### Useful measures
+Qualified trial conversion, renewal, benefit use, involuntary churn, cancellation completion, refund/support rate, and member satisfaction.
+
+---
+
+## 58. Crowdfunding and campaign
+
+### Primary job
+Turn belief into a time-bound contribution while accurately communicating feasibility, progress, and risk.
+
+### Audiences
+Backers/donors, advocates, press, partners, and skeptical evaluators.
+
+### Recommended information architecture
+- Specific goal and beneficiary/product.
+- Why now.
+- Plan, team, timeline, and budget.
+- Evidence or prototype.
+- Funding progress and deadline.
+- Contribution/reward options.
+- Risks and contingencies.
+- Updates and post-campaign accountability.
+
+### Visual direction
+Use a strong narrative arc, human media, diagrams, and visible momentum. Keep the contribution module stable and the evidence close to claims.
+
+### Essential components
+- Progress display with exact numbers
+- Reward/tier comparison
+- Timeline
+- Budget allocation
+- Prototype/demo
+- Update log
+- Share kit
+- Contribution receipt
+
+### Trust and inclusion
+- Distinguish donation, preorder, investment, and pledge.
+- Explain platform fees, delivery estimates, refund rules, and risk.
+- Keep updates immutable or show edit history.
+- Do not imply guaranteed outcomes.
+
+### Avoid
+- Progress animation that misrepresents totals
+- Buried risks
+- Unrealistic delivery dates
+- Manufactured urgency
+- Reward tiers impossible to compare
+- Emotional storytelling without a concrete plan
+- Silence after funding
+
+### Useful measures
+Contribution completion, average contribution, qualified sharing, update readership, refund/chargeback, delivery milestone accuracy, and repeat support.
+
+---
+
+## 59. Luxury, fashion, and beauty
+
+### Primary job
+Create desire and identity while giving enough material, fit, provenance, availability, and service detail for a confident purchase.
+
+### Audiences
+New shoppers, established clients, collectors, gift buyers, press, and stylists.
+
+### Recommended information architecture
+- Seasonal/editorial statement.
+- Collection and category browsing.
+- Product story plus exact materials, dimensions, fit, care, and delivery.
+- Rich imagery and motion.
+- Availability, appointment, or purchase.
+- Craft/provenance.
+- Service, returns, repair, and client care.
+
+### Visual direction
+Use high-control art direction: typography, negative space, film, texture, and rhythm. Luxury is precision, not intentionally poor usability. Keep commerce controls legible and predictable.
+
+### Essential components
+- Editorial lookbook linked to products
+- High-resolution gallery with efficient delivery
+- Size/fit guide
+- Material and provenance detail
+- Appointment/client-service booking
+- Wishlist
+- Packaging/gifting options
+- Care and repair
+
+### Trust and inclusion
+- State material composition, origin, sizing, stock, shipping, duties, returns, authenticity, and retouching/rendering where relevant.
+- Make sustainability claims specific and evidenced.
+
+### Avoid
+- Microscopic type
+- Mystery icons
+- Scroll-locking lookbooks
+- Price hidden without reason
+- Video as the only product view
+- Ambiguous size systems
+- Luxury language masking ordinary product detail
+- Inaccessible pale-on-pale palettes
+
+### Useful measures
+Product exploration, appointment/purchase, size-guide use, returns by reason, client-service contact, wishlist, and image performance.
+
+---
+
+## 60. Legal and professional services
+
+### Primary job
+Help a person recognize relevant expertise, assess credibility and conflict, understand the process, and make safe contact.
+
+### Audiences
+Individuals under stress, corporate buyers, referrers, journalists, and recruits.
+
+### Recommended information architecture
+- Clear practice areas and jurisdictions.
+- Who the firm serves and does not serve.
+- Professional profiles with actual experience.
+- Representative matters or case types with compliant wording.
+- Process and expected first contact.
+- Insights and updates.
+- Office/contact/accessibility.
+- Required disclaimers and privacy.
+
+### Visual direction
+Use sober editorial typography, real portraiture, precise navigation, and restrained brand color. Avoid the interchangeable marble-building aesthetic.
+
+### Essential components
+- Practice-area navigator
+- Professional directory
+- Jurisdiction filter
+- Insight library
+- Confidential inquiry guidance
+- Office/location detail
+- Accessible document library
+- Conflict/intake form
+
+### Trust and inclusion
+- Show bar/admission status, jurisdictions, role, office, contact, authorship, update dates, and limitations.
+- Clarify that contact does not automatically create a professional relationship.
+- Protect sensitive intake data.
+
+### Avoid
+- Guaranteeing outcomes
+- Vague “full service” language
+- Stock gavels and handshakes
+- Demanding detailed confidential facts in an insecure form
+- Outdated professional profiles
+- PDF-only insights
+- Hidden disclaimers in tiny text
+
+### Useful measures
+Qualified inquiry, practice-area findability, professional-profile depth, content-assisted contact, form abandonment, and inappropriate-inquiry reduction.
+
+---
+
+## 61. Progressive web app and utility
+
+### Primary job
+Let someone complete a repeated task quickly and reliably across network conditions and devices.
+
+### Audiences
+Frequent users, occasional users arriving from search, installed-app users, and people on constrained devices.
+
+### Recommended information architecture
+- Immediate task surface.
+- Clear data/input requirements.
+- Fast result with editable assumptions.
+- History, save, export, or share where valuable.
+- Offline/degraded behavior.
+- Installability only after demonstrated value.
+- Settings, privacy, and data controls.
+- Help and recovery.
+
+### Visual direction
+Utility is visual quality: crisp hierarchy, fast feedback, excellent states, and restrained delight. Brand through typography, micro-motion, iconography, and meaningful visualization.
+
+### Essential components
+- Task-focused shell
+- Local draft persistence
+- Offline indicator
+- Sync/conflict state
+- Install prompt triggered by intent
+- Share target/file integration where relevant
+- Keyboard shortcuts
+- Undo/history
+
+### Trust and inclusion
+- Explain local versus cloud storage, sync, permissions, export, deletion, and offline limitations.
+- Never imply data is saved until persistence succeeds.
+- Show last sync.
+
+### Avoid
+- Blocking install prompts on first visit
+- Native-app imitation that breaks web conventions
+- Offline mode with silent data loss
+- Full-screen loaders for small tasks
+- Permission requests without context
+- Unclear sync conflicts
+- Heavy shell before the task is usable
+
+### Useful measures
+Task completion time, repeat use, offline success, sync conflicts, installation after value, error recovery, INP, and data-loss incidents.
+
+---

--- a/plugins/design/skills/web-design/references/10-page-pattern-playbooks.md
+++ b/plugins/design/skills/web-design/references/10-page-pattern-playbooks.md
@@ -1,0 +1,488 @@
+# Page Pattern Playbooks
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part VII — Page-pattern playbooks
+These recipes describe the information and behavior a page must support. Visual composition should vary by brand and context.
+
+## 62. Homepage
+
+### Purpose
+Orient a mixed audience, establish relevance and trust, expose the most important paths, and create a reason to continue.
+
+### Recommended sequence
+- Identity and proposition: what this is, for whom, and why it matters.
+- Primary action plus a lower-commitment path.
+- Proof appropriate to the claim.
+- Key audience, product, service, or content paths.
+- Distinctive demonstration or story.
+- Objection handling.
+- Recent or fresh content when freshness is part of the value.
+- Final next step and complete footer.
+
+### Design rules
+- Treat the homepage as a routing and framing page, not a compressed sitemap.
+- Use a hero that communicates before its media finishes loading.
+- Prioritize one main proposition; secondary businesses can appear lower.
+- Make returning-user shortcuts visible when the site has frequent tasks.
+- Let real content establish credibility sooner than generic brand prose.
+- Keep promotional campaigns subordinate to the durable site identity.
+
+### Review questions
+- Five-second test: can someone state what the organization offers?
+- Can each core audience find a plausible path?
+- Does the first screen work without animation or video?
+- Is the homepage still useful to a returning visitor?
+- Does every section earn its place?
+
+---
+
+## 63. Campaign landing page
+
+### Purpose
+Convert traffic from a specific promise, audience, and source into one measurable action.
+
+### Recommended sequence
+- Message match with the ad, email, post, or referral.
+- Specific proposition and action.
+- Immediate proof or demonstration.
+- Benefit/outcome sequence.
+- How it works.
+- Evidence and objections.
+- Offer details, eligibility, or deadline.
+- Repeated CTA with risk reducer.
+- Minimal legal and trust footer.
+
+### Design rules
+- One campaign, one audience, one primary action.
+- Keep navigation minimal only when doing so does not trap or reduce trust.
+- Use source-aware copy sparingly; never make the page feel surveillant.
+- Repeat the CTA after persuasion milestones rather than every viewport.
+- Use a short form or multi-step flow only when qualification truly helps.
+- Preserve UTM and attribution without exposing private data.
+
+### Review questions
+- Does the headline match the acquisition promise?
+- Is price/commitment clear before form submission?
+- Does the page explain what happens after conversion?
+- Can the form be completed with keyboard and autofill?
+- Is urgency real and timestamped?
+
+---
+
+## 64. Pricing page
+
+### Purpose
+Help a buyer understand cost, choose an appropriate plan, and anticipate limits, changes, and total commitment.
+
+### Recommended sequence
+- Billing basis, currency, and audience.
+- Plan comparison with one recommended option only when genuinely appropriate.
+- Price, period, included usage, limits, and overages.
+- Core differentiators.
+- Calculator or usage examples where price varies.
+- Enterprise/custom route.
+- Full feature comparison.
+- FAQ on trial, renewal, cancellation, taxes, support, and migration.
+- CTA aligned to each plan.
+
+### Design rules
+- Make monthly versus annual totals unambiguous.
+- Show what happens when usage exceeds the plan.
+- Use plain names rather than forcing users to decode aspirational tiers.
+- Keep comparable features in aligned rows.
+- Explain unavailable features; avoid forests of unexplained dashes.
+- Allow users to change billing assumptions without losing their place.
+
+### Review questions
+- Can a buyer calculate the first bill and renewal bill?
+- Can two plans be compared without opening tooltips?
+- Is the recommended plan based on a clear audience?
+- Does the page work at narrow widths without losing row context?
+- Are cancellation and downgrade effects clear?
+
+---
+
+## 65. Product detail page
+
+### Purpose
+Resolve uncertainty about a specific item and support a confident purchase, booking, download, or inquiry.
+
+### Recommended sequence
+- Name, status, price, rating/proof, and primary media.
+- Variant/configuration.
+- Primary action and delivery/availability.
+- Essential facts.
+- Media gallery and demonstration.
+- Description and benefits.
+- Specifications, dimensions, compatibility, or ingredients.
+- Reviews/questions.
+- Returns, warranty, support, and related items.
+
+### Design rules
+- Keep selected variant, media, price, and availability synchronized.
+- Show unavailable combinations before a user reaches checkout.
+- Put material decision facts near the action.
+- Use sticky purchase UI only when it does not cover content or create duplicate focus confusion.
+- Preserve product context when opening size guides or technical detail.
+- Make related products relevant rather than a distraction from unresolved questions.
+
+### Review questions
+- Can a user identify exactly what will arrive?
+- Are total price and delivery visible?
+- Can media be operated without gestures only?
+- Are variants understandable without color alone?
+- Do reviews expose distribution and context rather than only an average?
+
+---
+
+## 66. Category or listing page
+
+### Purpose
+Support browsing, narrowing, comparison, and movement to a useful detail page.
+
+### Recommended sequence
+- Category name and concise orientation.
+- Subcategory or curated paths.
+- Result count and current scope.
+- Sort and filters.
+- Result grid/list with comparable attributes.
+- Pagination/load-more with preserved history.
+- Helpful category content after or around results, not before the task.
+- Empty and recovery states.
+
+### Design rules
+- Keep filters stable and URL-addressable.
+- Show active filters and allow one-tap clearing.
+- Use consistent media ratios and metadata positions.
+- Do not hide all filter controls behind a modal on wide screens.
+- Preserve scroll and filters after returning from detail.
+- Use pagination, load-more, or infinite loading based on task; preserve footer and browser history.
+
+### Review questions
+- Can a user compare cards without opening each item?
+- Does the back button restore position and state?
+- Can every filter be operated by keyboard?
+- Are unavailable and sponsored items labeled?
+- Does zero results provide a productive recovery?
+
+---
+
+## 67. Article page
+
+### Purpose
+Support comprehension, trust, citation, and continued exploration of a single piece of content.
+
+### Recommended sequence
+- Content type, headline, deck.
+- Author, publication/update date, reading or media context.
+- Hero/lead media when meaningful.
+- Readable body with structured headings.
+- Figures, citations, notes, and related definitions.
+- Author/source/correction context.
+- Relevant next reading.
+- Comments or discussion only when the publication can support them.
+
+### Design rules
+- Keep body measure readable and controls out of the text column.
+- Provide visible link treatment.
+- Place ads and subscription prompts without splitting thought or causing layout shift.
+- Use sticky outlines for truly long pieces, not every post.
+- Show updates and corrections transparently.
+- Support print and copy/paste.
+
+### Review questions
+- Does the article remain readable at 200% zoom?
+- Can citations and footnotes be reached and returned from?
+- Is publication versus update time unambiguous?
+- Does media have captions/transcripts?
+- Can users distinguish opinion, sponsored content, and reporting?
+
+---
+
+## 68. About page
+
+### Purpose
+Explain identity, motivation, legitimacy, culture, and the people or history behind the work.
+
+### Recommended sequence
+- Specific mission or reason for existence.
+- Origin and present focus.
+- People and governance.
+- Values shown through behavior or evidence.
+- Milestones and scale.
+- Locations and ways of working.
+- Press, careers, reports, or contact paths.
+- Current legal/company details where relevant.
+
+### Design rules
+- Use concrete language and actual examples.
+- Keep team data maintainable; stale rosters reduce trust.
+- Photograph people and places authentically.
+- Do not turn values into decorative nouns without evidence.
+- Use a timeline only when chronology helps understanding.
+- Make ownership, funding, or governance visible where trust depends on it.
+
+### Review questions
+- Could a visitor explain who operates the organization?
+- Are team images and titles current?
+- Do stated values connect to actions or policies?
+- Can press and prospective employees find their routes?
+- Does the page avoid repeating the homepage?
+
+---
+
+## 69. Case study
+
+### Purpose
+Prove capability through a specific problem, decision process, contribution, and outcome.
+
+### Recommended sequence
+- Client/context, project type, role, and date.
+- Executive summary and outcome.
+- Problem and constraints.
+- Research or evidence.
+- Key decisions and why.
+- Process highlights, not every workshop artifact.
+- Solution in context.
+- Measured results and caveats.
+- Credits, testimonial, and next relevant case/action.
+
+### Design rules
+- State exact contribution, especially in collaborative work.
+- Use before/after only when the comparison is fair.
+- Give metrics a baseline, period, and attribution.
+- Show work in realistic context and at readable scale.
+- Balance narrative with scannable summary.
+- Protect confidential information without filling gaps with invented detail.
+
+### Review questions
+- Can the reader distinguish problem, action, and result?
+- Are decisions explained rather than merely displayed?
+- Are all collaborators credited?
+- Are metrics credible and contextualized?
+- Does the case demonstrate relevant capability to the target audience?
+
+---
+
+## 70. Contact page
+
+### Purpose
+Route an inquiry to the right channel with clear expectations and minimal risk.
+
+### Recommended sequence
+- Reason to contact and expected response.
+- Channel options by purpose.
+- Short form with only necessary fields.
+- Office/address/hours when relevant.
+- Support, sales, press, careers, accessibility, and emergency alternatives.
+- Privacy and data-use explanation.
+- Success confirmation and reference.
+
+### Design rules
+- Publish a real alternate contact method when feasible.
+- Do not ask for sensitive project detail before secure handling is established.
+- Use conditional fields to reduce burden.
+- State response time as a service target only if maintained.
+- Keep location links and phone numbers copyable.
+- Send a confirmation that includes what was submitted where appropriate.
+
+### Review questions
+- Can a user choose the correct channel?
+- Does the form preserve data after an error?
+- Is the success state durable and unambiguous?
+- Can spam protection be completed accessibly?
+- Are urgent situations redirected appropriately?
+
+---
+
+## 71. Signup, login, and onboarding
+
+### Purpose
+Create or access an account, establish trust, and reach first value with the least necessary friction.
+
+### Recommended sequence
+- Clear account context and available methods.
+- Email/password, passkey, or identity provider options.
+- Terms and privacy at the point they matter.
+- Verification and recovery.
+- Minimal account setup.
+- First-value task.
+- Optional profile/team/personalization later.
+- Progress and exit/resume.
+
+### Design rules
+- Allow password managers and paste.
+- Explain whether social sign-in creates or links an account.
+- Do not ask onboarding questions that can be inferred or deferred.
+- Let users skip nonessential tours.
+- Use examples and default data to make an empty product understandable.
+- Preserve progress across verification and redirects.
+
+### Review questions
+- Can someone recover from a mistyped email?
+- Is the password visible on request?
+- Does keyboard focus survive route changes?
+- Can a user reach value without completing marketing enrichment?
+- Are authentication errors helpful without leaking account security?
+
+---
+
+## 72. Checkout
+
+### Purpose
+Complete a purchase accurately while minimizing effort, surprise, and fear.
+
+### Recommended sequence
+- Order summary and editable cart.
+- Guest/contact.
+- Delivery or fulfillment.
+- Address.
+- Shipping method and timing.
+- Payment.
+- Final review with total and terms.
+- Confirmation, receipt, next steps, and account option.
+
+### Design rules
+- Keep total cost visible and updated.
+- Use autocomplete and appropriate input modes.
+- Preserve data across errors and payment redirects.
+- Explain why billing differs from shipping.
+- Do not force account creation.
+- Do not add optional products by default.
+- Support back navigation without duplicate charges.
+
+### Review questions
+- Can a user identify the charged amount and currency before committing?
+- Are errors attached to fields and summarized?
+- Does retrying payment avoid duplicate orders?
+- Is stock retained or its expiry explained?
+- Does confirmation include order number, delivery expectation, and support?
+
+---
+
+## 73. Dashboard
+
+### Purpose
+Summarize current state, highlight exceptions, and provide direct paths into frequent decisions and actions.
+
+### Recommended sequence
+- Workspace/account/date context.
+- Critical alerts and freshness.
+- Top tasks.
+- Primary metrics with comparison.
+- Trends and drivers.
+- Recent activity or records.
+- Actions and deeper reports.
+- Customization only where it provides durable value.
+
+### Design rules
+- Do not put every metric on the first screen.
+- Distinguish monitoring from analysis.
+- Explain units and comparison windows.
+- Use color as a redundant cue, not the sole status.
+- Keep filters and date range consistent across linked views.
+- Let users reach exact records behind summaries.
+
+### Review questions
+- Can a user tell what needs attention?
+- Are stale and partial data visible?
+- Do metric changes have a comparison basis?
+- Can the dashboard be operated by keyboard?
+- Does personalization have a reset?
+
+---
+
+## 74. Search results
+
+### Purpose
+Turn a query into a useful destination, correction, or refined understanding.
+
+### Recommended sequence
+- Editable query and result count/scope.
+- Suggested correction or interpretation.
+- Top result cluster.
+- Filters and sort.
+- Results with useful excerpts and type metadata.
+- Pagination/load-more.
+- Related queries or categories.
+- No-results recovery.
+
+### Design rules
+- Prioritize relevance and explain non-obvious ranking.
+- Highlight matched terms carefully without breaking readability.
+- Do not mix paid and organic results without labels.
+- Preserve query and filters in the URL.
+- Handle abbreviations, synonyms, and common misspellings.
+- Scope search where multiple repositories exist.
+
+### Review questions
+- Can users distinguish result types?
+- Does the excerpt show why a result matches?
+- Can a correction be rejected?
+- Are filters accessible and stateful?
+- Does no-results keep the original query editable?
+
+---
+
+## 75. Help center and documentation
+
+### Purpose
+Resolve a task or problem through self-service while keeping escalation available.
+
+### Recommended sequence
+- Prominent scoped search.
+- Top tasks and product areas.
+- Contextual status/incidents.
+- Task articles with prerequisites and outcomes.
+- Troubleshooting paths.
+- Related reference.
+- Feedback.
+- Contact escalation with context transferred.
+
+### Design rules
+- Write titles in the user’s vocabulary.
+- Structure procedures as ordered steps with one action per step.
+- Separate symptoms, causes, and fixes.
+- Date and version content.
+- Include screenshots only when they add orientation; keep them current.
+- Pass query, article, and attempted steps into support when consent allows.
+
+### Review questions
+- Can a user find an article from the error wording they see?
+- Does each procedure state its expected result?
+- Are code and UI labels exact?
+- Can users reach human support without repeating everything?
+- Are deprecated versions clearly marked?
+
+---
+
+## 76. Error, offline, empty, and maintenance pages
+
+### Purpose
+Preserve orientation, data, and a productive next step when the normal path is unavailable.
+
+### Recommended sequence
+- Plain statement of the state.
+- Scope: what is and is not affected.
+- Data preservation status.
+- Primary recovery action.
+- Secondary route.
+- Status/support reference.
+- Technical identifier only if useful.
+
+### Design rules
+- Use correct HTTP status codes for server responses.
+- Keep site identity and navigation where safe.
+- Do not blame the user.
+- Differentiate not found, forbidden, expired, unavailable, offline, and empty.
+- Provide retry without causing duplicate actions.
+- Cache an offline shell only when it can represent data truthfully.
+
+### Review questions
+- Can a user recover without using browser refresh repeatedly?
+- Is unsaved work preserved or its loss stated?
+- Does the page work without loading the same failed dependency?
+- Is support information accessible?
+- Does playful copy remain appropriate to the severity?
+
+---

--- a/plugins/design/skills/web-design/references/11-aesthetic-directions-antipatterns.md
+++ b/plugins/design/skills/web-design/references/11-aesthetic-directions-antipatterns.md
@@ -1,0 +1,389 @@
+# Current Aesthetic Directions and Anti-Patterns
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part VIII — Current aesthetic directions
+
+## 77. What feels current in 2026
+These are **directions**, not requirements. Currentness is achieved by translating a cultural signal into a brand-specific system. Copying the visible surface of a trend produces instant datedness.
+
+### 77.1 Expressive typography as the main image
+Large variable type, condensed/wide contrasts, unusual line breaks, kinetic words, and type integrated with imagery remain prominent.
+
+**Why it works**
+
+- language becomes the identity;
+- fewer stock visuals are needed;
+- hierarchy is immediate;
+- a strong type license can create an ownable voice.
+
+**Functional guardrails**
+
+- preserve real text;
+- define narrow-screen line breaks intentionally;
+- cap fluid scaling;
+- provide reduced motion;
+- avoid blocking localization;
+- test diacritics and fallback;
+- keep critical words visible before font load.
+
+**Best fits:** editorial, portfolios, cultural work, launches, fashion, agencies.
+**Use lightly in:** public services, dense dashboards, healthcare tasks.
+
+### 77.2 Human-made texture and imperfect craft
+Grain, print artifacts, hand marks, collage, scanned materials, irregular borders, imperfect type, and documentary photography counter the uniformity of generated digital surfaces.
+
+**Why it works**
+
+- signals authorship;
+- creates tactile memory;
+- distinguishes a small brand;
+- connects physical and digital identity.
+
+**Functional guardrails**
+
+- keep texture out of the text contrast path;
+- compress layers;
+- avoid illegible distressed fonts for body copy;
+- make random effects deterministic enough for visual QA;
+- do not imitate cultural craft without context or credit.
+
+### 77.3 Editorial web layouts
+Asymmetric columns, margin notes, captions, oversized folios, pull quotes, sectional color shifts, and magazine-like pacing are spreading beyond publishing.
+
+**Why it works**
+
+- makes long pages feel composed;
+- supports multiple levels of reading;
+- creates variety without effects;
+- accommodates image-led storytelling.
+
+**Functional guardrails**
+
+- preserve logical source order;
+- keep reading measure controlled;
+- avoid visual jumps that obscure sequence;
+- linearize cleanly on narrow screens;
+- do not make every paragraph a separate “spread.”
+
+### 77.4 Spatial depth and dimensional interfaces
+Layered planes, tilt, perspective, 3D objects, volumetric gradients, and subtle parallax create a sense of place.
+
+**Why it works**
+
+- can demonstrate physical products;
+- makes digital products tangible;
+- creates an iconic hero;
+- supports spatial explanation.
+
+**Functional guardrails**
+
+- static first frame;
+- optional enhancement;
+- no critical copy in canvas;
+- low-end quality tier;
+- reduced-motion treatment;
+- avoid pointer-only discovery;
+- monitor memory and thermal cost.
+
+### 77.5 Purposeful micro-interaction
+Small animated confirmations, magnetic-but-subtle controls, shared-element transitions, expressive selection, and tactile state changes are replacing constant background spectacle.
+
+**Why it works**
+
+- reinforces causality;
+- makes systems feel responsive;
+- supports brand in repeated moments;
+- costs less than a cinematic shell.
+
+**Functional guardrails**
+
+- immediate state before flourish;
+- short duration;
+- no layout shift;
+- no blocked input;
+- clear reduced-motion version;
+- consistent motion language.
+
+### 77.6 Modular “bento” and dashboard composition
+Mixed-size tiles remain common because they package varied content and adapt well to responsive grids.
+
+**Why it works**
+
+- shows breadth;
+- creates a dashboard-like overview;
+- makes modular CMS content easy to arrange;
+- supports visual rhythm.
+
+**Functional guardrails**
+
+- each tile must represent a real content unit;
+- tile size should reflect importance;
+- avoid nested boxes;
+- align repeated content;
+- establish a clear mobile order;
+- do not make cards clickable in conflicting ways.
+
+### 77.7 Minimal copy with overview-first summaries
+Strong proposition lines, compact supporting copy, key points, and “TL;DR” summaries help users orient before choosing depth.
+
+**Why it works**
+
+- reduces initial cognitive load;
+- serves scanning;
+- supports search and answer retrieval;
+- makes complex content approachable.
+
+**Functional guardrails**
+
+- do not erase necessary limitations;
+- preserve deep detail;
+- avoid vague slogan-only pages;
+- provide source and method;
+- ensure summaries do not overstate conclusions.
+
+### 77.8 Rich, coherent color systems
+Brands are moving from one accent on white toward complete tonal environments: warm neutrals, deep canvases, tonal sections, perceptual palettes, and theme-aware illustration.
+
+**Why it works**
+
+- strengthens atmosphere;
+- makes sections and products distinguishable;
+- supports expressive dark themes;
+- can establish identity without heavy media.
+
+**Functional guardrails**
+
+- semantic roles first;
+- contrast in every state;
+- forced-color behavior;
+- avoid decorative semantic colors;
+- test OLED smearing and glare;
+- do not use saturation as the only hierarchy.
+
+### 77.9 Retro-futurism and interface nostalgia
+References to early web, desktop chrome, games, terminals, print catalogs, Y2K graphics, and analog devices remain visible.
+
+**Why it works**
+
+- evokes a shared cultural memory;
+- creates a playful frame;
+- resists generic app polish;
+- can match music, games, fashion, and creative technology.
+
+**Functional guardrails**
+
+- borrow visual language, not obsolete usability;
+- preserve semantic HTML and responsive behavior;
+- do not recreate inaccessible tiny bitmap text;
+- keep browser-like controls from misleading users;
+- make simulated windows keyboard accessible when interactive.
+
+### 77.10 Product UI as marketing art
+Real interfaces, animated workflows, interactive sandboxes, and product-generated visualizations increasingly replace abstract hero art.
+
+**Why it works**
+
+- reduces ambiguity;
+- demonstrates credibility;
+- helps prospects self-qualify;
+- connects visual identity to actual value.
+
+**Functional guardrails**
+
+- use realistic but privacy-safe data;
+- label simulations;
+- provide manual controls;
+- avoid tiny unreadable UI screenshots;
+- optimize the demo separately from the product;
+- never make the demo the only description.
+
+### 77.11 Adaptive and personalized surfaces
+Sites may adapt by theme, locale, account, task history, campaign, or declared preference.
+
+**Why it works**
+
+- reduces irrelevant content;
+- prioritizes frequent tasks;
+- accommodates user settings;
+- makes large systems manageable.
+
+**Functional guardrails**
+
+- prefer declared preference over opaque inference;
+- make personalization visible and reversible;
+- preserve shareable URLs;
+- prevent filter bubbles in informational contexts;
+- avoid exposing sensitive inferred traits;
+- maintain a coherent default.
+
+### 77.12 AI-native interface patterns
+Prompt boxes, multimodal input, generated drafts, provenance indicators, evaluation controls, and human-review checkpoints are becoming ordinary product components.
+
+**Why it works**
+
+- supports flexible intent;
+- compresses complex creation flows;
+- enables conversational refinement;
+- can expose capabilities without huge forms.
+
+**Functional guardrails**
+
+- make system capabilities and limits clear;
+- show what data is used;
+- distinguish source material from generated material;
+- preserve prompt and output history;
+- support edit, retry, compare, undo, and feedback;
+- communicate uncertainty where material;
+- require confirmation for high-impact actions;
+- never imply a person reviewed content when they did not.
+
+**Sources for this section:** current direction summaries from [Webflow’s 2026 web-design trends](https://webflow.com/blog/web-design-trends-2026), [Figma’s web-design trends resource](https://www.figma.com/resource-library/web-design-trends/), and [Framer’s web-design trends overview](https://www.framer.com/blog/web-design-trends/). Use these as evidence of current industry attention, not universal usability research.
+
+---
+
+## 78. Trend translation matrix
+Use this table to turn a visual reference into a controlled system.
+
+|Trend/reference|Extract the principle|Safe implementation|High-risk imitation|
+|---|---|---|---|
+|Oversized type|decisive hierarchy|one display scale, short copy|every heading fills viewport|
+|Bento grid|modular overview|meaningful modules and order|arbitrary box soup|
+|Glass|layered depth|limited raised surfaces|blurred text over busy video|
+|Brutalism|directness and contrast|plain structure, bold type|broken conventions and low accessibility|
+|Grain|human texture|lightweight overlay|noisy readability|
+|3D hero|embodied product idea|static poster + progressive canvas|mandatory GPU-heavy intro|
+|Scroll story|controlled narrative|chaptered, skippable sequence|scroll hijacking|
+|Retro UI|cultural memory|visual motifs on modern semantics|fake windows with fake controls|
+|Minimalism|focus|fewer elements, stronger content|missing labels and faint type|
+|Maximalism|layered expression|coherent palette and hierarchy|every element competing|
+|Monochrome|tonal cohesion|high-contrast tonal ramp|indistinguishable states|
+|Dark mode|reduced glare/atmosphere|redesigned semantic theme|inverted light theme|
+|Kinetic type|language as image|short, optional, reduced motion|unreadable moving body copy|
+|AI aesthetic|possibility and transformation|product-specific generated artifacts|generic purple glow|
+|Hand-drawn|authorship|custom marks and illustration grammar|random doodles on every section|
+|Editorial asymmetry|pacing|grid-anchored variation|inaccessible source-order tricks|
+|Horizontal gallery|spatial collection|optional track with controls|entire page rotated sideways|
+|Cursor interaction|playful affordance|secondary enhancement|replacing familiar pointer behavior|
+|Dynamic color|content connection|tokenized extraction with contrast|unpredictable text backgrounds|
+|Full-bleed video|atmosphere|compressed, muted, pausable|blocking LCP and autoplay audio|
+
+### A five-question trend filter
+Before adopting a direction, ask:
+
+1. Does it express something specific about this brand, product, or content?
+2. Does it improve hierarchy, comprehension, emotion, or demonstration?
+3. What is the fallback?
+4. What does it cost in accessibility, performance, content production, and maintenance?
+5. Will it still look intentional when the novelty fades?
+
+If the only answer is “it looks modern,” do not build it.
+
+---
+
+## 79. Anti-patterns
+
+### Visual anti-patterns
+- Pale gray body text presented as sophistication.
+- Four different corner-radius personalities on one page.
+- Random gradient blobs with no relation to content.
+- Every section using a different layout trick.
+- Every element inside a card.
+- Shadows used instead of hierarchy.
+- Huge display copy that says very little.
+- Generic device mockups floating in empty space.
+- Stock photos chosen by keyword rather than art direction.
+- Dark mode made by inverting colors.
+- Decorative grids that imply alignment but do not align content.
+- Glass layers without a coherent depth model.
+- Icons from incompatible families.
+- Generated imagery with unresolved text, anatomy, or symbolism.
+
+### Interaction anti-patterns
+- Scroll hijacking.
+- Hover-only content.
+- Custom cursor required to understand actions.
+- Carousels that rotate before reading is possible.
+- Tiny click targets.
+- Icon-only navigation for unfamiliar concepts.
+- Modals on arrival.
+- Nested scrolling regions.
+- Disabled buttons with no explanation.
+- Focus removed for aesthetic reasons.
+- Drag as the only way to reorder or set a value.
+- Surprise audio.
+- Automatic page transitions that delay navigation.
+- Swipe-only galleries.
+- Tooltips containing essential instructions.
+- Toasts for errors requiring action.
+
+### Content anti-patterns
+- “Revolutionize,” “reimagine,” and “next-generation” without specifics.
+- Navigation labels based on company departments.
+- “Learn more” repeated everywhere.
+- Benefits without mechanism or proof.
+- Case studies with no role or outcome context.
+- Placeholder FAQ content.
+- Legal constraints hidden in tiny text.
+- Artificially short copy that removes material details.
+- SEO text inserted before the primary task.
+- A company story told only as a vague manifesto.
+- AI-generated prose published without factual review or authorship policy.
+
+### Conversion anti-patterns
+- Fake scarcity.
+- Resetting countdown timers.
+- Preselected paid additions.
+- Forced account creation.
+- Hidden recurring billing.
+- Unequal accept/reject choices.
+- Cancellation by phone when signup was online.
+- Confirmshaming.
+- Lead capture before useful information.
+- Price revealed only after unnecessary qualification.
+- “Recommended” plan driven by margin but presented as user fit.
+- Notifications enabled through coercion.
+
+### Technical anti-patterns
+- Client-only rendering for essential public content without need.
+- Shipping a large framework bundle for a static page.
+- Loading every font weight.
+- Lazy-loading the LCP image.
+- Missing image dimensions.
+- Large fixed blur layers.
+- Third parties without ownership or budget.
+- A breakpoint for every device.
+- JavaScript reimplementations of native controls.
+- Excessive `will-change`.
+- High-resolution video on all devices.
+- Animation loops continuing off-screen.
+- CSS tied to arbitrary DOM depth.
+- CMS options that expose raw spacing and color values.
+
+### Accessibility anti-patterns
+- ARIA added to nonfunctional custom widgets.
+- Positive `tabindex`.
+- Placeholder-only fields.
+- Color-only errors or chart series.
+- Headings chosen by size instead of structure.
+- Text in images.
+- Captions omitted because video is “mostly visual.”
+- Focus trapped behind an overlay.
+- Inaccessible CAPTCHA.
+- Session timeout without warning.
+- Password paste blocked.
+- Important content hidden in hover cards.
+- Motion without reduced alternative.
+- Zoom causing clipped controls.
+- Disabled zoom in the viewport meta tag.
+
+### Organizational anti-patterns
+- Accessibility as a launch audit.
+- Performance as an engineering cleanup.
+- Content added after layout approval.
+- A design system with no governance.
+- Components accepted based only on default screenshots.
+- No ownership for stale pages.
+- Separate designer and engineer issue queues.
+- Trend selection by executive preference alone.
+- Copying award sites without matching their budget or purpose.
+- Measuring click-through while ignoring completion and harm.

--- a/plugins/design/skills/web-design/references/12-cookbook-page-components.md
+++ b/plugins/design/skills/web-design/references/12-cookbook-page-components.md
@@ -1,0 +1,559 @@
+# Implementation Cookbook: Page and Component Foundations
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+# Part IX — Practical tools
+
+## 80. Implementation cookbook
+The snippets below are composable starting points. Adapt naming, support policy, and framework integration. Keep semantics intact.
+
+### 80.1 A semantic page shell
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Specific page title — Site name</title>
+    <meta name="description" content="A specific description of this page.">
+    <link rel="canonical" href="https://example.com/current-page">
+    <link rel="stylesheet" href="/assets/site.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+      <a href="/" aria-label="Site name, home">
+        <svg aria-hidden="true" focusable="false"><!-- logo --></svg>
+      </a>
+
+      <nav aria-label="Primary">
+        <ul>
+          <li><a href="/products">Products</a></li>
+          <li><a href="/work">Work</a></li>
+          <li><a href="/about">About</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main id="main" tabindex="-1">
+      <h1>Page heading</h1>
+      <!-- page content -->
+    </main>
+
+    <footer>
+      <nav aria-label="Footer"><!-- secondary links --></nav>
+    </footer>
+
+    <script type="module" src="/assets/site.js"></script>
+  </body>
+</html>
+```
+
+Notes:
+
+- The skip target may use `tabindex="-1"` if your route/focus strategy needs programmatic focus.
+- Give multiple navigation regions distinct accessible labels.
+- Keep one primary page heading in most ordinary pages; nested component headings should reflect structure.
+- Use SVG logos with an accessible name on the link, not duplicate text inside the SVG.
+
+### 80.2 Foundations with cascade layers
+```css
+@layer reset, tokens, base, layout, components, utilities, overrides;
+
+@layer reset {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    hanging-punctuation: first last;
+  }
+
+  body,
+  h1,
+  h2,
+  h3,
+  p,
+  figure,
+  blockquote,
+  dl,
+  dd {
+    margin: 0;
+  }
+
+  img,
+  picture,
+  video,
+  canvas,
+  svg {
+    display: block;
+    max-inline-size: 100%;
+  }
+
+  button,
+  input,
+  textarea,
+  select {
+    font: inherit;
+  }
+}
+
+@layer tokens {
+  :root {
+    --canvas: oklch(98% 0.008 255);
+    --surface: oklch(100% 0 0);
+    --text: oklch(20% 0.025 255);
+    --text-muted: oklch(45% 0.025 255);
+    --border: oklch(86% 0.018 255);
+    --accent: oklch(58% 0.21 263);
+    --accent-hover: oklch(52% 0.21 263);
+    --on-accent: white;
+    --focus: oklch(76% 0.18 92);
+    --danger: oklch(55% 0.2 27);
+
+    --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
+    --font-serif: "Source Serif 4", ui-serif, Georgia, serif;
+    --font-mono: "SFMono-Regular", Consolas, monospace;
+
+    --step--1: clamp(0.875rem, 0.84rem + 0.15vw, 1rem);
+    --step-0: clamp(1rem, 0.95rem + 0.25vw, 1.125rem);
+    --step-1: clamp(1.25rem, 1.14rem + 0.55vw, 1.58rem);
+    --step-2: clamp(1.56rem, 1.33rem + 1.15vw, 2.25rem);
+    --step-3: clamp(1.95rem, 1.52rem + 2.15vw, 3.25rem);
+    --step-4: clamp(2.44rem, 1.66rem + 3.9vw, 4.8rem);
+
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+    --space-section: clamp(4rem, 8vw, 8rem);
+
+    --radius-sm: 0.5rem;
+    --radius-md: 0.875rem;
+    --radius-lg: 1.5rem;
+
+    --duration-fast: 140ms;
+    --duration-medium: 240ms;
+    --ease-standard: cubic-bezier(.2, .8, .2, 1);
+  }
+}
+
+@layer base {
+  html {
+    color-scheme: light;
+    scroll-behavior: smooth;
+  }
+
+  body {
+    min-block-size: 100vh;
+    background: var(--canvas);
+    color: var(--text);
+    font-family: var(--font-sans);
+    font-size: var(--step-0);
+    line-height: 1.55;
+    text-rendering: optimizeLegibility;
+  }
+
+  h1,
+  h2,
+  h3 {
+    line-height: 1.08;
+    text-wrap: balance;
+  }
+
+  p,
+  li {
+    text-wrap: pretty;
+  }
+
+  a {
+    color: currentColor;
+    text-decoration-thickness: 0.08em;
+    text-underline-offset: 0.17em;
+  }
+
+  :focus-visible {
+    outline: 3px solid var(--focus);
+    outline-offset: 3px;
+  }
+
+  ::selection {
+    background: color-mix(in oklch, var(--accent) 30%, transparent);
+  }
+}
+```
+
+`text-wrap: balance` and `pretty` are enhancements. Do not depend on them to prevent overflow.
+
+### 80.3 Skip link
+```css
+.skip-link {
+  position: fixed;
+  z-index: 1000;
+  inset-block-start: 0.75rem;
+  inset-inline-start: 0.75rem;
+  translate: 0 -200%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  background: var(--text);
+  color: var(--canvas);
+}
+
+.skip-link:focus {
+  translate: 0;
+}
+```
+
+Avoid `display: none` or `visibility: hidden`; the link must be focusable.
+
+### 80.4 Full-bleed layout with readable content
+```css
+.page-grid {
+  --gutter: clamp(1rem, 4vw, 4rem);
+  --content: min(72rem, calc(100vw - 2 * var(--gutter)));
+  --reading: min(68ch, calc(100vw - 2 * var(--gutter)));
+
+  display: grid;
+  grid-template-columns:
+    [full-start] minmax(var(--gutter), 1fr)
+    [content-start] minmax(0, calc((var(--content) - var(--reading)) / 2))
+    [reading-start] minmax(0, var(--reading))
+    [reading-end] minmax(0, calc((var(--content) - var(--reading)) / 2))
+    [content-end] minmax(var(--gutter), 1fr)
+    [full-end];
+}
+
+.page-grid > * {
+  grid-column: reading;
+}
+
+.page-grid > .wide {
+  grid-column: content;
+}
+
+.page-grid > .full {
+  grid-column: full;
+}
+```
+
+This pattern lets prose, wide figures, and full-width bands coexist without one-off negative margins.
+
+### 80.5 Auto-fit cards with container adaptation
+```css
+.card-grid {
+  display: grid;
+  grid-template-columns:
+    repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: clamp(1rem, 2vw, 2rem);
+}
+
+.card {
+  container: card / inline-size;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: clip;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.card__body {
+  padding: clamp(1rem, 5cqi, 2rem);
+}
+
+@container card (min-width: 30rem) {
+  .card--feature {
+    grid-template-columns: 1fr 1.2fr;
+    grid-template-rows: auto;
+  }
+}
+```
+
+Use container query units only when they improve a component. They can become difficult to reason about when nested indiscriminately.
+
+### 80.6 A stack and cluster utility
+```css
+.stack {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.stack > * {
+  margin-block: 0;
+}
+
+.stack > * + * {
+  margin-block-start: var(--stack-space, 1rem);
+}
+
+.cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cluster-gap, 0.75rem);
+  align-items: var(--cluster-align, center);
+  justify-content: var(--cluster-justify, flex-start);
+}
+```
+
+These two primitives cover much ordinary layout without component-specific margins.
+
+### 80.7 Accessible button styles
+```html
+<button class="button button--primary" type="button">
+  <span>Save changes</span>
+</button>
+```
+
+```css
+.button {
+  display: inline-flex;
+  min-block-size: 2.75rem;
+  min-inline-size: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  font-weight: 650;
+  line-height: 1.1;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    translate var(--duration-fast) var(--ease-standard);
+}
+
+.button--primary {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.button--primary:hover {
+  background: var(--accent-hover);
+}
+
+.button:active {
+  translate: 0 1px;
+}
+
+.button[aria-busy="true"] {
+  cursor: progress;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+}
+```
+
+Do not use `pointer-events: none` on disabled controls if users need to reach an explanation. Consider an enabled button that validates instead.
+
+### 80.8 Icon-only button
+```html
+<button class="icon-button" type="button" aria-label="Close dialog">
+  <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+    <path d="M6 6l12 12M18 6L6 18" />
+  </svg>
+</button>
+```
+
+```css
+.icon-button {
+  display: grid;
+  inline-size: 2.75rem;
+  block-size: 2.75rem;
+  place-items: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: currentColor;
+}
+
+.icon-button svg {
+  inline-size: 1.25rem;
+  block-size: 1.25rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+}
+```
+
+The accessible name describes the action, not the icon’s appearance.
+
+### 80.9 Form field with help and error
+```html
+<div class="field" data-state="error">
+  <label for="company">
+    Company name
+    <span class="field__optional">Optional</span>
+  </label>
+
+  <p id="company-help" class="field__help">
+    Use the name shown on your invoices.
+  </p>
+
+  <input
+    id="company"
+    name="company"
+    type="text"
+    autocomplete="organization"
+    aria-describedby="company-help company-error"
+    aria-invalid="true">
+
+  <p id="company-error" class="field__error">
+    Enter 100 characters or fewer.
+  </p>
+</div>
+```
+
+```css
+.field {
+  display: grid;
+  gap: 0.4rem;
+  max-inline-size: 36rem;
+}
+
+.field label {
+  font-weight: 650;
+}
+
+.field__help {
+  color: var(--text-muted);
+  font-size: var(--step--1);
+}
+
+.field input {
+  min-block-size: 2.75rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.field input[aria-invalid="true"] {
+  border-color: var(--danger);
+  border-inline-start-width: 0.3rem;
+}
+
+.field__error {
+  color: var(--danger);
+  font-weight: 600;
+}
+```
+
+Only include the error ID in `aria-describedby` while the error exists. Do not announce the same message repeatedly on every keystroke.
+
+### 80.10 Error summary
+```html
+<section
+  class="error-summary"
+  role="alert"
+  aria-labelledby="error-summary-title"
+  tabindex="-1">
+  <h2 id="error-summary-title">Fix 2 fields</h2>
+  <ul>
+    <li><a href="#email">Enter a valid email address</a></li>
+    <li><a href="#postal-code">Enter a postal code</a></li>
+  </ul>
+</section>
+```
+
+On failed submission, focus the summary and let each link focus its corresponding field.
+
+### 80.11 Native dialog with focus restoration
+```html
+<button id="open-delete" type="button">Delete project</button>
+
+<dialog id="delete-dialog" aria-labelledby="delete-title">
+  <form method="dialog">
+    <h2 id="delete-title">Delete “Ocean Atlas”?</h2>
+    <p>The project will move to trash for 30 days.</p>
+    <div class="cluster">
+      <button value="cancel">Cancel</button>
+      <button value="confirm" class="button--danger">Move to trash</button>
+    </div>
+  </form>
+</dialog>
+```
+
+```js
+const trigger = document.querySelector("#open-delete");
+const dialog = document.querySelector("#delete-dialog");
+
+trigger?.addEventListener("click", () => dialog?.showModal());
+
+dialog?.addEventListener("close", () => {
+  trigger?.focus();
+
+  if (dialog.returnValue === "confirm") {
+    // Perform the destructive action, then expose undo when safe.
+  }
+});
+```
+
+Native `<dialog>` supplies important behavior, but test screen-reader/browser combinations in your support matrix. Ensure close buttons, Escape behavior, and destructive wording match the consequence.
+
+### 80.12 Disclosure
+```html
+<details>
+  <summary>What happens after the trial?</summary>
+  <div class="prose">
+    <p>Your workspace remains available in read-only mode...</p>
+  </div>
+</details>
+```
+
+Use native disclosure for ordinary expandable content. A disclosure is not automatically a tab, menu, or modal.
+
+### 80.13 Responsive image with correct sizing
+```html
+<img
+  src="/media/project-960.webp"
+  srcset="
+    /media/project-480.webp 480w,
+    /media/project-960.webp 960w,
+    /media/project-1440.webp 1440w,
+    /media/project-1920.webp 1920w"
+  sizes="
+    (min-width: 80rem) 70rem,
+    (min-width: 50rem) calc(100vw - 6rem),
+    calc(100vw - 2rem)"
+  width="1600"
+  height="1000"
+  alt="A dashboard comparing tidal temperature readings"
+  decoding="async">
+```
+
+Use `loading="lazy"` for appropriate below-the-fold images. Omit it for likely LCP imagery and consider `fetchpriority="high"` only for the true priority resource.
+
+### 80.14 Art-directed picture
+```html
+<picture>
+  <source
+    media="(min-width: 64rem)"
+    srcset="/media/team-wide.avif"
+    type="image/avif">
+  <source
+    media="(min-width: 64rem)"
+    srcset="/media/team-wide.webp"
+    type="image/webp">
+  <source
+    srcset="/media/team-tight.avif"
+    type="image/avif">
+  <img
+    src="/media/team-tight.jpg"
+    width="900"
+    height="1100"
+    alt="The research team testing sensors on a pier">
+</picture>
+```
+
+The crop changes, but the semantic meaning and alt text remain consistent.

--- a/plugins/design/skills/web-design/references/13-cookbook-interaction-quality.md
+++ b/plugins/design/skills/web-design/references/13-cookbook-interaction-quality.md
@@ -1,0 +1,486 @@
+# Implementation Cookbook: Interaction, Media, Performance, and Readiness
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+### 80.15 Font face with fallback metrics
+```css
+@font-face {
+  font-family: "Brand Sans";
+  src: url("/fonts/brand-sans.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 300 800;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Brand Sans Fallback";
+  src: local("Arial");
+  size-adjust: 101%;
+  ascent-override: 91%;
+  descent-override: 23%;
+  line-gap-override: 0%;
+}
+
+:root {
+  --font-sans: "Brand Sans", "Brand Sans Fallback", sans-serif;
+}
+```
+
+Calculate overrides for the actual fonts. Incorrect metrics can make fallback rendering worse.
+
+### 80.16 Theme preference with system default
+```html
+<button type="button" id="theme-toggle" aria-pressed="false">
+  Use dark theme
+</button>
+```
+
+```css
+:root {
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: oklch(17% 0.018 255);
+  --surface: oklch(22% 0.02 255);
+  --text: oklch(94% 0.01 255);
+  --text-muted: oklch(74% 0.018 255);
+  --border: oklch(35% 0.025 255);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --canvas: oklch(17% 0.018 255);
+    --surface: oklch(22% 0.02 255);
+    --text: oklch(94% 0.01 255);
+    --text-muted: oklch(74% 0.018 255);
+    --border: oklch(35% 0.025 255);
+  }
+}
+```
+
+```js
+const root = document.documentElement;
+const button = document.querySelector("#theme-toggle");
+const stored = localStorage.getItem("theme");
+
+if (stored === "light" || stored === "dark") {
+  root.dataset.theme = stored;
+}
+
+function resolvedTheme() {
+  if (root.dataset.theme) return root.dataset.theme;
+  return matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function syncButton() {
+  const dark = resolvedTheme() === "dark";
+  button?.setAttribute("aria-pressed", String(dark));
+  if (button) button.textContent = dark ? "Use light theme" : "Use dark theme";
+}
+
+button?.addEventListener("click", () => {
+  const next = resolvedTheme() === "dark" ? "light" : "dark";
+  root.dataset.theme = next;
+  localStorage.setItem("theme", next);
+  syncButton();
+});
+
+syncButton();
+```
+
+A three-option control—system, light, dark—is often clearer than a binary toggle.
+
+### 80.17 Reduced-motion strategy
+```css
+.reveal {
+  opacity: 0;
+  translate: 0 1rem;
+  transition:
+    opacity 400ms var(--ease-standard),
+    translate 400ms var(--ease-standard);
+}
+
+.reveal[data-visible="true"] {
+  opacity: 1;
+  translate: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .reveal {
+    opacity: 1;
+    translate: none;
+    transition: none;
+  }
+
+  .ambient,
+  .parallax,
+  [data-auto-animate] {
+    animation: none !important;
+    transform: none !important;
+  }
+}
+```
+
+Do not disable indeterminate progress indicators or other motion required to communicate ongoing state. Replace or simplify them.
+
+### 80.18 Intersection-based progressive reveal
+```js
+const elements = document.querySelectorAll(".reveal");
+
+if (
+  !matchMedia("(prefers-reduced-motion: reduce)").matches &&
+  "IntersectionObserver" in window
+) {
+  const observer = new IntersectionObserver(
+    entries => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          entry.target.dataset.visible = "true";
+          observer.unobserve(entry.target);
+        }
+      }
+    },
+    { rootMargin: "0px 0px -10% 0px" }
+  );
+
+  elements.forEach(element => observer.observe(element));
+} else {
+  elements.forEach(element => {
+    element.dataset.visible = "true";
+  });
+}
+```
+
+Content should exist and be accessible before the reveal script runs. Avoid leaving content permanently transparent when JavaScript fails.
+
+### 80.19 Accessible status announcements
+```html
+<div
+  id="save-status"
+  class="visually-hidden"
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"></div>
+```
+
+```css
+.visually-hidden {
+  position: absolute !important;
+  inline-size: 1px !important;
+  block-size: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+```
+
+```js
+const status = document.querySelector("#save-status");
+
+async function save(data) {
+  if (status) status.textContent = "Saving";
+
+  try {
+    await persist(data);
+    if (status) status.textContent = "Changes saved";
+  } catch {
+    if (status) status.textContent = "Changes were not saved";
+    // Also show a visible, actionable error.
+  }
+}
+```
+
+Do not flood live regions with rapid updates. A visible status is still required when the information matters to everyone.
+
+### 80.20 A responsive data table wrapper
+```html
+<div class="table-region" tabindex="0" role="region"
+     aria-labelledby="invoice-table-title">
+  <table>
+    <caption id="invoice-table-title">Invoices, April to June 2026</caption>
+    <thead>
+      <tr>
+        <th scope="col">Invoice</th>
+        <th scope="col">Customer</th>
+        <th scope="col">Issued</th>
+        <th scope="col" class="numeric">Amount</th>
+        <th scope="col">Status</th>
+      </tr>
+    </thead>
+    <tbody><!-- rows --></tbody>
+  </table>
+</div>
+```
+
+```css
+.table-region {
+  max-inline-size: 100%;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+table {
+  inline-size: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  border-block-end: 1px solid var(--border);
+  text-align: start;
+  white-space: nowrap;
+}
+
+th {
+  position: sticky;
+  inset-block-start: 0;
+  background: var(--surface);
+}
+
+.numeric {
+  text-align: end;
+}
+```
+
+A focusable scroll region helps keyboard users access horizontal overflow, but do not add `tabindex` to every small table. Label the region and test announcement.
+
+### 80.21 Responsive embedded media
+```css
+.media-frame {
+  overflow: clip;
+  border-radius: var(--radius-lg);
+  aspect-ratio: 16 / 9;
+  background: var(--surface);
+}
+
+.media-frame > iframe,
+.media-frame > video,
+.media-frame > img {
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: cover;
+}
+```
+
+For third-party embeds, use a lightweight poster/consent placeholder and initialize on intent when possible.
+
+### 80.22 Visually stable async content
+```css
+.product-media {
+  aspect-ratio: 4 / 5;
+  background: color-mix(in oklch, var(--surface) 80%, var(--border));
+}
+
+.recommendation-slot {
+  min-block-size: 18rem;
+  contain: layout paint;
+}
+```
+
+Reserve expected space, but avoid huge empty blocks when content may never appear. Collapse with an explicit completed-empty state rather than a delayed jump.
+
+### 80.23 CSS-only decorative atmosphere
+```css
+.hero {
+  position: relative;
+  isolation: isolate;
+  overflow: clip;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  inset: -30%;
+  background:
+    radial-gradient(circle at 25% 25%,
+      color-mix(in oklch, var(--accent) 30%, transparent),
+      transparent 35%),
+    radial-gradient(circle at 75% 60%,
+      oklch(72% 0.17 330 / 0.22),
+      transparent 32%);
+  filter: blur(3rem);
+  pointer-events: none;
+}
+```
+
+Keep decorative effects isolated, noninteractive, and outside contrast-critical areas. Measure paint cost on real mobile hardware.
+
+### 80.24 Feature detection and fallback
+```css
+.surface {
+  background: rgb(255 255 255 / 0.96);
+}
+
+@supports (background: color-mix(in oklch, white, black)) {
+  .surface {
+    background:
+      color-mix(in oklch, var(--surface) 88%, transparent);
+  }
+}
+
+@supports (backdrop-filter: blur(1rem)) {
+  .surface--glass {
+    backdrop-filter: blur(1rem);
+  }
+}
+```
+
+Feature detection answers whether syntax is understood, not whether performance is acceptable.
+
+### 80.25 Route-change focus helper
+For client-rendered navigation, update the document title and move focus intentionally.
+
+```ts
+export function announceRoute(
+  title: string,
+  heading: HTMLElement | null
+): void {
+  document.title = `${title} — Product name`;
+
+  requestAnimationFrame(() => {
+    if (!heading) return;
+    heading.setAttribute("tabindex", "-1");
+    heading.focus({ preventScroll: true });
+    heading.scrollIntoView({ block: "start" });
+  });
+}
+```
+
+Only use this after actual route changes, not routine state updates. Avoid leaving every heading in the tab sequence.
+
+### 80.26 A performance-aware 3D/media enhancement contract
+Before loading an immersive module, evaluate:
+
+```js
+const reduceMotion = matchMedia(
+  "(prefers-reduced-motion: reduce)"
+).matches;
+
+const saveData = navigator.connection?.saveData === true;
+const lowMemory =
+  typeof navigator.deviceMemory === "number" &&
+  navigator.deviceMemory <= 4;
+
+const canEnhance = !reduceMotion && !saveData && !lowMemory;
+
+if (canEnhance) {
+  import("./immersive-hero.js")
+    .then(({ mount }) => mount(document.querySelector("#hero-canvas")))
+    .catch(() => {
+      // Keep the static poster already present.
+    });
+}
+```
+
+These signals are incomplete and not universally available. Use them as hints, never as identity or capability judgments. Also provide a manual pause or static-mode control for expensive experiences.
+
+### 80.27 Structured data example
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Designing a resilient tidal sensor network",
+  "datePublished": "2026-05-12",
+  "dateModified": "2026-06-02",
+  "author": {
+    "@type": "Person",
+    "name": "Amina Haddad"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Ocean Atlas"
+  },
+  "mainEntityOfPage": "https://example.com/journal/tidal-sensors"
+}
+</script>
+```
+
+The data must match visible page content. Validate it using the relevant search tooling and schema documentation.
+
+### 80.28 Content security and external links
+For links that open a new context, do not add `target="_blank"` by default. When required:
+
+```html
+<a
+  href="https://external.example/report"
+  target="_blank"
+  rel="noopener noreferrer">
+  Read the independent report
+  <span class="visually-hidden">(opens in a new tab)</span>
+</a>
+```
+
+Opening new tabs can disorient users. Use it selectively and communicate the behavior.
+
+### 80.29 Print style for useful pages
+```css
+@media print {
+  header,
+  footer,
+  nav,
+  .no-print,
+  [data-interactive-only] {
+    display: none !important;
+  }
+
+  body {
+    background: white;
+    color: black;
+    font: 11pt/1.45 Georgia, serif;
+  }
+
+  main {
+    max-inline-size: none;
+  }
+
+  a[href]::after {
+    content: " (" attr(href) ")";
+    overflow-wrap: anywhere;
+  }
+
+  h2,
+  h3,
+  figure {
+    break-inside: avoid;
+  }
+}
+```
+
+For receipts, directions, articles, legal material, and public services, print remains a real use case.
+
+### 80.30 Component readiness checklist
+Before publishing a component:
+
+```text
+[ ] Semantic element/role is correct
+[ ] Accessible name and description are correct
+[ ] Keyboard model is documented and tested
+[ ] Default, hover, active, focus, selected, disabled states exist
+[ ] Loading, success, error, empty states exist where relevant
+[ ] Pointer target is large enough
+[ ] Contrast passes in every theme/state
+[ ] Content can wrap and expand
+[ ] RTL and localization have been tested
+[ ] Reduced motion is defined
+[ ] Forced colors are usable
+[ ] Performance cost is measured
+[ ] Analytics do not expose sensitive data
+[ ] Visual regression examples exist
+[ ] Ownership and version are documented
+```

--- a/plugins/design/skills/web-design/references/14-launch-checklists.md
+++ b/plugins/design/skills/web-design/references/14-launch-checklists.md
@@ -1,0 +1,234 @@
+# Launch Checklists
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+## 81. Launch checklists
+A checklist does not replace judgment. Use it to prevent known omissions, then perform scenario-based testing.
+
+### 81.1 Strategy and scope
+- [ ] The primary audience and task are named.
+- [ ] Secondary audiences have deliberate routes.
+- [ ] The proposition is specific and defensible.
+- [ ] Primary and secondary conversions are defined.
+- [ ] Success metrics measure completion and quality, not clicks alone.
+- [ ] Browser/device support is documented.
+- [ ] Accessibility target is documented.
+- [ ] Performance budgets are documented.
+- [ ] Localization requirements are documented.
+- [ ] Privacy, legal, and security owners are involved.
+- [ ] Content ownership and review dates exist.
+- [ ] High-risk technical or visual ideas were prototyped early.
+- [ ] The design ambition matches content and maintenance capacity.
+- [ ] Launch scope excludes features that cannot be finished safely.
+- [ ] A rollback or feature-disable path exists for risky enhancements.
+
+### 81.2 Information architecture and content
+- [ ] Navigation reflects audience vocabulary.
+- [ ] Top tasks are reachable through obvious paths.
+- [ ] Page titles and headings are unique and descriptive.
+- [ ] Every page has one clear purpose.
+- [ ] Calls to action describe their consequence.
+- [ ] Claims have evidence or are softened appropriately.
+- [ ] Dates, currencies, units, time zones, and availability are explicit.
+- [ ] Pricing, recurring billing, fees, and cancellation are clear.
+- [ ] Error, empty, loading, offline, and success copy exists.
+- [ ] Contact and support routes are current.
+- [ ] Policies are readable and linked at relevant decision points.
+- [ ] Stale and duplicate content has been removed or redirected.
+- [ ] Links use meaningful text.
+- [ ] Images have purposeful alt text or empty alt.
+- [ ] Video has captions and required alternatives.
+- [ ] Content survives long strings and missing media.
+- [ ] Authors, update dates, and correction paths exist where needed.
+- [ ] Search results and zero-results states are written.
+- [ ] The 404 page offers useful routes.
+- [ ] HTML is preferred to inaccessible document-only publishing.
+
+### 81.3 Visual design and brand
+- [ ] The page has a clear first focal point.
+- [ ] Primary action is visually distinct without coercion.
+- [ ] There is one dominant signature device, not many competing effects.
+- [ ] Typography roles are consistent.
+- [ ] Body text has comfortable measure and line height.
+- [ ] Text and non-text contrast pass.
+- [ ] Inline links remain identifiable.
+- [ ] Color is not the only status cue.
+- [ ] Spacing expresses grouping consistently.
+- [ ] Alignment is intentional across templates.
+- [ ] Cards are used only for meaningful units.
+- [ ] Icon styles are coherent and labels exist where needed.
+- [ ] Image crops follow a system.
+- [ ] Dark mode, if present, is individually art-directed.
+- [ ] High contrast/forced colors remain understandable.
+- [ ] Real content has been used in visual QA.
+- [ ] The design remains coherent with missing or extreme content.
+- [ ] Print styles exist for print-relevant pages.
+- [ ] Generated assets have been reviewed and disclosed where needed.
+- [ ] Brand expression does not hide standard controls.
+
+### 81.4 Responsive and device behavior
+- [ ] Source order is logical without CSS.
+- [ ] Navigation works at all widths.
+- [ ] No ordinary content causes unintended horizontal page scrolling.
+- [ ] Text and controls survive 200% zoom.
+- [ ] Layout reflows under enlarged text.
+- [ ] Sticky elements do not cover focus or content.
+- [ ] Mobile keyboard does not hide active fields or submit.
+- [ ] Touch targets are sufficiently large and separated.
+- [ ] Hover enhancements have touch and keyboard equivalents.
+- [ ] Orientation changes preserve task state.
+- [ ] Very short viewport heights are usable.
+- [ ] Very wide displays do not create extreme line lengths.
+- [ ] Images use appropriate sources and crops.
+- [ ] Tables have an intentional narrow-screen strategy.
+- [ ] Modals and sheets can scroll internally without trapping the page.
+- [ ] Safe-area insets are respected in full-screen layouts.
+- [ ] Back navigation restores useful state.
+- [ ] Filters and search state are shareable where appropriate.
+- [ ] Device testing includes low-end hardware.
+- [ ] Embedded contexts and container widths are tested where relevant.
+
+### 81.5 Accessibility
+- [ ] Document language is declared.
+- [ ] Each page has a unique title.
+- [ ] A skip link reaches main content.
+- [ ] Heading order communicates structure.
+- [ ] Landmarks are correct and not excessive.
+- [ ] Native elements are used where possible.
+- [ ] Every function is keyboard operable.
+- [ ] Focus order follows meaning.
+- [ ] Focus is always visible.
+- [ ] Dialogs manage and restore focus.
+- [ ] No keyboard trap exists.
+- [ ] Hover/focus content is dismissible, hoverable, and persistent as needed.
+- [ ] Pointer target requirements are met.
+- [ ] Dragging has a non-drag alternative.
+- [ ] Forms have visible labels and associated help.
+- [ ] Errors are identified in text and announced.
+- [ ] Authentication allows paste and assistive mechanisms.
+- [ ] Time limits are explained and adjustable where required.
+- [ ] Status messages are announced without focus theft.
+- [ ] Alternative text matches image purpose.
+- [ ] Captions, transcripts, and audio description/equivalent are supplied.
+- [ ] Moving content can be paused, stopped, or hidden where required.
+- [ ] Reduced-motion preference is honored.
+- [ ] Content works with user text-spacing overrides.
+- [ ] Content reflows under zoom.
+- [ ] Forced-colors mode is usable.
+- [ ] Automated scans have been manually triaged.
+- [ ] A keyboard-only pass is complete.
+- [ ] Screen-reader flows for core tasks are complete.
+- [ ] Accessibility feedback has an owner and route.
+
+### 81.6 Forms and transactional flows
+- [ ] Only necessary information is requested.
+- [ ] Guest completion is available where appropriate.
+- [ ] Input types, input modes, and autocomplete tokens are correct.
+- [ ] Required/optional strategy is consistent.
+- [ ] Instructions appear before the action.
+- [ ] Validation does not punish incomplete typing.
+- [ ] Errors preserve submitted data.
+- [ ] Long forms provide progress and save/resume where needed.
+- [ ] File uploads state size/type and offer a non-drag path.
+- [ ] Submission shows immediate feedback.
+- [ ] Duplicate submissions are prevented safely.
+- [ ] Retry cannot create duplicate charges or records.
+- [ ] Final review shows all material facts.
+- [ ] Success state includes durable reference and next steps.
+- [ ] Destructive actions match consequence and support undo/recovery.
+- [ ] Session expiry warns and preserves work where possible.
+- [ ] Password managers and passkeys are supported as applicable.
+- [ ] Address forms support relevant countries.
+- [ ] Dates and phone numbers are not overvalidated.
+- [ ] Payment failure and recovery have been tested.
+
+### 81.7 Performance
+- [ ] Field Core Web Vitals or a collection plan exists.
+- [ ] LCP, INP, and CLS targets are met on representative templates.
+- [ ] LCP resource is discovered and prioritized appropriately.
+- [ ] Likely LCP imagery is not lazy-loaded.
+- [ ] Images have intrinsic dimensions.
+- [ ] Responsive image sources and sizes are correct.
+- [ ] Below-the-fold media is lazy-loaded appropriately.
+- [ ] Font families, weights, and preloads are limited.
+- [ ] Fallback font metrics reduce shift.
+- [ ] Initial JavaScript fits the budget.
+- [ ] Route and component code splitting is effective.
+- [ ] Long tasks and slow interactions have been profiled.
+- [ ] Third-party scripts have owners and budgets.
+- [ ] Noncritical scripts load after consent/intent where appropriate.
+- [ ] Expensive animation pauses off-screen and in hidden tabs.
+- [ ] Blur, filters, fixed backgrounds, and canvas effects are tested on mobile.
+- [ ] Server response and caching are configured.
+- [ ] Static/server rendering strategy supports public content.
+- [ ] Layout shift is tested through cookie, ad, embed, font, and async states.
+- [ ] Slow network and low-end device tests are complete.
+- [ ] Performance regression checks run in CI or release review.
+- [ ] A static/low-fidelity fallback exists for immersive content.
+
+### 81.8 SEO and sharing
+- [ ] Public pages return correct status codes.
+- [ ] Titles and descriptions are unique and useful.
+- [ ] Canonical URLs are correct.
+- [ ] Robots directives are intentional.
+- [ ] XML sitemap is current where needed.
+- [ ] Internal links are crawlable anchors.
+- [ ] Mobile content has parity.
+- [ ] Structured data matches visible content and validates.
+- [ ] Open Graph/social preview metadata is present.
+- [ ] Social images are legible at common crops.
+- [ ] Redirects preserve important old URLs.
+- [ ] No important page is orphaned.
+- [ ] Pagination and faceted URLs have a crawl strategy.
+- [ ] Search pages are indexed or excluded deliberately.
+- [ ] Author, date, and update context exists for relevant content.
+- [ ] Image/video metadata supports discovery where important.
+- [ ] Public content is present in resilient HTML.
+- [ ] Consent or interstitial UI does not block all content.
+- [ ] Broken-link and missing-asset scans pass.
+- [ ] Search Console or equivalent monitoring is configured.
+
+### 81.9 Privacy, analytics, and security
+- [ ] Data collection is minimized.
+- [ ] Each analytics event has a product question and owner.
+- [ ] Sensitive data is excluded from analytics, logs, and URLs.
+- [ ] Consent choices are balanced and accessible.
+- [ ] Optional tracking waits for valid consent where required.
+- [ ] Preference withdrawal works.
+- [ ] Privacy notice matches actual implementation.
+- [ ] Retention and deletion behavior is implemented.
+- [ ] External embeds are inventoried.
+- [ ] Content Security Policy and security headers are configured appropriately.
+- [ ] Authentication and recovery have threat-model review.
+- [ ] Session expiry and device management are understandable.
+- [ ] Permission prompts happen in context.
+- [ ] File uploads are constrained and safely processed.
+- [ ] User-generated content has moderation/reporting paths.
+- [ ] Error messages do not expose secrets.
+- [ ] Forms and APIs protect against abuse.
+- [ ] Destructive and financial actions are auditable.
+- [ ] Dependency and third-party risk are reviewed.
+- [ ] Incident communication and status ownership exist.
+
+### 81.10 Operations and post-launch
+- [ ] Monitoring covers availability and core transactions.
+- [ ] Error reporting preserves privacy.
+- [ ] Real-user performance monitoring is active.
+- [ ] Conversion/task funnels are verified with test data.
+- [ ] Alerts have meaningful thresholds and owners.
+- [ ] Content owners know the publishing workflow.
+- [ ] Legal, price, availability, and team content have review dates.
+- [ ] Redirect and 404 logs are reviewed.
+- [ ] Search logs inform content gaps.
+- [ ] Accessibility issues have a public or internal reporting route.
+- [ ] A post-launch usability review is scheduled.
+- [ ] Feature flags can disable risky enhancements.
+- [ ] Backup and recovery are tested.
+- [ ] Status page and support macros are current.
+- [ ] No launch-only banner remains indefinitely.
+- [ ] Results are compared with the pre-launch baseline.
+- [ ] Metrics are segmented by device and relevant audience.
+- [ ] Harm and exclusion signals are reviewed, not only conversion.
+- [ ] The team has a process for removing experiments.
+- [ ] A design-system/content-debt backlog is maintained.
+
+---

--- a/plugins/design/skills/web-design/references/15-quality-audit-reference-library.md
+++ b/plugins/design/skills/web-design/references/15-quality-audit-reference-library.md
@@ -1,0 +1,287 @@
+# Quality Audit, Reference Library, and Closing Principle
+Source: Modern Functional Web Design Mega Handbook 2026.
+
+## 82. 100-point quality audit
+Score each statement **1** when clearly true, **0.5** when partially true, and **0** when false or unknown. Unknown should not receive the benefit of the doubt.
+
+### Interpretation
+|Score|Interpretation|
+|---:|---|
+|90–100|Excellent foundation; refine craft and edge cases|
+|75–89|Good but material gaps remain|
+|60–74|Uneven; prioritize core-task and inclusion defects|
+|40–59|Significant redesign or technical remediation needed|
+|0–39|Experience is not production-ready|
+
+A high total cannot excuse a severe defect. A keyboard trap, data-loss bug, deceptive payment flow, or critical security issue is a release blocker regardless of score.
+
+### A. Purpose and clarity — 10 points
+1. The primary audience and task are explicit.
+2. The first meaningful view explains what the site is.
+3. The primary action is clear and accurately labeled.
+4. Content hierarchy matches decision priority.
+5. Navigation labels use audience vocabulary.
+6. Each page has a distinct purpose.
+7. Claims are specific and evidenced.
+8. Material limits and conditions are visible.
+9. The next step is predictable.
+10. Empty/error states explain recovery.
+
+### B. Information architecture and content — 10 points
+1. Top tasks are easy to locate.
+2. Related content is grouped consistently.
+3. Search is available when the content scale requires it.
+4. Search/filter state is preserved appropriately.
+5. Headings support scanning and structure.
+6. Long content offers meaningful summaries or navigation.
+7. Links describe destinations.
+8. Dates, units, prices, and time zones are explicit.
+9. Content ownership and freshness are visible internally.
+10. The site avoids duplicate and orphaned pages.
+
+### C. Visual hierarchy and brand — 10 points
+1. The first three focal elements match the intended hierarchy.
+2. Typography roles are coherent.
+3. Body text is comfortable to read.
+4. Spacing expresses grouping.
+5. Alignment creates a stable composition.
+6. Color roles are consistent.
+7. Imagery has a coherent art direction.
+8. Icons belong to one system.
+9. The brand has at least one ownable signature.
+10. Decoration does not compete with content.
+
+### D. Interaction and usability — 10 points
+1. Buttons and links use correct semantics.
+2. Controls communicate state.
+3. Feedback appears immediately after action.
+4. Loading behavior preserves orientation.
+5. Forms minimize effort and recover gracefully.
+6. Destructive actions match consequence.
+7. Back, refresh, and deep links behave predictably.
+8. Mobile touch interaction is comfortable.
+9. Search, filters, and tables support real workflows.
+10. The core task does not depend on hidden gestures.
+
+### E. Accessibility — 10 points
+1. Semantic structure and landmarks are correct.
+2. Full keyboard operation works.
+3. Focus is visible and managed.
+4. Text and UI contrast pass.
+5. Information is not conveyed by color alone.
+6. Text zoom/reflow works.
+7. Target size and spacing are sufficient.
+8. Media and images have alternatives.
+9. Forms and errors are accessible.
+10. Reduced motion, forced colors, and assistive technology are tested.
+
+### F. Responsive and international — 10 points
+1. Layout responds to content rather than device labels alone.
+2. Narrow, wide, short, and zoomed viewports work.
+3. Source order remains logical.
+4. Media crops are art-directed where needed.
+5. Tables and dense content have a narrow-screen strategy.
+6. Text expansion does not break components.
+7. Dates, numbers, currency, names, and addresses are locale-aware.
+8. RTL/logical properties are supported when required.
+9. Theme and input capabilities are handled.
+10. Real devices and low-end hardware are tested.
+
+### G. Performance and resilience — 10 points
+1. LCP meets the good threshold in representative field data or a credible launch test.
+2. INP meets the good threshold.
+3. CLS meets the good threshold.
+4. Images and fonts are efficiently delivered.
+5. Initial JavaScript is justified and budgeted.
+6. Third parties are controlled.
+7. Expensive media is progressive and pausable.
+8. Slow, offline, and partial failures are designed.
+9. No critical task loses data on routine failure.
+10. Performance regressions are monitored.
+
+### H. Trust, privacy, and ethics — 10 points
+1. Ownership and contact are clear.
+2. Pricing and recurring terms are transparent.
+3. Reviews, metrics, and testimonials are credible.
+4. Consent is balanced and reversible.
+5. Sensitive data collection is minimized and explained.
+6. Security and privacy claims have evidence.
+7. Sponsored, personalized, and generated content is identified.
+8. Cancellation and account deletion are findable.
+9. Urgency and scarcity are genuine.
+10. High-impact automation supports review and override.
+
+### I. Discoverability and technical foundation — 10 points
+1. Public content is crawlable HTML.
+2. Titles, metadata, URLs, and status codes are correct.
+3. Mobile content has parity.
+4. Structured data is accurate.
+5. Internal linking supports important content.
+6. Old URLs redirect appropriately.
+7. HTML, CSS, and component architecture are maintainable.
+8. Design tokens encode semantic decisions.
+9. Component states and behavior are documented.
+10. Automated, integration, and human tests cover core flows.
+
+### J. Operational quality — 10 points
+1. Analytics measure task quality.
+2. Error and availability monitoring exist.
+3. Accessibility issues have ownership.
+4. Content freshness has ownership.
+5. Performance has ownership and budgets.
+6. The design system has governance.
+7. Legal/security/privacy review is integrated.
+8. Feature flags or rollback exist for risky changes.
+9. Post-launch research informs iteration.
+10. Known debt is documented and prioritized.
+
+### Priority formula
+After scoring, classify every failed item:
+
+- **P0:** safety, security, legal, data loss, inaccessible core task.
+- **P1:** blocks primary task or materially misleads.
+- **P2:** major friction, trust, performance, or responsive defect.
+- **P3:** craft, consistency, or lower-frequency edge case.
+- **P4:** enhancement.
+
+Fix by severity and user impact, not by how visually easy the issue is.
+
+---
+
+## 83. Reference library
+This handbook synthesizes standards, browser-platform documentation, mature public design systems, usability research, commerce research, and current design-direction reporting. The following are the strongest starting points.
+
+### Accessibility standards and practices
+- [Web Content Accessibility Guidelines (WCAG) overview — W3C WAI](https://www.w3.org/WAI/standards-guidelines/wcag/)
+- [WCAG 2.2 quick reference — W3C WAI](https://www.w3.org/WAI/WCAG22/quickref/)
+- [What’s new in WCAG 2.2 — W3C WAI](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/)
+- [WCAG 2.2 Understanding documents — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/)
+- [Understanding contrast minimum — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum)
+- [Understanding target size minimum — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)
+- [Understanding focus appearance — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html)
+- [Understanding resize text — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [Understanding dragging movements — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html)
+- [Understanding accessible authentication — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html)
+- [Understanding content on hover or focus — W3C WAI](https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html)
+- [WAI-ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/)
+- [ARIA widget patterns](https://www.w3.org/WAI/ARIA/apg/patterns/)
+- [Developing a keyboard interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+- [WAI forms tutorial](https://www.w3.org/WAI/tutorials/forms/)
+- [WAI images tutorial](https://www.w3.org/WAI/tutorials/images/)
+- [WAI writing tips](https://www.w3.org/WAI/tips/writing/)
+- [WAI designing tips](https://www.w3.org/WAI/tips/designing/)
+- [WAI developing tips](https://www.w3.org/WAI/tips/developing/)
+
+### Performance and responsive design
+- [Web Vitals — web.dev](https://web.dev/articles/vitals)
+- [Top Core Web Vitals recommendations — web.dev](https://web.dev/articles/top-cwv)
+- [Optimize Largest Contentful Paint — web.dev](https://web.dev/articles/optimize-lcp)
+- [Optimize Cumulative Layout Shift — web.dev](https://web.dev/articles/optimize-cls)
+- [Fast load times collection — web.dev](https://web.dev/explore/fast)
+- [Responsive design introduction — web.dev](https://web.dev/learn/design/intro)
+- [The picture element — web.dev](https://web.dev/learn/design/picture-element)
+- [High-performance CSS animations — web.dev](https://web.dev/articles/animations-guide)
+- [Rendering performance — web.dev](https://web.dev/articles/rendering-performance)
+- [Font best practices — web.dev](https://web.dev/articles/font-best-practices)
+- [Responsive fluid typography — web.dev](https://web.dev/articles/baseline-in-action-fluid-type)
+- [Baseline web-platform status](https://web.dev/baseline)
+- [Web performance — MDN](https://developer.mozilla.org/en-US/docs/Web/Performance)
+
+### Modern CSS and platform features
+- [Responsive design — MDN](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Responsive_Design)
+- [Container queries — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries)
+- [CSS subgrid — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
+- [Cascade layers — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40layer)
+- [CSS nesting — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Nesting/Using)
+- [View transitions — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40view-transition)
+- [Scroll-driven animations — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations)
+- [`prefers-reduced-motion` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/prefers-reduced-motion)
+- [`forced-colors` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/forced-colors)
+- [`prefers-contrast` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/prefers-contrast)
+- [`prefers-color-scheme` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/%40media/prefers-color-scheme)
+- [OKLCH — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/oklch)
+- [Relative colors — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Colors/Using_relative_colors)
+- [`color-mix()` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/color-mix)
+- [`light-dark()` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark)
+- [Variable fonts — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Fonts/Variable_fonts)
+- [WebGL — MDN](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API)
+- [`will-change` — MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/will-change)
+
+### Forms and authentication
+- [Sign-in form best practices — web.dev](https://web.dev/articles/sign-in-form-best-practices)
+- [Sign-up form best practices — web.dev](https://web.dev/articles/sign-up-form-best-practices)
+- [Payment and address form best practices — web.dev](https://web.dev/articles/payment-and-address-form-best-practices)
+- [Passkey management — web.dev](https://web.dev/articles/passkey-management)
+- [`autocomplete` — MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete)
+- [`inputmode` — MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode)
+- [HTML constraint validation — MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Constraint_validation)
+
+### Public design systems
+- [Material Design 3](https://m3.material.io/)
+- [Material 3 typography](https://m3.material.io/styles/typography/applying-type)
+- [Material 3 color roles](https://m3.material.io/styles/color/roles)
+- [Material design tokens](https://m3.material.io/foundations/design-tokens)
+- [GOV.UK Design System](https://design-system.service.gov.uk/)
+- [GOV.UK patterns](https://design-system.service.gov.uk/patterns/)
+- [GOV.UK focus states](https://design-system.service.gov.uk/get-started/focus-states/)
+- [U.S. Web Design System](https://designsystem.digital.gov/)
+- [USWDS accessibility documentation](https://designsystem.digital.gov/documentation/accessibility/)
+- [USWDS form guidance](https://designsystem.digital.gov/components/form/)
+- [USWDS typography](https://designsystem.digital.gov/components/typography/)
+- [Carbon Design System](https://carbondesignsystem.com/)
+- [Carbon data table](https://carbondesignsystem.com/components/data-table/usage/)
+- [Carbon data visualization](https://carbondesignsystem.com/data-visualization/chart-types/)
+- [Atlassian spacing foundation](https://atlassian.design/foundations/spacing)
+- [Atlassian color foundation](https://atlassian.design/foundations/color)
+- [Fluent 2 Design System](https://fluent2.microsoft.design/)
+- [Apple Human Interface Guidelines: typography](https://developer.apple.com/design/human-interface-guidelines/typography)
+- [Apple Human Interface Guidelines: layout](https://developer.apple.com/design/human-interface-guidelines/layout)
+- [Apple Human Interface Guidelines: accessibility](https://developer.apple.com/design/Human-Interface-Guidelines/accessibility)
+- [Apple Human Interface Guidelines: motion](https://developer.apple.com/design/human-interface-guidelines/motion)
+
+### Information architecture, content, and usability
+- [Visual hierarchy in UX — Nielsen Norman Group](https://www.nngroup.com/articles/visual-hierarchy-ux-definition/)
+- [Homepage design principles — Nielsen Norman Group](https://www.nngroup.com/articles/homepage-design-principles/)
+- [Menu design checklist — Nielsen Norman Group](https://www.nngroup.com/articles/menu-design/)
+- [F-shaped reading pattern — Nielsen Norman Group](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/)
+- [Diátaxis documentation framework](https://diataxis.fr/)
+- [Google developer documentation style guide](https://developers.google.com/style)
+- [Google style guide: headings](https://developers.google.com/style/headings)
+- [Google style guide: procedures](https://developers.google.com/style/procedures)
+
+### E-commerce research and guidance
+- [Shopify theme best practices](https://shopify.dev/docs/storefronts/themes/best-practices)
+- [Shopify accessibility guidance](https://shopify.dev/docs/storefronts/themes/best-practices/accessibility)
+- [Shopify theme design guidance](https://shopify.dev/docs/storefronts/themes/best-practices/design)
+- [Baymard: current state of checkout UX](https://baymard.com/blog/current-state-of-checkout-ux)
+- [Baymard: checkout form fields](https://baymard.com/blog/checkout-flow-average-form-fields)
+- [Baymard: product-page UX](https://baymard.com/blog/current-state-ecommerce-product-page-ux)
+- [Baymard: mobile commerce](https://baymard.com/blog/mobile-commerce-design)
+
+### Search and discoverability
+- [Google Search: page experience](https://developers.google.com/search/docs/appearance/page-experience)
+- [Google Search: mobile-first indexing](https://developers.google.com/search/docs/crawling-indexing/mobile/mobile-sites-mobile-first-indexing)
+- [Google Search: structured data introduction](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- [Google Search Essentials and SEO starter guide](https://developers.google.com/search/docs/fundamentals/seo-starter-guide)
+- [Google guidance for AI features and search](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide)
+
+### AI interaction guidance
+- [Microsoft Guidelines for Human-AI Interaction](https://www.microsoft.com/en-us/haxtoolkit/ai-guidelines/)
+- [Microsoft HAX design patterns](https://www.microsoft.com/en-us/haxtoolkit/design-patterns/)
+- [Carbon for AI](https://carbondesignsystem.com/guidelines/carbon-for-ai/)
+- [Google People + AI Guidebook](https://pair.withgoogle.com/guidebook/)
+- [PAIR: explainability and trust](https://pair.withgoogle.com/chapter/explainability-trust/)
+- [Apple Human Interface Guidelines: generative AI](https://developer.apple.com/design/human-interface-guidelines/generative-ai)
+
+### Current visual-direction sources
+- [Webflow: web-design trends for 2026](https://webflow.com/blog/web-design-trends-2026)
+- [Figma: web-design trends](https://www.figma.com/resource-library/web-design-trends/)
+- [Framer: web-design trends](https://www.framer.com/blog/web-design-trends/)
+- [Awwwards](https://www.awwwards.com/) — useful as a visual reference stream; evaluate showcased work separately for accessibility, performance, and task fit.
+
+---
+
+# Closing principle
+A visually stunning website is not the one with the most visible design. It is the one where every visible decision feels inevitable: the hierarchy matches the task, the type fits the voice, the imagery earns its weight, the motion explains rather than delays, and the interface keeps working for people outside the ideal demo.
+
+Build the durable experience first. Add one strong expressive idea. Measure what it costs. Refine the details people touch repeatedly. That combination ages better than a stack of trends.


### PR DESCRIPTION
## Summary
- Add `design:web-design` as a compact, content-led website design skill for marketing sites, landing pages, public website audits, and related page/content surfaces.
- Convert the provided modern web design handbook into 16 progressively loaded reference files under `plugins/design/skills/web-design/references/` so `SKILL.md` stays small.
- Register the skill in the design plugin and regenerate Codex, Claude, Cursor, marketplace, and plugin README artifacts.

## Validation
- `python3 /Users/luca/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/design/skills/web-design`
- Verified all 747 source handbook headings are preserved across the reference files.
- `bun run marketplace:write`
- `bun run ci`

## Notes
- `bun run ci` passes with existing token-size warnings plus warnings for some new reference files, but no strict-mode errors.