### PR TITLE
feat(codebase): add codebase structure skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,6 +5,22 @@
 	},
 	"plugins": [
 		{
+			"name": "codebase-management",
+			"source": {
+				"source": "local",
+				"path": "./plugins/codebase-management"
+			},
+			"policy": {
+				"installation": "AVAILABLE",
+				"authentication": "ON_INSTALL"
+			},
+			"category": "Development",
+			"interface": {
+				"displayName": "Codebase Management",
+				"shortDescription": "Structure and clean up codebases"
+			}
+		},
+		{
 			"name": "collaboration",
 			"source": {
 				"source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,28 @@
 	},
 	"plugins": [
 		{
+			"name": "codebase-management",
+			"source": "./plugins/codebase-management",
+			"description": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.",
+			"version": "2.0.0",
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			},
+			"category": "Development",
+			"keywords": [
+				"codebase",
+				"repository",
+				"structure",
+				"monorepo",
+				"workspace",
+				"scaffold",
+				"refactor",
+				"cleanup",
+				"llm"
+			]
+		},
+		{
 			"name": "collaboration",
 			"source": "./plugins/collaboration",
 			"description": "Collaboration and communication skills for shared understanding: repository docs, decision trees, onboarding context, and human-readable coordination artifacts.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,6 +12,11 @@
 	},
 	"plugins": [
 		{
+			"name": "codebase-management",
+			"source": "codebase-management",
+			"description": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization."
+		},
+		{
 			"name": "collaboration",
 			"source": "collaboration",
 			"description": "Collaboration and communication skills for shared understanding: repository docs, decision trees, onboarding context, and human-readable coordination artifacts."

--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ bun run ci
 
 `bun run ci` is the same validation GitHub Actions runs on pull requests (marketplace sync, Cursor marketplace layout, skill checks, markdown format, JSON manifests). Use `bun run check` locally for a non-strict dry-run with warnings only.
 
+Use `bun run tree` to print a concise AI-readable tree of plugins, skills, and reference counts. Add `--descriptions`, `--references`, `--metadata`, `--paths`, `--support`, or `--format json` when you need a fuller inventory.
+
 Agent and contributor guidance lives in `AGENTS.md`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"install:codex-skills": "bun scripts/install-skills.ts --target codex",
 		"marketplace": "bun scripts/marketplace.ts",
 		"marketplace:write": "bun scripts/marketplace.ts --write",
+		"tree": "bun scripts/skill-tree.ts",
 		"validate:cursor": "bun scripts/validate-cursor-marketplace.ts"
 	}
 }

--- a/plugin-groups.json
+++ b/plugin-groups.json
@@ -40,6 +40,19 @@
 			}
 		},
 		{
+			"name": "codebase-management",
+			"displayName": "Codebase Management",
+			"description": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.",
+			"shortDescription": "Structure and clean up codebases",
+			"category": "Development",
+			"keywords": ["codebase", "repository", "structure", "monorepo", "workspace", "scaffold", "refactor", "cleanup", "llm"],
+			"skills": ["codebase-structure"],
+			"author": {
+				"name": "Luca Silverentand",
+				"email": "dev@lucasilverentand.com"
+			}
+		},
+		{
 			"name": "design",
 			"displayName": "Design",
 			"description": "Design and architecture skills for product UI, websites, Apple platforms, system architecture, data modeling, API design, technical design docs, ADRs, C4 diagrams, and design reviews.",

--- a/plugins/codebase-management/.claude-plugin/plugin.json
+++ b/plugins/codebase-management/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+	"name": "codebase-management",
+	"description": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.",
+	"version": "2.0.0",
+	"skills": [
+		"./skills/codebase-structure"
+	],
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"codebase",
+		"repository",
+		"structure",
+		"monorepo",
+		"workspace",
+		"scaffold",
+		"refactor",
+		"cleanup",
+		"llm"
+	]
+}

--- a/plugins/codebase-management/.codex-plugin/plugin.json
+++ b/plugins/codebase-management/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+	"name": "codebase-management",
+	"version": "2.0.0",
+	"description": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"homepage": "https://github.com/lucasilverentand/skills",
+	"repository": "https://github.com/lucasilverentand/skills",
+	"license": "MIT",
+	"keywords": [
+		"codebase",
+		"repository",
+		"structure",
+		"monorepo",
+		"workspace",
+		"scaffold",
+		"refactor",
+		"cleanup",
+		"llm"
+	],
+	"skills": "./skills/",
+	"interface": {
+		"displayName": "Codebase Management",
+		"shortDescription": "Structure and clean up codebases",
+		"longDescription": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.",
+		"developerName": "Luca Silverentand",
+		"category": "Development",
+		"capabilities": [
+			"Read",
+			"Write"
+		],
+		"websiteURL": "https://github.com/lucasilverentand/skills",
+		"defaultPrompt": [
+			"Use Codebase Management when the task matches one of its bundled skills."
+		]
+	}
+}

--- a/plugins/codebase-management/.cursor-plugin/plugin.json
+++ b/plugins/codebase-management/.cursor-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+	"name": "codebase-management",
+	"displayName": "Codebase Management",
+	"version": "2.0.0",
+	"description": "Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.",
+	"author": {
+		"name": "Luca Silverentand",
+		"email": "dev@lucasilverentand.com"
+	},
+	"license": "MIT",
+	"keywords": [
+		"codebase",
+		"repository",
+		"structure",
+		"monorepo",
+		"workspace",
+		"scaffold",
+		"refactor",
+		"cleanup",
+		"llm"
+	]
+}

--- a/plugins/codebase-management/README.md
+++ b/plugins/codebase-management/README.md
@@ -1,0 +1,34 @@
+# Codebase Management
+Codebase management skills for repository structure, project-type organization, monorepo boundaries, code ownership, cleanup of LLM-generated layouts, and incremental codebase reorganization.
+
+## Skills
+- `codebase-management:codebase-structure`
+
+## Install
+Codex:
+
+```bash
+codex plugin marketplace add lucasilverentand/skills
+```
+
+Claude Code:
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install codebase-management@skills-of-luca
+```
+
+Cursor (team marketplace):
+
+1. Dashboard → Settings → Plugins → Import
+2. Paste `https://github.com/lucasilverentand/skills`
+3. Install `codebase-management` (Required or Optional)
+
+Cursor (IDE slash commands):
+
+```text
+/plugin marketplace add lucasilverentand/skills
+/plugin install codebase-management@skills-of-luca
+```
+
+This plugin owns its skill source under `plugins/codebase-management/skills/`. Edit those files directly, then run `bun run marketplace:write` to refresh generated manifests and marketplaces.

--- a/plugins/codebase-management/skills/codebase-structure/SKILL.md
+++ b/plugins/codebase-management/skills/codebase-structure/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: codebase-structure
+description: Structures codebases and repositories by project type, runtime boundary, domain ownership, and maintenance workflow. Use when the user asks how to organize a codebase, scaffold a repo, split a monolith, design a monorepo, move files, choose folders, clean up LLM-generated project layout, or decide where app, package, service, test, config, docs, and deployment code should live. Covers Apple apps, web apps, websites, Expo/React Native, Cloudflare/full-stack services, CLIs, agent skills/plugins, Home Assistant integrations, and GitOps/homelab projects.
+---
+
+# Codebase Structure
+Use this skill to choose a codebase shape that helps agents and humans find the right place for code, tests, configuration, deployment, and documentation. Treat existing repositories as evidence of constraints, not as examples to copy; many real layouts contain accidental LLM organization, stale experiments, or historical compromises.
+
+## Decision Tree
+- What is the user asking for?
+  - **Greenfield structure or scaffold** -> classify the project type, read `references/project-type-playbooks.md`, and propose a clean tree with rationale.
+  - **Existing repo cleanup or reorganization** -> inspect the current tree, read `references/migration-and-review.md`, and produce an incremental migration plan.
+  - **"Where should this code live?"** -> identify the runtime, owner, lifecycle, and dependency direction, then apply `references/core-principles.md`.
+  - **Monorepo or multi-app workspace** -> read `references/core-principles.md`, define deployable apps first, then shared packages only where reuse is real.
+  - **LLM-generated messy project** -> read `references/migration-and-review.md`, preserve working behavior, reject generic buckets, and restructure around project type, runtime boundaries, and domain workflows.
+  - **Architecture, API, data model, UI, dashboard, or website design rather than file layout** -> use the relevant design skill first, then return here for repository shape.
+
+## Core Workflow
+1. Identify project type or project-type mix. Use the user's named platform if given; otherwise infer from package files, build tools, source directories, deployment config, and tests.
+2. Inventory hard constraints: runtime targets, deployment units, package manager, generated files, build system, test runner, native platform conventions, and existing public APIs.
+3. Read `references/core-principles.md` before making structural recommendations.
+4. Read only the relevant section of `references/project-type-playbooks.md` for the project type.
+5. Choose top-level boundaries by deployable unit and lifecycle before choosing feature folders.
+6. Place shared code only after proving it is used by more than one owner or must be centralized for correctness.
+7. For existing repos, read `references/migration-and-review.md` and prefer small behavior-preserving moves with validation gates.
+8. Return a proposed tree, reasoning, rejected alternatives, migration steps if needed, and validation commands.
+
+## Rules
+- Do not copy the organization of one of Luca's existing projects just because it exists. Use the project type, not the current project's accidental folder names.
+- Keep framework conventions where they carry toolchain meaning. Override local clutter where it is merely historical or LLM-generated.
+- Separate deployable apps from reusable packages, generated artifacts, infrastructure, and docs.
+- Prefer domain or feature ownership inside an app; avoid broad buckets like `components`, `utils`, `helpers`, `services`, and `lib` when they become dumping grounds.
+- Keep tests near the code when the ecosystem supports it; use separate integration or end-to-end roots when tests cross runtime or deployment boundaries.
+- Make dependency direction obvious: app -> feature/domain -> shared primitives. Shared packages must not import apps.
+- Keep generated files, build output, vendored assets, and local machine config out of authored source paths.
+
+## Reference Routing
+|Need|Read|
+|---|---|
+|Universal structure rules, boundary tests, naming, tests, docs, generated files|`references/core-principles.md`|
+|Project-type playbooks for Apple, web, Expo, Cloudflare, CLI, skills/plugins, Home Assistant, GitOps/homelab|`references/project-type-playbooks.md`|
+|Existing repo audits, migration plans, review checklist, LLM-layout cleanup|`references/migration-and-review.md`|
+
+## Output Shape
+For advisory work, include:
+
+1. Project type classification and assumptions.
+2. Proposed top-level tree and one representative deeper slice.
+3. Boundary rationale: deployables, domains, shared packages, tests, infrastructure, docs.
+4. Anti-patterns rejected from the current or likely LLM-generated layout.
+5. Validation plan: build, test, lint, import checks, generated artifact checks.
+
+For implementation work, make the moves, update imports/configs, run the validation plan, and summarize the resulting structure.

--- a/plugins/codebase-management/skills/codebase-structure/agents/openai.yaml
+++ b/plugins/codebase-management/skills/codebase-structure/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codebase Structure"
+  short_description: "Structure codebases by project type"
+  default_prompt: "Use $codebase-structure to choose a clean codebase structure for this project."

--- a/plugins/codebase-management/skills/codebase-structure/references/core-principles.md
+++ b/plugins/codebase-management/skills/codebase-structure/references/core-principles.md
@@ -1,0 +1,70 @@
+# Core Structure Principles
+
+## Boundary Order
+Choose boundaries in this order:
+
+1. **Deployable runtime**: app, Worker, native target, CLI binary, Home Assistant integration, Kubernetes app, or plugin package.
+2. **Domain ownership**: account, billing, camera, occupancy, routing, publishing, planning, etc.
+3. **Interface layer**: UI, API route, command, automation, background job, device adapter.
+4. **Shared primitives**: design tokens, config loaders, test helpers, domain-agnostic utilities.
+
+Do not start with generic folders. A tree full of `components`, `services`, `helpers`, `utils`, `models`, and `hooks` usually describes implementation technique, not product ownership.
+
+## Top-Level Shape
+Use stable top-level roots that answer lifecycle questions:
+
+|Root|Use for|
+|---|---|
+|`apps/`|Deployable user-facing apps or app targets in a workspace|
+|`services/`|Deployable non-UI services, queue workers, cron jobs, sync daemons|
+|`packages/`|Reusable libraries with clear owners and public APIs|
+|`integrations/`|External-system adapters when they are first-class products|
+|`infra/` or `deploy/`|Terraform, Kubernetes, Helm, Kustomize, Wrangler deploy config, release manifests|
+|`docs/`|Durable human documentation, decisions, runbooks, architecture notes|
+|`scripts/`|Repo automation invoked by humans or CI|
+|`tools/`|Developer tools that are built or maintained as code|
+|`fixtures/`|Shared test fixtures that are intentionally cross-suite|
+
+Not every repo needs every root. A single-platform app can be flatter. A monorepo earns more roots because each deployable has a separate lifecycle.
+
+## Naming
+- Name folders after owned concepts, not programming patterns.
+- Prefer `billing`, `recording`, `occupancy`, `routing`, `publishing`, `settings`, or `devices` over `services` or `managers`.
+- Avoid suffixes that hide responsibility: `Core`, `Common`, `Shared`, `Base`, `Utils`.
+- If a shared package cannot state its public contract in one sentence, it is probably too broad.
+
+## Shared Code Test
+Move code to `packages/` or a shared module only when one of these is true:
+
+- Two or more deployables import it today.
+- Centralizing it prevents a correctness or security bug.
+- It is a stable public abstraction with tests and documented ownership.
+
+Otherwise keep it inside the app or domain that owns it. Premature shared packages create dependency knots and slow refactors.
+
+## Tests
+- Put fast unit tests next to the code when the ecosystem supports it.
+- Put integration tests near the boundary they exercise, such as API routes, database adapters, device adapters, or queue handlers.
+- Put end-to-end tests under `e2e/` or `tests/e2e/` when they cross deployables or drive UI.
+- Keep test helpers scoped. A global test helper should earn its place by removing real duplication across suites.
+
+## Configuration
+- Keep checked-in defaults close to the runtime that consumes them.
+- Keep secrets out of source. Provide examples only when they cannot leak real values.
+- Separate local-only config from production deploy config.
+- Validate runtime config at startup when the language/runtime supports it.
+
+## Generated Files
+- Keep generated artifacts in predictable generated roots or beside the owning source only when the toolchain requires it.
+- Add a short comment or docs note for how generated files are produced.
+- Do not edit generated files manually unless the repo convention explicitly requires checked-in output.
+
+## Documentation
+Use docs for decisions that change maintenance behavior:
+
+- `docs/architecture/` for system shape and boundaries.
+- `docs/runbooks/` for operational recovery.
+- `docs/decisions/` for ADRs or durable trade-offs.
+- Feature README files only when a folder has a non-obvious local workflow.
+
+Do not add documentation to justify clutter. Fix the structure first.

--- a/plugins/codebase-management/skills/codebase-structure/references/migration-and-review.md
+++ b/plugins/codebase-management/skills/codebase-structure/references/migration-and-review.md
@@ -1,0 +1,65 @@
+# Migration and Review
+
+## Existing Repo Audit
+Before moving files, inspect:
+
+- top-level tree and package/workspace files;
+- build system and generated-file rules;
+- app entrypoints and deployment config;
+- test layout and CI commands;
+- import aliases and path mapping;
+- public API exports;
+- docs that may reference paths.
+
+Classify every top-level folder as one of:
+
+|Class|Meaning|Action|
+|---|---|---|
+|Deployable|Built, shipped, or run independently|Keep as a first-class boundary|
+|Domain|Owns product/business behavior|Keep close to its app unless shared by contract|
+|Shared package|Imported by multiple deployables|Require a public API and tests|
+|Generated|Produced by tooling|Do not reorganize manually without updating generator|
+|Artifact|Build output, cache, local state|Remove from source or ignore|
+|Ambiguous bucket|`utils`, `helpers`, broad `lib`, broad `services`|Split by owner or keep only tiny framework glue|
+
+## Migration Plan
+Use small moves that preserve behavior:
+
+1. Propose the target tree and explain the boundary rule.
+2. Move one domain or deployable at a time.
+3. Update imports, path aliases, package exports, and build config.
+4. Run the smallest validation command that proves the move.
+5. Repeat until the layout matches the target structure.
+6. Leave compatibility shims only when downstream callers need a staged migration.
+
+Avoid cosmetic churn if the repo is actively shipping. A better tree that breaks deployment is not better.
+
+## LLM-Generated Layout Smells
+- `src/components`, `src/services`, `src/utils`, and `src/types` contain most of the application.
+- Many files have names like `Manager`, `Service`, `Handler`, `Helper`, or `Provider` without domain meaning.
+- Business rules live in UI components or route files.
+- Tests are absent, only snapshots exist, or all tests are in one global folder without ownership.
+- Environment config is copied across apps instead of validated and owned.
+- Generated files are mixed with authored source.
+- Multiple frameworks or package managers appear without a clear migration reason.
+
+When these appear, preserve working behavior but restructure around deployables and domains.
+
+## Review Checklist
+- Can a new agent find the entrypoint for each deployable in under a minute?
+- Is there one obvious owner for each domain concept?
+- Do shared packages have narrow names, tests, and public exports?
+- Are route files, command handlers, and Worker handlers thin enough to read quickly?
+- Are test locations predictable from the source location?
+- Are generated files and artifacts clearly separated?
+- Does the structure match the actual deployment and CI model?
+- Are risky moves broken into commits or steps that can be validated independently?
+
+## Recommended Response Format
+For a structural review, answer in this order:
+
+1. Current classification: project type, deployables, shared packages, generated/artifact roots.
+2. Main structural risks, ordered by maintenance impact.
+3. Proposed target tree.
+4. Migration sequence with validation after each step.
+5. Follow-up work that is useful but out of scope.

--- a/plugins/codebase-management/skills/codebase-structure/references/project-type-playbooks.md
+++ b/plugins/codebase-management/skills/codebase-structure/references/project-type-playbooks.md
@@ -1,0 +1,199 @@
+# Project-Type Playbooks
+Use the project type as the input, not the current organization of an existing repo. These playbooks encode common project types in Luca's work; adapt to local toolchain constraints.
+
+## Apple Apps: iOS, macOS, SwiftUI, UIKit, AppKit
+Prefer Xcode/Tuist/SwiftPM conventions where the toolchain expects them.
+
+```text
+AppName/
+  App/                 # app entry, scenes, app lifecycle, composition root
+  Features/            # product features or domains
+  Shared/              # design system, primitives, cross-feature utilities
+  Data/                # persistence, repositories, sync, model adapters
+  Platform/            # device APIs, permissions, system services
+  Resources/           # assets, localization, previews/sample data
+  Tests/
+  UITests/
+```
+
+Guidance:
+- Keep SwiftUI views with their view models or reducers when the feature is small; split only when files become hard to navigate.
+- Put OS integrations behind narrow adapters in `Platform/`.
+- Keep generated project files and build output out of authored source unless the toolchain owns them.
+- For multi-target apps, structure by target at the project level and by feature inside each target.
+
+## Web Apps and Dashboards
+Use framework route conventions, then organize business logic by feature/domain.
+
+```text
+app/ or src/app/       # routes, layouts, server/client entrypoints
+features/             # user-visible product areas
+components/           # only truly shared UI primitives
+lib/                  # framework glue and small cross-cutting helpers
+server/               # server-only domain services when framework allows
+styles/ or tokens/    # design tokens and global styling
+tests/
+e2e/
+```
+
+Guidance:
+- Route folders are not domain ownership by themselves. Keep substantial business logic out of route files.
+- Avoid a huge global `components/`; feature-specific UI belongs with the feature.
+- Put dashboard-specific tables, filters, actions, and state handling in the owning feature, not in generic UI folders.
+
+## Marketing Websites and Content Sites
+Optimize for content ownership, page patterns, media, and build-time safety.
+
+```text
+src/
+  pages/ or app/       # framework routes
+  content/             # markdown, MDX, CMS schemas, collections
+  sections/            # reusable page sections with content contracts
+  components/          # shared primitives
+  styles/
+  media/               # source media when checked in
+public/                # static public assets
+```
+
+Guidance:
+- Keep content models explicit. Do not bury page copy in arbitrary components if non-engineers need to edit it.
+- Separate page sections from low-level UI primitives.
+- Keep SEO, metadata, sitemap, and structured-data logic discoverable.
+
+## Expo and React Native
+Respect Expo Router and native platform folders while keeping domain logic portable.
+
+```text
+app/                   # Expo Router routes
+features/              # product domains
+components/            # shared cross-feature UI primitives
+native/                # native modules or platform bridges
+assets/
+hooks/                 # only cross-feature hooks
+lib/                   # config, clients, framework glue
+ios/
+android/
+```
+
+Guidance:
+- Do not scatter product logic through route files.
+- Keep platform-specific behavior behind adapters or `.ios` / `.android` files.
+- Keep design tokens and shared UI primitives small enough for repeated mobile use.
+
+## Cloudflare and Full-Stack Services
+Separate deployable Workers from shared packages. A queue consumer or cron job is a separate lifecycle, even when it shares code with the API.
+
+```text
+apps/
+  web/
+  api/
+services/
+  queue-worker/
+  cron-worker/
+packages/
+  db/
+  auth/
+  config/
+  domain/
+infra/
+  wrangler/
+```
+
+Guidance:
+- Keep Workers thin at the edge; domain logic should be testable outside request handlers.
+- Put bindings and environment parsing close to the Worker that consumes them.
+- Do not add a shared package for every small helper. Shared packages need contracts.
+- Keep migrations with the database package or the app that owns the database.
+
+## CLIs and Developer Tools
+Separate command parsing from core behavior so the tool can be tested without spawning processes.
+
+```text
+src/
+  cli/                 # argument parsing, terminal IO, exit codes
+  commands/            # command handlers
+  core/                # business logic independent of terminal IO
+  adapters/            # filesystem, network, git, platform APIs
+  output/              # formatting, reporters, diagnostics
+tests/
+fixtures/
+```
+
+Guidance:
+- Command handlers should orchestrate; core modules should do the work.
+- Keep terminal formatting out of domain logic.
+- Put golden fixtures under `fixtures/` only when multiple suites need them.
+
+## Agent Skills and Plugins
+Use plugin-owned skill directories as the source of truth. Generated marketplace/plugin files are outputs.
+
+```text
+plugins/
+  <plugin>/
+    skills/
+      <skill>/
+        SKILL.md
+        references/
+        scripts/
+        assets/
+    commands/
+    documents/
+plugin-groups.json
+scripts/
+```
+
+Guidance:
+- Keep each skill focused. Split detailed guidance into one-level `references/`.
+- Do not create root-level `skills/` when the repo uses plugin-owned sources.
+- Regenerate marketplace artifacts after source changes when the repo requires it.
+- Do not install or symlink live skills unless explicitly asked.
+
+## Home Assistant Integrations and Automation
+Separate integration runtime code, fixtures, config examples, and operational docs.
+
+```text
+custom_components/
+  <domain>/
+    __init__.py
+    config_flow.py
+    coordinator.py
+    sensor.py
+    binary_sensor.py
+    services.yaml
+tests/
+  fixtures/
+examples/
+docs/
+```
+
+Guidance:
+- Follow Home Assistant platform file conventions; they are part of the runtime contract.
+- Keep test fixtures anonymized and deterministic.
+- Put example YAML under `examples/`, not mixed into production integration code.
+- Keep recorder/state-history analysis scripts separate from integration runtime code.
+
+## GitOps, Homelab, and Kubernetes
+Separate desired state, reusable base manifests, environment overlays, secrets strategy, and operational docs.
+
+```text
+clusters/
+  <cluster>/
+    apps/
+    infrastructure/
+apps/
+  <app>/
+    base/
+    overlays/
+infra/
+  controllers/
+  storage/
+  networking/
+docs/
+  runbooks/
+```
+
+Guidance:
+- Keep cluster-specific overlays explicit. Do not hide environment differences in generated YAML blobs.
+- Separate render-valid from live-healthy validation in docs and scripts.
+- Keep secret references in manifests; keep secret material in the chosen secret system.
+- Put runbooks next to the operational surface, not inside application source.

--- a/scripts/skill-tree.ts
+++ b/scripts/skill-tree.ts
@@ -1,0 +1,436 @@
+#!/usr/bin/env bun
+
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const PLUGINS_DIR = resolve(ROOT, "plugins");
+const GROUPS_PATH = resolve(ROOT, "plugin-groups.json");
+
+interface Owner {
+	name: string;
+	url?: string;
+	email?: string;
+}
+
+interface PluginGroup {
+	name: string;
+	displayName: string;
+	description: string;
+	shortDescription: string;
+	category: string;
+	keywords?: string[];
+	skills: string[];
+	commands?: string[];
+	readmeBody?: string;
+	author: Owner;
+}
+
+interface PluginGroups {
+	name: string;
+	owner: Owner;
+	metadata: {
+		version: string;
+		homepage?: string;
+		repository?: string;
+		license?: string;
+	};
+	plugins: PluginGroup[];
+}
+
+interface Options {
+	format: "text" | "json";
+	includeDescriptions: boolean;
+	includeKeywords: boolean;
+	includeMetadata: boolean;
+	includePaths: boolean;
+	includeReferences: boolean;
+	includeSupport: boolean;
+	maxDescription: number;
+	pluginFilters: Set<string>;
+	skillFilters: Set<string>;
+	unicode: boolean;
+}
+
+interface SkillNode {
+	name: string;
+	path: string;
+	frontmatter: Record<string, string>;
+	description?: string;
+	references: string[];
+	scripts: string[];
+	agents: string[];
+	otherSupport: string[];
+}
+
+interface PluginNode {
+	name: string;
+	displayName: string;
+	path: string;
+	category: string;
+	shortDescription: string;
+	description: string;
+	keywords: string[];
+	commands: string[];
+	skills: SkillNode[];
+}
+
+const args = process.argv.slice(2);
+
+function usage(): never {
+	console.log(`Usage: bun run tree [options]
+
+Print an AI-readable tree of plugin, skill, and reference metadata.
+
+Options:
+  --plugin <name>        Only include one plugin. Repeatable.
+  --skill <name>         Only include one skill or plugin:skill. Repeatable.
+  --references, --refs   List reference files instead of only counts.
+  --support              Include scripts, agents, and other support files.
+  --metadata             Include categories, keywords, commands, and frontmatter.
+  --keywords             Include plugin keywords without full metadata.
+  --paths                Include repo-relative paths.
+  --descriptions         Include plugin and skill description snippets.
+  --no-descriptions      Hide description snippets.
+  --max-description <n>  Snippet length, default 120.
+  --format <text|json>   Output format, default text.
+  --ascii                Use plain ASCII tree characters.
+  --unicode              Use box-drawing tree characters. Default.
+  --all                  Shortcut for --references --support --metadata --paths.
+  --help                 Show this help.
+`);
+	process.exit(0);
+}
+
+function parseOptions(): Options {
+	const options: Options = {
+		format: "text",
+		includeDescriptions: false,
+		includeKeywords: false,
+		includeMetadata: false,
+		includePaths: false,
+		includeReferences: false,
+		includeSupport: false,
+		maxDescription: 120,
+		pluginFilters: new Set(),
+		skillFilters: new Set(),
+		unicode: true,
+	};
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		const next = () => {
+			const value = args[++i];
+			if (!value) throw new Error(`${arg} needs a value`);
+			return value;
+		};
+
+		switch (arg) {
+			case "--help":
+			case "-h":
+				usage();
+			case "--plugin":
+				options.pluginFilters.add(next());
+				break;
+			case "--skill":
+				options.skillFilters.add(next());
+				break;
+			case "--references":
+			case "--refs":
+				options.includeReferences = true;
+				break;
+			case "--support":
+				options.includeSupport = true;
+				break;
+			case "--metadata":
+				options.includeMetadata = true;
+				break;
+			case "--keywords":
+				options.includeKeywords = true;
+				break;
+			case "--paths":
+				options.includePaths = true;
+				break;
+			case "--descriptions":
+				options.includeDescriptions = true;
+				break;
+			case "--no-descriptions":
+				options.includeDescriptions = false;
+				break;
+			case "--max-description":
+				options.maxDescription = Number.parseInt(next(), 10);
+				if (!Number.isFinite(options.maxDescription) || options.maxDescription < 20) {
+					throw new Error("--max-description must be a number >= 20");
+				}
+				break;
+			case "--format": {
+				const format = next();
+				if (format !== "text" && format !== "json") throw new Error("--format must be text or json");
+				options.format = format;
+				break;
+			}
+			case "--ascii":
+				options.unicode = false;
+				break;
+			case "--unicode":
+				options.unicode = true;
+				break;
+			case "--all":
+				options.includeReferences = true;
+				options.includeSupport = true;
+				options.includeMetadata = true;
+				options.includePaths = true;
+				break;
+			default:
+				throw new Error(`Unknown option: ${arg}`);
+		}
+	}
+
+	return options;
+}
+
+async function readJson<T>(path: string): Promise<T> {
+	return JSON.parse(await readFile(path, "utf-8")) as T;
+}
+
+function rel(path: string): string {
+	return relative(ROOT, path);
+}
+
+function parseFrontmatter(content: string): Record<string, string> {
+	const match = content.match(/^---\n([\s\S]*?)\n---/);
+	if (!match) return {};
+
+	const fields: Record<string, string> = {};
+	for (const line of match[1].split("\n")) {
+		const parts = line.match(/^(\w[\w-]*):\s*(.*)$/);
+		if (!parts) continue;
+		let value = parts[2].trim();
+		if (
+			(value.startsWith("\"") && value.endsWith("\"")) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		fields[parts[1]] = value;
+	}
+	return fields;
+}
+
+function compact(text: string | undefined, max: number): string | undefined {
+	if (!text) return undefined;
+	const flattened = text.replace(/\s+/g, " ").trim();
+	if (flattened.length <= max) return flattened;
+	return `${flattened.slice(0, max - 1).trimEnd()}...`;
+}
+
+async function walkFiles(root: string): Promise<string[]> {
+	if (!existsSync(root)) return [];
+
+	const files: string[] = [];
+	async function walk(current: string) {
+		const entries = await readdir(current, { withFileTypes: true });
+		for (const entry of entries) {
+			const abs = join(current, entry.name);
+			if (entry.isDirectory()) {
+				await walk(abs);
+			} else if (entry.isFile()) {
+				files.push(rel(abs));
+			}
+		}
+	}
+
+	await walk(root);
+	return files.sort();
+}
+
+async function skillNode(plugin: PluginGroup, skillName: string): Promise<SkillNode> {
+	const skillRoot = resolve(PLUGINS_DIR, plugin.name, "skills", skillName);
+	const skillPath = resolve(skillRoot, "SKILL.md");
+	const content = existsSync(skillPath) ? await readFile(skillPath, "utf-8") : "";
+	const frontmatter = parseFrontmatter(content);
+	const directFiles = existsSync(skillRoot)
+		? (await readdir(skillRoot, { withFileTypes: true }))
+				.filter((entry) => entry.isFile() && entry.name !== "SKILL.md")
+				.map((entry) => rel(resolve(skillRoot, entry.name)))
+				.sort()
+		: [];
+
+	return {
+		name: skillName,
+		path: rel(skillRoot),
+		frontmatter,
+		description: frontmatter.description,
+		references: await walkFiles(resolve(skillRoot, "references")),
+		scripts: await walkFiles(resolve(skillRoot, "scripts")),
+		agents: await walkFiles(resolve(skillRoot, "agents")),
+		otherSupport: directFiles,
+	};
+}
+
+function skillMatches(options: Options, pluginName: string, skillName: string): boolean {
+	if (options.skillFilters.size === 0) return true;
+	return (
+		options.skillFilters.has(skillName) ||
+		options.skillFilters.has(`${pluginName}:${skillName}`) ||
+		options.skillFilters.has(`${pluginName}/${skillName}`)
+	);
+}
+
+async function buildTree(options: Options): Promise<{
+	name: string;
+	version: string;
+	plugins: PluginNode[];
+	totals: { plugins: number; skills: number; references: number; supportFiles: number };
+}> {
+	const groups = await readJson<PluginGroups>(GROUPS_PATH);
+	const plugins: PluginNode[] = [];
+
+	for (const group of groups.plugins.toSorted((a, b) => a.name.localeCompare(b.name))) {
+		if (options.pluginFilters.size && !options.pluginFilters.has(group.name)) continue;
+
+		const skills = (
+			await Promise.all(
+				group.skills
+					.toSorted((a, b) => a.localeCompare(b))
+					.filter((skill) => skillMatches(options, group.name, skill))
+					.map((skill) => skillNode(group, skill)),
+			)
+		).filter(Boolean);
+
+		if (options.skillFilters.size && skills.length === 0) continue;
+
+		plugins.push({
+			name: group.name,
+			displayName: group.displayName,
+			path: rel(resolve(PLUGINS_DIR, group.name)),
+			category: group.category,
+			shortDescription: group.shortDescription,
+			description: group.description,
+			keywords: group.keywords ?? [],
+			commands: group.commands ?? [],
+			skills,
+		});
+	}
+
+	const totals = plugins.reduce(
+		(acc, plugin) => {
+			acc.skills += plugin.skills.length;
+			for (const skill of plugin.skills) {
+				acc.references += skill.references.length;
+				acc.supportFiles += skill.scripts.length + skill.agents.length + skill.otherSupport.length;
+			}
+			return acc;
+		},
+		{ plugins: plugins.length, skills: 0, references: 0, supportFiles: 0 },
+	);
+
+	return {
+		name: groups.name,
+		version: groups.metadata.version,
+		plugins,
+		totals,
+	};
+}
+
+function treeGlyphs(unicode: boolean) {
+	return unicode
+		? { tee: "\u251c\u2500\u2500", last: "\u2514\u2500\u2500", pipe: "\u2502  ", blank: "   " }
+		: { tee: "|--", last: "`--", pipe: "|  ", blank: "   " };
+}
+
+function printChild(lines: string[], prefix: string, isLast: boolean, label: string, unicode: boolean) {
+	const glyphs = treeGlyphs(unicode);
+	lines.push(`${prefix}${isLast ? glyphs.last : glyphs.tee} ${label}`);
+}
+
+function detailLine(lines: string[], prefix: string, isLast: boolean, label: string, unicode: boolean) {
+	printChild(lines, prefix, isLast, label, unicode);
+}
+
+function formatText(tree: Awaited<ReturnType<typeof buildTree>>, options: Options): string {
+	const lines: string[] = [];
+	const glyphs = treeGlyphs(options.unicode);
+	lines.push(
+		`${tree.name} v${tree.version} - ${tree.totals.plugins} plugins, ${tree.totals.skills} skills, ${tree.totals.references} references`,
+	);
+
+	for (const [pluginIndex, plugin] of tree.plugins.entries()) {
+		const pluginLast = pluginIndex === tree.plugins.length - 1;
+		const pluginDesc = options.includeDescriptions
+			? ` - ${compact(plugin.shortDescription || plugin.description, options.maxDescription)}`
+			: "";
+		printChild(lines, "", pluginLast, `[P] ${plugin.name} (${plugin.skills.length} skills)${pluginDesc}`, options.unicode);
+
+		const pluginPrefix = pluginLast ? glyphs.blank : glyphs.pipe;
+		const pluginDetails: string[] = [];
+		if (options.includePaths) pluginDetails.push(`path: ${plugin.path}`);
+		if (options.includeMetadata) {
+			pluginDetails.push(`category: ${plugin.category}`);
+			if (plugin.commands.length) pluginDetails.push(`commands: ${plugin.commands.join(", ")}`);
+		}
+		if ((options.includeKeywords || options.includeMetadata) && plugin.keywords.length) {
+			pluginDetails.push(`keywords: ${plugin.keywords.join(", ")}`);
+		}
+
+		for (const [detailIndex, detail] of pluginDetails.entries()) {
+			const isLast = plugin.skills.length === 0 && detailIndex === pluginDetails.length - 1;
+			detailLine(lines, pluginPrefix, isLast, detail, options.unicode);
+		}
+
+		for (const [skillIndex, skill] of plugin.skills.entries()) {
+			const supportCount = skill.scripts.length + skill.agents.length + skill.otherSupport.length;
+			const skillLast = skillIndex === plugin.skills.length - 1;
+			const refSummary = `${skill.references.length} refs`;
+			const supportSummary = supportCount > 0 ? `, ${supportCount} support` : "";
+			const skillDesc = options.includeDescriptions
+				? ` - ${compact(skill.description, options.maxDescription)}`
+				: "";
+			printChild(
+				lines,
+				pluginPrefix,
+				skillLast,
+				`[S] ${skill.name} (${refSummary}${supportSummary})${skillDesc}`,
+				options.unicode,
+			);
+
+			const skillPrefix = `${pluginPrefix}${skillLast ? glyphs.blank : glyphs.pipe}`;
+			const skillDetails: string[] = [];
+			if (options.includePaths) skillDetails.push(`path: ${skill.path}`);
+			if (options.includeMetadata) {
+				for (const [key, value] of Object.entries(skill.frontmatter)) {
+					if (key === "description" && options.includeDescriptions) continue;
+					skillDetails.push(`${key}: ${compact(value, options.maxDescription)}`);
+				}
+			}
+			if (options.includeReferences) {
+				for (const reference of skill.references) skillDetails.push(`ref: ${reference}`);
+			}
+			if (options.includeSupport) {
+				for (const agent of skill.agents) skillDetails.push(`agent: ${agent}`);
+				for (const script of skill.scripts) skillDetails.push(`script: ${script}`);
+				for (const file of skill.otherSupport) skillDetails.push(`file: ${file}`);
+			}
+
+			for (const [detailIndex, detail] of skillDetails.entries()) {
+				detailLine(lines, skillPrefix, detailIndex === skillDetails.length - 1, detail, options.unicode);
+			}
+		}
+	}
+
+	return `${lines.join("\n")}\n`;
+}
+
+try {
+	const options = parseOptions();
+	const tree = await buildTree(options);
+	if (options.format === "json") {
+		console.log(JSON.stringify(tree, null, "\t"));
+	} else {
+		process.stdout.write(formatText(tree, options));
+	}
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add the codebase-management plugin with a codebase-structure skill and project-type references
- register the plugin in generated Codex, Claude, Cursor, and marketplace metadata
- add `bun run tree` for AI-readable plugin and skill inventory output

## Validation
- `bun run marketplace:write`
- `bun run ci`
- `bun run tree --plugin codebase-management --all --ascii`